### PR TITLE
Add critical safety check to prevent data market robbery

### DIFF
--- a/node/mep_cli_provider.py
+++ b/node/mep_cli_provider.py
@@ -42,6 +42,8 @@ class MEPCLIProvider:
         os.makedirs(self.workspace_dir, exist_ok=True)
         self.upload_code = os.getenv("MEP_CLI_UPLOAD_CODE", "false").lower() in ("1", "true", "yes")
         self.max_code_chars = int(os.getenv("MEP_CLI_MAX_CODE_CHARS", "12000"))
+        # Safety: maximum SECONDS a node will spend to buy data (negative bounty)
+        self.max_purchase_price = float(os.getenv("MEP_MAX_PURCHASE_PRICE", "0.0"))
 
     async def _post_with_retry(self, url: str, payload_str: str | None = None, json_body: dict | None = None, headers: dict | None = None, timeout: int = 20):
         delays = [1, 2, 4, 8]
@@ -105,7 +107,18 @@ class MEPCLIProvider:
         
         if model not in self.capabilities and model is not None:
             return
-            
+        
+        # 🛡️ CRITICAL SAFETY CHECK: DO NOT BUY DATA UNLESS EXPLICITLY ENABLED
+        if bounty < 0:
+            cost = abs(bounty)
+            if cost > self.max_purchase_price:
+                print(f"[CLI Provider] 🚨 REJECTED DATA MARKET TASK {task_id[:8]}: "
+                      f"Price {cost:.6f} SECONDS exceeds max_purchase_price {self.max_purchase_price:.6f}")
+                return
+            else:
+                print(f"[CLI Provider] ✅ Accepting data purchase {task_id[:8]} for {cost:.6f} SECONDS "
+                      f"(max allowed: {self.max_purchase_price:.6f})")
+        
         print(f"[CLI Provider] Received matching RFC {task_id[:8]} for {bounty:.6f} SECONDS. Bidding...")
         
         try:


### PR DESCRIPTION
## 🛡️ Security Fix: Prevent Data Market Robbery

This PR adds a critical safety check to protect MEP CLI Provider nodes from accidentally draining their SECONDS balance by buying data market tasks.

### Changes:
1. **Adds `MEP_MAX_PURCHASE_PRICE` environment variable** (default: `0.0`)
2. **Rejects data market tasks** (negative bounty) unless explicitly enabled
3. **Prints clear warnings** when rejecting expensive data purchases
4. **Protects nodes** from malicious consumers selling worthless data

### Why This Is Critical:
- Without this check, nodes can be tricked into spending SECONDS on worthless data
- Malicious consumers could broadcast tasks with `-100.0 SECONDS` bounties
- Every CLI node would instantly drain its wallet buying garbage strings

### Usage:
- `MEP_MAX_PURCHASE_PRICE=0.0` → Node will NEVER buy data (safe for public nodes)
- `MEP_MAX_PURCHASE_PRICE=5.0` → Node can spend up to 5 SECONDS buying datasets
- `MEP_MAX_PURCHASE_PRICE=100.0` → Node can spend 100 SECONDS (only for trusted networks)

### Tested:
- ✅ Successfully prevented a 5.0 SECONDS robbery attempt
- ✅ Properly rejects expensive data purchases
- ✅ Allows purchases when explicitly enabled

**This fix is mandatory for all MEP CLI Provider deployments!**