### PR TITLE
fix(hub): format Pydantic 422 errors into readable field:message pairs

### DIFF
--- a/hub/main.py
+++ b/hub/main.py
@@ -226,7 +226,7 @@ async def http_exception_handler(_: Request, exc: HTTPException):
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(_: Request, exc: RequestValidationError):
     # Format Pydantic errors into readable field:message pairs
-    formatted = "; ".join(f"{'.'.join(str(l) for l in e['loc'])}: {e['msg']}" for e in exc.errors())
+    formatted = "; ".join(f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors())
     return JSONResponse(
         status_code=422,
         content={"status": "error", "detail": formatted}

--- a/hub/main.py
+++ b/hub/main.py
@@ -225,9 +225,11 @@ async def http_exception_handler(_: Request, exc: HTTPException):
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(_: Request, exc: RequestValidationError):
+    # Format Pydantic errors into readable field:message pairs
+    formatted = "; ".join(f"{'.'.join(str(l) for l in e['loc'])}: {e['msg']}" for e in exc.errors())
     return JSONResponse(
         status_code=422,
-        content={"status": "error", "detail": exc.errors()}
+        content={"status": "error", "detail": formatted}
     )
 
 @app.exception_handler(Exception)


### PR DESCRIPTION
## Summary
Pydantic validation errors returned as opaque arrays - hard to debug.

**Before:** `{"detail": [{loc: [...], msg: "...", type: "..."}]}`  
**After:** `{"detail": "field.subfield: validation message"}`

## Changes
- Format `RequestValidationError` errors into `field:message` pairs  
- Each error: `loc串msg`

## Testing
- Deployed to mep-hub.silentcopilot.ai
- DM test confirmed 422 was causingElsaws reply failures