### PR TITLE
feat(hub): offline DM queue — store and deliver when target reconnects

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -167,6 +167,15 @@ def init_db():
             resolved_at REAL
         )
     ''')
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS pending_dms (
+            task_id TEXT PRIMARY KEY,
+            consumer_id TEXT NOT NULL,
+            target_node TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            created_at REAL NOT NULL
+        )
+    ''')
     conn.commit()
     _release_conn(conn)
 
@@ -968,5 +977,48 @@ def resolve_dispute(task_id: str, resolution: str, resolved_at: float) -> bool:
     conn.commit()
     _release_conn(conn)
     return updated > 0
+
+def queue_offline_dm(task_id: str, consumer_id: str, target_node: str, payload: str, created_at: float) -> None:
+    conn = _get_conn()
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute(
+            "INSERT INTO pending_dms (task_id, consumer_id, target_node, payload, created_at) VALUES (%s, %s, %s, %s, %s)",
+            (task_id, consumer_id, target_node, payload, created_at)
+        )
+    else:
+        cursor.execute(
+            "INSERT INTO pending_dms (task_id, consumer_id, target_node, payload, created_at) VALUES (?, ?, ?, ?, ?)",
+            (task_id, consumer_id, target_node, payload, created_at)
+        )
+    conn.commit()
+    _release_conn(conn)
+
+def get_pending_dms(target_node: str) -> list:
+    conn = _get_conn()
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute(
+            "SELECT task_id, consumer_id, target_node, payload, created_at FROM pending_dms WHERE target_node = %s ORDER BY created_at ASC",
+            (target_node,)
+        )
+    else:
+        cursor.execute(
+            "SELECT task_id, consumer_id, target_node, payload, created_at FROM pending_dms WHERE target_node = ? ORDER BY created_at ASC",
+            (target_node,)
+        )
+    rows = cursor.fetchall()
+    _release_conn(conn)
+    return [_row_to_dict(cursor, row) for row in rows]
+
+def delete_pending_dm(task_id: str) -> None:
+    conn = _get_conn()
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute("DELETE FROM pending_dms WHERE task_id = %s", (task_id,))
+    else:
+        cursor.execute("DELETE FROM pending_dms WHERE task_id = ?", (task_id,))
+    conn.commit()
+    _release_conn(conn)
 
 init_db()

--- a/hub/db.py
+++ b/hub/db.py
@@ -1,6 +1,7 @@
 import sqlite3
 import os
 import json
+import time
 from typing import Optional
 
 try:
@@ -175,6 +176,11 @@ def init_db():
             payload TEXT NOT NULL,
             created_at REAL NOT NULL
         )
+    ''')
+    # Index for efficient lookup of pending DMs by target node + ordering by creation time
+    cursor.execute('''
+        CREATE INDEX IF NOT EXISTS idx_pending_dms_target_created
+        ON pending_dms (target_node, created_at)
     ''')
     conn.commit()
     _release_conn(conn)
@@ -1020,5 +1026,23 @@ def delete_pending_dm(task_id: str) -> None:
         cursor.execute("DELETE FROM pending_dms WHERE task_id = ?", (task_id,))
     conn.commit()
     _release_conn(conn)
+
+PENDING_DM_TTL_SECONDS = float(os.getenv("MEP_PENDING_DM_TTL_SECONDS", "86400"))  # Default 24h
+
+def cleanup_expired_pending_dms() -> int:
+    """Remove pending DMs older than PENDING_DM_TTL_SECONDS. Returns count of removed entries."""
+    if PENDING_DM_TTL_SECONDS <= 0:
+        return 0
+    conn = _get_conn()
+    cursor = conn.cursor()
+    cutoff = time.time() - PENDING_DM_TTL_SECONDS
+    if _is_postgres():
+        cursor.execute("DELETE FROM pending_dms WHERE created_at < %s", (cutoff,))
+    else:
+        cursor.execute("DELETE FROM pending_dms WHERE created_at < ?", (cutoff,))
+    removed = cursor.rowcount
+    conn.commit()
+    _release_conn(conn)
+    return removed
 
 init_db()

--- a/hub/main.py
+++ b/hub/main.py
@@ -1013,6 +1013,11 @@ async def submit_task(
                     if connected_nodes.get(task.target_node) is target_ws:
                         del connected_nodes[task.target_node]
                 raise HTTPException(status_code=409, detail="Target node disconnected")
+        # Target offline — queue DM for delivery when they reconnect
+        if task.target_node:
+            db.queue_offline_dm(task_id, task.consumer_id, task.target_node, payload, now)
+            log_event("dm_queued_offline", f"DM {task_id[:8]} queued for offline target {task.target_node}", task_id=task_id, target=task.target_node)
+            return {"status": "success", "task_id": task_id, "routed_to": task.target_node, "queued": True}
         raise HTTPException(status_code=404, detail="Target node not currently connected to Hub")
 
     model_requirement = _normalize_model_requirement(task.model_requirement)
@@ -1556,6 +1561,28 @@ async def websocket_endpoint(
     async with node_lock:
         connected_nodes[node_id] = websocket
     db.update_registry_availability(node_id, "online", time.time())
+    # Deliver any DMs that were queued while this node was offline
+    pending_dms = db.get_pending_dms(node_id)
+    for dm in pending_dms:
+        try:
+            delivery = {
+                "event": "new_task",
+                "data": {
+                    "id": dm["task_id"],
+                    "consumer_id": dm["consumer_id"],
+                    "payload": dm["payload"],
+                    "bounty": 0.0,
+                    "status": "assigned",
+                    "provider_id": node_id,
+                    "queued": True
+                }
+            }
+            await websocket.send_json(delivery)
+            db.delete_pending_dm(dm["task_id"])
+            log_event("dm_delivered_online", f"Queued DM {dm['task_id'][:8]} delivered to {node_id}", task_id=dm["task_id"])
+        except Exception as exc:
+            log_event("dm_delivery_failed", f"Failed to deliver queued DM to {node_id}: {exc}", task_id=dm["task_id"])
+            break
     try:
         while True:
             await websocket.receive_text()

--- a/hub/main.py
+++ b/hub/main.py
@@ -676,6 +676,9 @@ async def _maintenance_worker():
         try:
             await _evict_completed_tasks_cache()
             _sweep_idempotency_records()
+            removed = db.cleanup_expired_pending_dms()
+            if removed > 0:
+                log_event("pending_dms_cleaned", f"Removed {removed} expired pending DMs", removed=removed)
         except Exception as exc:
             log_event("maintenance_sweep_failed", f"Maintenance sweep failed: {exc}")
         await asyncio.sleep(max(1, MAINTENANCE_SWEEP_INTERVAL_SECONDS))


### PR DESCRIPTION
## Summary
Direct messages to offline nodes were being discarded with 404. Now they are queued and delivered automatically when the target reconnects.

**Before:** DM to offline node → 404 lost forever
**After:** DM to offline node → 200 queued → delivered on reconnect

## Changes

### hub/db.py
- New `pending_dms` table: task_id, consumer_id, target_node, payload, created_at
- `queue_offline_dm()` — store offline DM
- `get_pending_dms(node_id)` — retrieve queued DMs for reconnecting node
- `delete_pending_dm(task_id)` — remove after delivery

### hub/main.py
- When `target_node` is offline: queue DM instead of raising 404
- On WebSocket reconnect: deliver all queued DMs before normal processing
- `/tasks/submit` returns `{..., queued: true}` for offline DMs

## Testing
- Deploy to mep-hub.silentcopilot.ai
- Restart Hub to trigger `init_db()` for new table
- Test: send DM to offline Elsaws → expect 200 with `queued: true`
- Reconnect Elsaws → expect queued DM delivered immediately