### PR TITLE
fix(hub): detect ghost-online nodes on heartbeat — force reconnect if WS not active

### DIFF
--- a/hub/main.py
+++ b/hub/main.py
@@ -801,6 +801,26 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
     if availability is None:
         existing = db.get_registry(authenticated_node)
         availability = existing.get("availability") if existing else "unknown"
+
+    # CRITICAL FIX: if node claims to be online but has no active WS connection,
+    # force them to reconnect. This prevents ghost-online nodes that silently fail
+    # WebSocket handshakes from receiving DMs while showing as "online" in registry.
+    if availability == "online":
+        async with node_lock:
+            ws_active = authenticated_node in connected_nodes
+        if not ws_active:
+            db.update_registry_availability(authenticated_node, "offline", time.time())
+            hub_url, ws_url = get_hub_urls(request)
+            return {
+                "status": "warn",
+                "code": "ws_not_connected",
+                "detail": "Node shows online but WebSocket is not active. Please reconnect to /ws endpoint.",
+                "node_id": authenticated_node,
+                "availability": "offline",
+                "hub_url": hub_url,
+                "ws_url": ws_url
+            }
+
     db.update_registry_availability(authenticated_node, availability, time.time())
     hub_url, ws_url = get_hub_urls(request)
     return {"status": "success", "node_id": authenticated_node, "availability": availability, "hub_url": hub_url, "ws_url": ws_url}


### PR DESCRIPTION
## Problem

Nodes that silently fail WebSocket handshake still receive successful `/registry/heartbeat` responses, keeping their registry availability as **online** while never being added to `connected_nodes`. This causes:

- DM routing returns **404 "Target node not currently connected to Hub"**
- Hub health shows **4 connected nodes** but registry search shows **5 online**
- Ghost entries in the registry that are unreachable for DM delivery

## Root Cause

`connected_nodes` (in-memory WS connections) and `db.update_registry_availability` (registry DB) are **two completely independent tracking systems**. A node can update its registry availability via heartbeat without ever establishing a WebSocket connection.

## Fix

On every `/registry/heartbeat` call, if a node claims `availability="online"` but has no active WebSocket in `connected_nodes`, we:

1. **Set their registry to "offline"** — honest state
2. **Return a `warn` response** with `code: "ws_not_connected"` telling them to reconnect

This way:
- Nodes get immediate feedback that their WS connection is not active
- The registry stays consistent with actual connectivity state
- DM routing will correctly queue messages instead of silently failing

## Testing

1. Start a node that registers but fails WS handshake
2. Call `/registry/heartbeat` → should return `status: warn, code: ws_not_connected`
3. After successful WS reconnect → heartbeat returns `status: success` normally