### PR TITLE
fix(hub): add WebSocket keepalive — close dead connections after 30s idle

### DIFF
--- a/hub/main.py
+++ b/hub/main.py
@@ -1614,8 +1614,16 @@ async def websocket_endpoint(
                 break
     try:
         while True:
-            await websocket.receive_text()
+            try:
+                await asyncio.wait_for(websocket.receive_text(), timeout=300)
+            except asyncio.TimeoutError:
+                # No message received for 300s — client is likely dead.
+                # Close the connection to force a clean reconnect.
+                await websocket.close(code=4000, reason="Keepalive timeout")
+                break
     except WebSocketDisconnect:
+        pass  # Clean close is handled in finally block
+    finally:
         async with node_lock:
             if connected_nodes.get(node_id) is websocket:
                 del connected_nodes[node_id]


### PR DESCRIPTION
## Problem

Nodes that lose their network connection silently (no TCP FIN) appear as "online" in the registry forever, because the hub `connected_nodes` dict is never cleaned up — `receive_text()` just hangs waiting for a message that never arrives.

This is the **phantom node bug**: registry shows a node "online" but DM routing to it returns 404 because the WebSocket is actually dead.

## Fix

Replace the bare `while True: await websocket.receive_text()` loop with a timeout-based keepalive:

```python
try:
    await asyncio.wait_for(websocket.receive_text(), timeout=300)
except asyncio.TimeoutError:
    # No message received for 300s — client is likely dead.
    # Close the connection to force a clean reconnect.
    await websocket.close(code=4000, reason="Keepalive timeout")
    break
```

**Timeout set to 300s (5 min)** to avoid kicking healthy-but-idle nodes. Nodes sending registry heartbeat (~60s) will not be affected.

**Changes from PR #51:**
- ❌ Removed `websocket.ping()` — Starlette/FastAPI WebSocket does not expose a ping() API
- ❌ Removed unused `msg =` variable — fixed lint failure
- ✅ Uses `close(code=4000)` instead to force clean reconnect on dead connections
- ✅ Clean commit with only the keepalive change (no unrelated doc commit)
- ✅ 300s timeout instead of 30s (addresses reconnect storm concern)

## Testing

1. Connect a node via WebSocket
2. Block/drop network traffic to that node (simulating silent disconnect)
3. Wait 300s — Hub should close connection with code 4000
4. Node should auto-reconnect
5. Registry `connected_nodes` should be clean (no phantom entries)