### PR TITLE
feat(ws): app heartbeat + stale connection eviction

### DIFF
--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -12,6 +12,7 @@ from clients.shared.identity import MEPIdentity
 
 HUB_URL = os.getenv("HUB_URL", "https://mep-hub.silentcopilot.ai")
 WS_URL = os.getenv("WS_URL", "wss://mep-hub.silentcopilot.ai")
+WS_HEARTBEAT_INTERVAL_SECONDS = float(os.getenv("MEP_WS_HEARTBEAT_INTERVAL_SECONDS", "60"))
 
 
 class MEPClient:
@@ -106,13 +107,26 @@ class MEPClient:
             uri = f"{WS_URL}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
             try:
                 async with websockets.connect(uri) as ws:
-                    while not self._stop.is_set():
-                        msg = await ws.recv()
-                        data = json.loads(msg)
-                        if data.get("event") == "task_result":
-                            await on_result(data["data"])
+                    heartbeat_task: Optional[asyncio.Task] = None
+                    if WS_HEARTBEAT_INTERVAL_SECONDS > 0:
+                        heartbeat_task = asyncio.create_task(self._heartbeat_loop(ws))
+                    try:
+                        while not self._stop.is_set():
+                            msg = await ws.recv()
+                            data = json.loads(msg)
+                            if data.get("event") == "task_result":
+                                await on_result(data["data"])
+                    finally:
+                        if heartbeat_task:
+                            heartbeat_task.cancel()
+                            await asyncio.gather(heartbeat_task, return_exceptions=True)
             except Exception:
                 await asyncio.sleep(2)
+
+    async def _heartbeat_loop(self, ws) -> None:
+        while not self._stop.is_set():
+            await asyncio.sleep(WS_HEARTBEAT_INTERVAL_SECONDS)
+            await ws.send(json.dumps({"event": "heartbeat", "node_id": self.node_id, "ts": int(time.time())}))
 
     def stop(self) -> None:
         self._stop.set()

--- a/hub/main.py
+++ b/hub/main.py
@@ -102,6 +102,7 @@ COMPLETED_TASK_CACHE_MAX_ITEMS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_MAX_ITE
 IDEMPOTENCY_TTL_SECONDS = int(os.getenv("MEP_IDEMPOTENCY_TTL_SECONDS", "86400"))
 WS_READ_TIMEOUT_SECONDS = float(os.getenv("MEP_WS_READ_TIMEOUT_SECONDS", "60"))
 WS_STALE_SECONDS = float(os.getenv("MEP_WS_STALE_SECONDS", "360"))
+WS_STALE_GRACE_SECONDS = float(os.getenv("MEP_WS_STALE_GRACE_SECONDS", "5"))
 TIMEOUT_POLICY = os.getenv("MEP_TIMEOUT_POLICY", "refund").lower()
 VALID_AVAILABILITY = {"online", "idle", "busy", "offline", "unknown"}
 DEFAULT_REGISTRY_MAX_AGE_MINUTES = float(os.getenv("MEP_REGISTRY_MAX_AGE_MINUTES", "0") or "0")
@@ -1637,7 +1638,7 @@ async def websocket_endpoint(
             except asyncio.TimeoutError:
                 async with node_lock:
                     last_seen = ws_last_seen.get(node_id, 0.0)
-                if time.time() - last_seen > WS_STALE_SECONDS:
+                if time.time() - last_seen > (WS_STALE_SECONDS + WS_STALE_GRACE_SECONDS):
                     await websocket.close(code=4000, reason="WebSocket stale timeout")
                     break
     except WebSocketDisconnect:

--- a/hub/main.py
+++ b/hub/main.py
@@ -24,6 +24,7 @@ app = FastAPI(title="MEP Hub", description="The Time Exchange Clearinghouse", ve
 active_tasks: Dict[str, dict] = {}
 completed_tasks: Dict[str, dict] = {}
 connected_nodes: Dict[str, WebSocket] = {}
+ws_last_seen: Dict[str, float] = {}
 rate_limits: Dict[str, List[float]] = {}
 task_lock = asyncio.Lock()
 node_lock = asyncio.Lock()
@@ -99,6 +100,8 @@ MAINTENANCE_SWEEP_INTERVAL_SECONDS = int(os.getenv("MEP_MAINTENANCE_SWEEP_INTERV
 COMPLETED_TASK_CACHE_TTL_SECONDS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_TTL_SECONDS", "3600"))
 COMPLETED_TASK_CACHE_MAX_ITEMS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_MAX_ITEMS", "1000"))
 IDEMPOTENCY_TTL_SECONDS = int(os.getenv("MEP_IDEMPOTENCY_TTL_SECONDS", "86400"))
+WS_READ_TIMEOUT_SECONDS = float(os.getenv("MEP_WS_READ_TIMEOUT_SECONDS", "60"))
+WS_STALE_SECONDS = float(os.getenv("MEP_WS_STALE_SECONDS", "360"))
 TIMEOUT_POLICY = os.getenv("MEP_TIMEOUT_POLICY", "refund").lower()
 VALID_AVAILABILITY = {"online", "idle", "busy", "offline", "unknown"}
 DEFAULT_REGISTRY_MAX_AGE_MINUTES = float(os.getenv("MEP_REGISTRY_MAX_AGE_MINUTES", "0") or "0")
@@ -804,6 +807,7 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
     if availability is None:
         existing = db.get_registry(authenticated_node)
         availability = existing.get("availability") if existing else "unknown"
+    now = time.time()
 
     # CRITICAL FIX: if node claims to be online but has no active WS connection,
     # force them to reconnect. This prevents ghost-online nodes that silently fail
@@ -811,8 +815,10 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
     if availability == "online":
         async with node_lock:
             ws_active = authenticated_node in connected_nodes
+            if ws_active:
+                ws_last_seen[authenticated_node] = now
         if not ws_active:
-            db.update_registry_availability(authenticated_node, "offline", time.time())
+            db.update_registry_availability(authenticated_node, "offline", now)
             hub_url, ws_url = get_hub_urls(request)
             return {
                 "status": "warn",
@@ -824,7 +830,7 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
                 "ws_url": ws_url
             }
 
-    db.update_registry_availability(authenticated_node, availability, time.time())
+    db.update_registry_availability(authenticated_node, availability, now)
     hub_url, ws_url = get_hub_urls(request)
     return {"status": "success", "node_id": authenticated_node, "availability": availability, "hub_url": hub_url, "ws_url": ws_url}
 
@@ -1581,9 +1587,11 @@ async def websocket_endpoint(
         return
 
     await websocket.accept()
+    now = time.time()
     async with node_lock:
         connected_nodes[node_id] = websocket
-    db.update_registry_availability(node_id, "online", time.time())
+        ws_last_seen[node_id] = now
+    db.update_registry_availability(node_id, "online", now)
     # Deliver any DMs that were queued while this node was offline
     pending_dms = db.get_pending_dms(node_id)
     failed_deliveries = 0
@@ -1614,9 +1622,29 @@ async def websocket_endpoint(
                 break
     try:
         while True:
-            await websocket.receive_text()
+            try:
+                message = await asyncio.wait_for(websocket.receive_text(), timeout=WS_READ_TIMEOUT_SECONDS)
+                async with node_lock:
+                    if connected_nodes.get(node_id) is websocket:
+                        ws_last_seen[node_id] = time.time()
+                if message:
+                    try:
+                        payload = json.loads(message)
+                    except json.JSONDecodeError:
+                        payload = None
+                    if payload and payload.get("event") == "heartbeat":
+                        continue
+            except asyncio.TimeoutError:
+                async with node_lock:
+                    last_seen = ws_last_seen.get(node_id, 0.0)
+                if time.time() - last_seen > WS_STALE_SECONDS:
+                    await websocket.close(code=4000, reason="WebSocket stale timeout")
+                    break
     except WebSocketDisconnect:
+        pass
+    finally:
         async with node_lock:
             if connected_nodes.get(node_id) is websocket:
                 del connected_nodes[node_id]
+            ws_last_seen.pop(node_id, None)
         db.update_registry_availability(node_id, "offline", time.time())

--- a/node/client.py
+++ b/node/client.py
@@ -8,6 +8,8 @@ import urllib.parse
 from reputation import ReputationManager
 from identity import MEPIdentity
 
+WS_HEARTBEAT_INTERVAL_SECONDS = 60
+
 class ChronosNode:
     """
     Simulated Clawdbot Client (Both Consumer & Provider)
@@ -81,14 +83,24 @@ class ChronosNode:
         uri = f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig_safe}"
         async with websockets.connect(uri) as ws:
             print(f"[Node {self.node_id}] Connected to Hub via WebSocket.")
-            while True:
-                msg = await ws.recv()
-                data = json.loads(msg)
-                
-                if data["event"] == "new_task":
-                    asyncio.create_task(self._handle_new_task(data["data"]))
-                elif data["event"] == "task_result":
-                    asyncio.create_task(self._handle_task_result(data["data"]))
+            heartbeat_task = asyncio.create_task(self._heartbeat_loop(ws))
+            try:
+                while True:
+                    msg = await ws.recv()
+                    data = json.loads(msg)
+
+                    if data["event"] == "new_task":
+                        asyncio.create_task(self._handle_new_task(data["data"]))
+                    elif data["event"] == "task_result":
+                        asyncio.create_task(self._handle_task_result(data["data"]))
+            finally:
+                heartbeat_task.cancel()
+                await asyncio.gather(heartbeat_task, return_exceptions=True)
+
+    async def _heartbeat_loop(self, ws):
+        while True:
+            await asyncio.sleep(WS_HEARTBEAT_INTERVAL_SECONDS)
+            await ws.send(json.dumps({"event": "heartbeat", "node_id": self.node_id, "ts": int(time.time())}))
 
     async def submit_task(self, payload: str, bounty: float):
         """As a Consumer, create a task and lock SECONDS."""


### PR DESCRIPTION
## Summary
- add app-level WS heartbeat handling on hub and clients
- track last-seen per connected node and evict stale sockets after timeout
- keep ghost-online prevention in registry heartbeat while refreshing last-seen when WS is active

## Changes
- hub/main.py
  - add ws_last_seen map
  - add MEP_WS_READ_TIMEOUT_SECONDS and MEP_WS_STALE_SECONDS
  - update /registry/heartbeat to refresh last-seen when online+connected
  - in /ws/{node_id} loop, use timed receive and close stale connections
- clients/shared/mep_client.py
  - add periodic heartbeat sender (event=heartbeat) while listening for results
- 
ode/client.py
  - add periodic heartbeat sender in demo client listen loop

## Validation
- python -m ruff check hub/main.py clients/shared/mep_client.py node/client.py
- python -m pytest tests -q --maxfail=1 (53 passed, 1 skipped)
