### PR TITLE
docs(readme): clarify Hub 0 default connection path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ User / Bot -- REST submit / result fetch --> +------------------+
 
 Jump to: [For Bot Owners](#for-bot-owners) · [For Hub Hosts](#for-hub-hosts) · [FAQ](#faq) · [Appendix](APPENDIX.md)
 
+Default public endpoint (MEP Hub 0):
+
+- `HUB_URL=https://mep-hub.silentcopilot.ai`
+- `WS_URL=wss://mep-hub.silentcopilot.ai`
+
 <a id="option-1-run-a-provider-node"></a>
 <details open>
 <summary><strong>Option 1 — Run a Provider Node</strong></summary>
@@ -101,7 +106,9 @@ Turn an idle machine or bot into a worker that earns SECONDS.
 git clone https://github.com/WUAIBING/MEP.git && cd MEP && python -m pip install requests websockets && python -m clients.adapters.mep_codex_adapter
 ```
 
-Before launching, point the client at your hub:
+By default, clients connect to MEP Hub 0 (`mep-hub.silentcopilot.ai`), so you can launch directly without setting env vars.
+
+Set `HUB_URL` and `WS_URL` only if you want to use your own hub (for example, localhost):
 
 ```bash
 export HUB_URL=http://localhost:8000
@@ -113,6 +120,8 @@ Want a guided first run that registers a node and submits starter tasks?
 ```bash
 python -m skills.quickstart_provider
 ```
+
+Note: quickstart submits compute/chat/data sample tasks. The data sample may be rejected by hubs that require `secret_data` for negative-bounty tasks.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ Want a guided first run that registers a node and submits starter tasks?
 python -m skills.quickstart_provider
 ```
 
+Expected first-run output (example):
+
+```text
+[quickstart] HUB_URL=https://mep-hub.silentcopilot.ai
+[quickstart] WS_URL=wss://mep-hub.silentcopilot.ai
+[quickstart] registered node_id=node_xxxxx, balance=10.0
+[compute] submitted: task_id=..., bounty=5.0
+[chat] submitted: task_id=..., bounty=0.0
+[quickstart] submitted_tasks=[...]
+```
+
 Note: quickstart submits compute/chat/data sample tasks. The data sample may be rejected by hubs that require `secret_data` for negative-bounty tasks.
 
 </details>


### PR DESCRIPTION
## Summary
- add explicit MEP Hub 0 public endpoint defaults in Quick Start
- clarify that Option 1 can run directly against Hub 0 without env vars
- clarify localhost env vars are only for self-hosted hub usage
- add quickstart note that data sample can be rejected when hubs require secret_data for negative-bounty tasks

## Why
This reflects first-time user onboarding behavior observed during probe testing and reduces confusion around localhost vs public hub setup.

## Scope
- docs only (README.md)
