### PR TITLE
feat(hub): add bio field and /registry/online for easier node discovery

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -66,6 +66,19 @@ def _ensure_registry_availability_column(cursor):
         if "availability" not in columns:
             cursor.execute("ALTER TABLE agent_registry ADD COLUMN availability TEXT NOT NULL DEFAULT 'unknown'")
 
+def _ensure_registry_bio_column(cursor):
+    if _is_postgres():
+        cursor.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = 'agent_registry' AND column_name = 'bio'"
+        )
+        if not cursor.fetchone():
+            cursor.execute("ALTER TABLE agent_registry ADD COLUMN bio TEXT")
+    else:
+        cursor.execute("PRAGMA table_info(agent_registry)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if "bio" not in columns:
+            cursor.execute("ALTER TABLE agent_registry ADD COLUMN bio TEXT")
+
 def init_db():
     conn = _get_conn()
     cursor = conn.cursor()
@@ -116,6 +129,7 @@ def init_db():
         CREATE TABLE IF NOT EXISTS agent_registry (
             node_id TEXT PRIMARY KEY,
             alias TEXT,
+            bio TEXT,
             skills TEXT NOT NULL,
             models TEXT NOT NULL,
             metadata TEXT NOT NULL,
@@ -124,6 +138,7 @@ def init_db():
             x25519_public_key TEXT
         )
     ''')
+    _ensure_registry_bio_column(cursor)
     _ensure_registry_availability_column(cursor)
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS reputation (
@@ -540,43 +555,46 @@ def delete_idempotency_before(cutoff_ts: float) -> int:
     _release_conn(conn)
     return int(deleted or 0)
 
-def upsert_registry(node_id: str, alias: Optional[str], skills: list[str], models: list[str], metadata: dict, availability: str, updated_at: float, x25519_public_key: Optional[str] = None):
+def upsert_registry(node_id: str, alias: Optional[str], skills: list[str], models: list[str], metadata: dict, availability: str, updated_at: float, x25519_public_key: Optional[str] = None, bio: Optional[str] = None):
     conn = _get_conn()
     cursor = conn.cursor()
     _ensure_registry_availability_column(cursor)
+    _ensure_registry_bio_column(cursor)
     skills_payload = json.dumps(skills)
     models_payload = json.dumps(models)
     metadata_payload = json.dumps(metadata)
     
     if _is_postgres():
         query = """
-            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO agent_registry (node_id, alias, bio, skills, models, metadata, availability, updated_at, x25519_public_key)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (node_id) DO UPDATE SET
                 alias = EXCLUDED.alias,
+                bio = EXCLUDED.bio,
                 skills = EXCLUDED.skills,
                 models = EXCLUDED.models,
                 metadata = EXCLUDED.metadata,
                 availability = EXCLUDED.availability,
                 updated_at = EXCLUDED.updated_at
         """
-        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
+        params = [node_id, alias, bio, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
         if x25519_public_key:
             query += ", x25519_public_key = EXCLUDED.x25519_public_key"
         cursor.execute(query, tuple(params))
     else:
         query = """
-            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO agent_registry (node_id, alias, bio, skills, models, metadata, availability, updated_at, x25519_public_key)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(node_id) DO UPDATE SET
                 alias=excluded.alias,
+                bio=excluded.bio,
                 skills=excluded.skills,
                 models=excluded.models,
                 metadata=excluded.metadata,
                 availability=excluded.availability,
                 updated_at=excluded.updated_at
         """
-        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
+        params = [node_id, alias, bio, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
         if x25519_public_key:
             query += ", x25519_public_key=excluded.x25519_public_key"
         cursor.execute(query, tuple(params))

--- a/hub/main.py
+++ b/hub/main.py
@@ -768,7 +768,7 @@ async def register_node(node: NodeRegistration, request: Request):
     node_id = auth.derive_node_id(node.pubkey)
     balance = db.register_node(node_id, node.pubkey)
     if node.alias or getattr(node, 'x25519_public_key', None):
-        db.upsert_registry(node_id, node.alias, [], [], {}, "offline", time.time(), getattr(node, 'x25519_public_key', None))
+        db.upsert_registry(node_id, node.alias, None, [], [], {}, "offline", time.time(), getattr(node, 'x25519_public_key', None))
 
     log_event("node_registered", f"Node {node_id} registered with starting balance {balance}", node_id=node_id, starting_balance=balance)
     log_audit("REGISTER", node_id, balance, balance, "START_BONUS")
@@ -786,7 +786,7 @@ async def update_registry(payload: RegistryUpdate, authenticated_node: str = Dep
     if availability is None:
         existing = db.get_registry(authenticated_node)
         availability = existing.get("availability") if existing else "unknown"
-    db.upsert_registry(authenticated_node, payload.alias, skills, models, metadata, availability, time.time())
+    db.upsert_registry(authenticated_node, payload.alias, payload.bio, skills, models, metadata, availability, time.time())
     return {"status": "success", "node_id": authenticated_node}
 
 @app.post("/registry/availability")
@@ -804,6 +804,25 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
     db.update_registry_availability(authenticated_node, availability, time.time())
     hub_url, ws_url = get_hub_urls(request)
     return {"status": "success", "node_id": authenticated_node, "availability": availability, "hub_url": hub_url, "ws_url": ws_url}
+
+@app.get("/registry/online")
+async def get_online_nodes():
+    """List all nodes currently connected via WebSocket - for easy node discovery."""
+    online = []
+    for node_id in connected_nodes:
+        registry = db.get_registry(node_id)
+        if registry:
+            online.append({
+                "node_id": node_id,
+                "alias": registry.get("alias"),
+                "bio": registry.get("bio"),
+                "skills": registry.get("skills", []),
+                "models": registry.get("models", []),
+                "availability": registry.get("availability", "unknown")
+            })
+        else:
+            online.append({"node_id": node_id, "alias": None, "bio": None})
+    return {"count": len(online), "nodes": online}
 
 @app.get("/registry/search")
 async def search_registry(

--- a/hub/models.py
+++ b/hub/models.py
@@ -33,6 +33,7 @@ class NodeBalance(BaseModel):
 
 class RegistryUpdate(BaseModel):
     alias: Optional[str] = None
+    bio: Optional[str] = None
     skills: Optional[List[str]] = None
     models: Optional[List[str]] = None
     metadata: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary

### Problem
Nodes are hard to discover - there is no public endpoint to list currently connected nodes, making it difficult for bots to find each other for DM without pre-sharing node IDs.

### Solution
1. **Add `bio` field** to `agent_registry` table - optional brief description each node can set
2. **Add `/registry/online` endpoint** - returns list of all nodes currently connected via WebSocket

### Changes
- `hub/models.py`: Add `bio: Optional[str]` to `RegistryUpdate`
- `hub/db.py`: Add `bio` column to schema, migration helper, update `upsert_registry`
- `hub/main.py`: Add `/registry/online` endpoint + wire up bio in registry update

### Example Usage
```bash
# List online nodes with bios
curl https://mep-hub.silentcopilot.ai/registry/online
# Response: {"count": 2, "nodes": [{"node_id": "node_xxx", "alias": "Hub Sentinel", "bio": "AI provider with DeepSeek"}]}

# Update your bio
curl -X POST https://mep-hub.silentcopilot.ai/registry/update \
  -H "x-mep-nodeid: YOUR_NODE_ID" \
  -H "x-mep-signature: YOUR_SIG" \
  -d "{"alias": "Hub Sentinel", "bio": "AI provider with DeepSeek/GLM chain"}"
```

Closes #57 (node discovery issue)