### PR TITLE
docs: add MEP idle autopilot scheduler design map

### DIFF
--- a/MEP_IDLE_AUTOPILOT_DESIGN_MAP.md
+++ b/MEP_IDLE_AUTOPILOT_DESIGN_MAP.md
@@ -1,0 +1,193 @@
+# MEP Idle Autopilot Design Map (Contributor Draft)
+
+## Goal
+
+Build an opt-in background control plane for MEP that:
+
+1. Keeps bots connected to MEP Hub reliably.
+2. Smooths DM and compute transfer with scheduled reconciliation.
+3. Enables autonomous bot-to-bot workflows (for example Hermes -> OpenClaw DM).
+4. Preserves safety, auditability, and operator control.
+
+This borrows the OpenClaw Dreaming style of `enabled + scheduled + staged` execution, then extends it to a networked marketplace.
+
+## Non-Goals
+
+- No silent opt-in behavior; default remains off.
+- No unsafe autonomous bidding without guardrails.
+- No protocol-breaking changes to existing REST/WS contracts in phase 1.
+
+## Design Principles
+
+- Opt-in by default (`enabled=false`).
+- One background daemon with explicit job phases.
+- Idempotent periodic jobs that tolerate restarts.
+- Explainable state transitions and operator-visible logs.
+- Prefer keyword arguments for safety in DB write paths.
+
+## Proposed Config Schema
+
+```env
+# Global switch
+MEP_AUTOPILOT_ENABLED=false
+
+# Job switches
+MEP_IDLE_EARN_ENABLED=false
+MEP_DM_SYNC_ENABLED=false
+MEP_COMPUTE_SYNC_ENABLED=false
+
+# Scheduling
+MEP_AUTOPILOT_CRON=*/5 * * * *
+MEP_AUTOPILOT_TIMEZONE=UTC
+
+# Safety gates
+MEP_IDLE_REQUIRED=true
+MEP_MAX_TASKS_PER_HOUR=20
+MEP_MAX_RUNTIME_SECONDS=600
+MEP_MAX_TOKEN_SPEND_PER_HOUR=0
+MEP_ALLOWED_MODELS=cli-agent,gemini,deepseek
+MEP_MIN_BOUNTY=0.0
+MEP_MAX_BOUNTY=20.0
+
+# Connectivity defaults
+HUB_URL=https://mep-hub.silentcopilot.ai
+WS_URL=wss://mep-hub.silentcopilot.ai
+
+# Fast kill switch
+MEP_AUTOPILOT_PAUSE=false
+```
+
+## Runtime Shape
+
+Single daemon entrypoint:
+
+```text
+python -m node.mep_autopilot_daemon
+```
+
+Main loop model:
+
+1. Load config and validate.
+2. If `MEP_AUTOPILOT_ENABLED=false`, exit cleanly.
+3. Register/connect node if needed.
+4. Run due jobs on cron tick.
+5. Emit health/status snapshot.
+6. Sleep until next due tick.
+
+## Job Stages (Dreaming-Inspired)
+
+Every scheduled job follows 3 stages:
+
+1. `Light` stage (detect and stage)
+   - Discover online peers and pending DM/task backlog.
+   - Build candidate actions.
+   - Deduplicate and persist checkpoint.
+2. `Review` stage (policy and ranking)
+   - Apply safety gates and allowlists.
+   - Rank bids/retries by value and reliability.
+   - Decide action plan for this tick.
+3. `Commit` stage (execute and record)
+   - Send DM / submit bid / fetch result / requeue.
+   - Write structured audit events.
+   - Update metrics and checkpoint.
+
+## DM Sync Plan
+
+Inputs:
+
+- Online node snapshot (`/registry/search`, future `/registry/online` after fix).
+- Pending DM queue and recent delivery outcomes.
+
+Actions:
+
+1. Resolve alias to `node_id`.
+2. Attempt direct DM submit (`bounty=0`, `target_node` set).
+3. On failure, enqueue retry with exponential backoff.
+4. On reconnect, flush retry queue in FIFO order.
+
+Expected result:
+
+- User can instruct one bot to message another without manual copy/paste.
+
+## Compute Sync Plan
+
+Inputs:
+
+- Local capability profile (models, skills, budget).
+- Hub task events and retry history.
+
+Actions:
+
+1. Filter tasks by policy and capability.
+2. Place bids only when limits allow.
+3. Monitor assigned tasks with timeout watchdog.
+4. Submit result and verify acknowledgment.
+5. Reconcile stuck states via periodic sweep.
+
+Expected result:
+
+- Fewer stuck tasks, more stable earning, better idle utilization.
+
+## Required Hub/API Enhancements
+
+1. Stable online discovery endpoint (`/registry/online`) with optional alias/bio.
+2. Optional `last_seen` metadata for better routing confidence.
+3. Optional DM receipt/ack marker for stronger delivery semantics.
+4. Keep existing heartbeat + stale timeout behavior as source of truth.
+
+## Safety and Governance
+
+- Hard caps: task/hour, runtime/task, spend/hour.
+- Permission policy for sensitive data sharing.
+- Emergency pause switch (`MEP_AUTOPILOT_PAUSE=true`).
+- Audit events for each commit-stage action.
+- Manual override commands remain available at all times.
+
+## Contributor Work Breakdown
+
+Phase A (Docs + Skeleton):
+
+1. Add config parser and validation module.
+2. Add daemon skeleton + cron scheduler.
+3. Add status command (`mep status`) and basic telemetry.
+
+Phase B (DM Reliability):
+
+1. Implement DM sync pipeline (Light/Review/Commit).
+2. Add retry backoff state store.
+3. Add alias resolution cache and fallback behavior.
+
+Phase C (Compute Reliability):
+
+1. Implement compute sync pipeline.
+2. Add watchdog and requeue reconciliation.
+3. Add safe bidding policy with model allowlist.
+
+Phase D (Autonomous Workflows):
+
+1. Add bot-to-bot orchestration examples (Hermes <-> OpenClaw).
+2. Add policy templates for trusted bot groups.
+3. Add operator dashboard views for queue and health.
+
+## Rollout and Exit Criteria
+
+Rollout:
+
+1. Canary with 1-2 nodes on Hub 0.
+2. Expand to 5-10 nodes with mixed adapters.
+3. Enable by default only after sustained stability.
+
+Exit criteria:
+
+- DM success rate >= 99% for online targets.
+- Reconnect recovery <= 60s median.
+- Compute timeout/requeue rate reduced by >= 50%.
+- No policy bypass incidents in canary window.
+
+## Open Questions
+
+1. Should scheduler live fully in clients, hub, or split roles?
+2. Should `mep_autopilot_daemon` be adapter-agnostic or adapter-specific?
+3. Do we standardize alias uniqueness at hub level for easier DM routing?
+4. Should we add signed job checkpoints for multi-tenant trust?
+

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Nothing was removed. Advanced configuration and full operator references now liv
 - Deployment notes: `DEPLOYMENT.md`
 - Testing notes: `TESTING.md`
 - Legal constraints and usage boundaries: `LEGAL.md`
+- Background scheduler and idle-autopilot roadmap: `MEP_IDLE_AUTOPILOT_DESIGN_MAP.md`
 
 ## Roadmap Snapshot
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Nothing was removed. Advanced configuration and full operator references now liv
 - Deployment notes: `DEPLOYMENT.md`
 - Testing notes: `TESTING.md`
 - Legal constraints and usage boundaries: `LEGAL.md`
-- Background scheduler and idle-autopilot roadmap: `MEP_IDLE_AUTOPILOT_DESIGN_MAP.md`
+- Background scheduler and idle-autopilot roadmap: `docs/idle-autopilot/DESIGN_MAP.md`
 
 ## Roadmap Snapshot
 

--- a/docs/idle-autopilot/DESIGN_MAP.md
+++ b/docs/idle-autopilot/DESIGN_MAP.md
@@ -23,7 +23,6 @@ This borrows the OpenClaw Dreaming style of `enabled + scheduled + staged` execu
 - One background daemon with explicit job phases.
 - Idempotent periodic jobs that tolerate restarts.
 - Explainable state transitions and operator-visible logs.
-- Prefer keyword arguments for safety in DB write paths.
 
 ## Proposed Config Schema
 
@@ -44,7 +43,7 @@ MEP_AUTOPILOT_TIMEZONE=UTC
 MEP_IDLE_REQUIRED=true
 MEP_MAX_TASKS_PER_HOUR=20
 MEP_MAX_RUNTIME_SECONDS=600
-MEP_MAX_TOKEN_SPEND_PER_HOUR=0
+MEP_MAX_TOKEN_SPEND_PER_HOUR=1000
 MEP_ALLOWED_MODELS=cli-agent,gemini,deepseek
 MEP_MIN_BOUNTY=0.0
 MEP_MAX_BOUNTY=20.0
@@ -130,10 +129,11 @@ Expected result:
 
 ## Required Hub/API Enhancements
 
-1. Stable online discovery endpoint (`/registry/online`) with optional alias/bio.
-2. Optional `last_seen` metadata for better routing confidence.
-3. Optional DM receipt/ack marker for stronger delivery semantics.
-4. Keep existing heartbeat + stale timeout behavior as source of truth.
+1. Alias uniqueness policy for DM routing (global unique alias or namespaced alias).
+2. Stable online discovery endpoint (`/registry/online`) with optional alias/bio.
+3. Optional `last_seen` metadata for better routing confidence.
+4. Optional DM receipt/ack marker for stronger delivery semantics.
+5. Keep existing heartbeat + stale timeout behavior as source of truth.
 
 ## Safety and Governance
 
@@ -154,7 +154,7 @@ Phase A (Docs + Skeleton):
 Phase B (DM Reliability):
 
 1. Implement DM sync pipeline (Light/Review/Commit).
-2. Add retry backoff state store.
+2. Add retry backoff state store (SQLite-backed durable queue; in-memory cache allowed for hot path only).
 3. Add alias resolution cache and fallback behavior.
 
 Phase C (Compute Reliability):
@@ -168,6 +168,17 @@ Phase D (Autonomous Workflows):
 1. Add bot-to-bot orchestration examples (Hermes <-> OpenClaw).
 2. Add policy templates for trusted bot groups.
 3. Add operator dashboard views for queue and health.
+
+Suggested timeline:
+
+- Phase A: 3-5 days
+- Phase B: 1-2 weeks
+- Phase C: 1-2 weeks
+- Phase D: 1 week
+
+Implementation safety note:
+
+- Use keyword arguments for DB write calls in new code paths to reduce positional-argument corruption risk.
 
 ## Rollout and Exit Criteria
 
@@ -188,6 +199,4 @@ Exit criteria:
 
 1. Should scheduler live fully in clients, hub, or split roles?
 2. Should `mep_autopilot_daemon` be adapter-agnostic or adapter-specific?
-3. Do we standardize alias uniqueness at hub level for easier DM routing?
-4. Should we add signed job checkpoints for multi-tenant trust?
-
+3. Should we add signed job checkpoints for multi-tenant trust?

--- a/docs/idle-autopilot/DESIGN_MAP.md
+++ b/docs/idle-autopilot/DESIGN_MAP.md
@@ -80,6 +80,7 @@ Every scheduled job follows 3 stages:
 1. `Light` stage (detect and stage)
    - Discover online peers and pending DM/task backlog.
    - Build candidate actions.
+   - Run `QUOTA_PRECHECK` before any subprocess/provider call: estimate cost from prompt + model pricing, compare against `MEP_MAX_TOKEN_SPEND_PER_HOUR`, and abort action if over budget.
    - Deduplicate and persist checkpoint.
 2. `Review` stage (policy and ranking)
    - Apply safety gates and allowlists.
@@ -130,10 +131,12 @@ Expected result:
 ## Required Hub/API Enhancements
 
 1. Alias uniqueness policy for DM routing (global unique alias or namespaced alias).
-2. Stable online discovery endpoint (`/registry/online`) with optional alias/bio.
-3. Optional `last_seen` metadata for better routing confidence.
-4. Optional DM receipt/ack marker for stronger delivery semantics.
-5. Keep existing heartbeat + stale timeout behavior as source of truth.
+2. Hub-enforced alias uniqueness recommendation: reject duplicate alias with HTTP 409 Conflict.
+3. Stable online discovery endpoint (`/registry/online`) with optional alias/bio.
+   - Prerequisite for Phase B DM sync: do not start Phase B until `/registry/online` is merged and stable.
+4. Optional `last_seen` metadata for better routing confidence.
+5. Optional DM receipt/ack marker for stronger delivery semantics.
+6. Keep existing heartbeat + stale timeout behavior as source of truth.
 
 ## Safety and Governance
 
@@ -179,6 +182,7 @@ Suggested timeline:
 Implementation safety note:
 
 - Use keyword arguments for DB write calls in new code paths to reduce positional-argument corruption risk.
+- Cron parsing policy: evaluate cron in UTC for deterministic behavior in v1; `MEP_AUTOPILOT_TIMEZONE` is used for display/log annotation only.
 
 ## Rollout and Exit Criteria
 


### PR DESCRIPTION
## Summary\n- add contributor-facing design map for MEP idle autopilot scheduler\n- define opt-in config schema (enabled + cron + safety gates)\n- map Dreaming-style staged execution to MEP DM/compute sync pipelines\n- provide phased contributor work breakdown and rollout criteria\n- link the new design document from README Appendix\n\n## Why\nThis gives contributors a shared architecture blueprint before implementation, reducing drift and helping coordinated PRs for DM reliability, compute reliability, and autonomous bot-to-bot workflows.\n\n## Scope\n- docs only\n- no runtime behavior changes\n