### PR TITLE
feat(node): PR-A autopilot skeleton and mep status

### DIFF
--- a/APPENDIX.md
+++ b/APPENDIX.md
@@ -37,6 +37,16 @@ Optional:
 - `--key-path` to reuse a specific node identity key file
 - Uses `HUB_URL` and `WS_URL` from environment when set
 
+### Autopilot PR-A Skeleton Commands
+
+The Phase A scaffold adds safe status/skeleton commands only (no autonomous DM or compute execution yet):
+
+```bash
+python -m node.mep_status
+python -m node.mep_autopilot_daemon --status
+python -m node.mep_autopilot_daemon --once
+```
+
 ### Option 2: Use Client Adapters
 
 Submit tasks from your bot and earn SECONDS automatically.

--- a/node/__init__.py
+++ b/node/__init__.py
@@ -1,0 +1,2 @@
+"""Node package for MEP runtime modules."""
+

--- a/node/mep_autopilot_config.py
+++ b/node/mep_autopilot_config.py
@@ -102,6 +102,8 @@ class AutopilotConfig:
             raise ConfigValidationError("MEP_MAX_RUNTIME_SECONDS must be > 0")
         if cfg.max_token_spend_per_hour < 0:
             raise ConfigValidationError("MEP_MAX_TOKEN_SPEND_PER_HOUR must be >= 0")
+        if cfg.min_bounty < 0 or cfg.max_bounty < 0:
+            raise ConfigValidationError("MEP_MIN_BOUNTY and MEP_MAX_BOUNTY must be >= 0")
         if cfg.min_bounty > cfg.max_bounty:
             raise ConfigValidationError("MEP_MIN_BOUNTY cannot be greater than MEP_MAX_BOUNTY")
         if not cfg.allowed_models:

--- a/node/mep_autopilot_config.py
+++ b/node/mep_autopilot_config.py
@@ -1,0 +1,139 @@
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+
+class ConfigValidationError(ValueError):
+    pass
+
+
+def _parse_bool(raw: str, key: str) -> bool:
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    raise ConfigValidationError(f"{key} must be a boolean-like value, got: {raw!r}")
+
+
+def _parse_int(raw: str, key: str) -> int:
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ConfigValidationError(f"{key} must be an integer, got: {raw!r}") from exc
+
+
+def _parse_float(raw: str, key: str) -> float:
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise ConfigValidationError(f"{key} must be numeric, got: {raw!r}") from exc
+
+
+def _parse_csv(raw: str) -> tuple[str, ...]:
+    return tuple(item.strip() for item in raw.split(",") if item.strip())
+
+
+def _validate_cron(expr: str) -> None:
+    # v1 keeps classic 5-field cron syntax for predictable cross-platform behavior.
+    if len(expr.split()) != 5:
+        raise ConfigValidationError(
+            "MEP_AUTOPILOT_CRON must contain 5 fields (minute hour day month weekday)"
+        )
+
+
+def _validate_url(url: str, key: str, allowed_prefixes: tuple[str, ...]) -> None:
+    if not url.startswith(allowed_prefixes):
+        raise ConfigValidationError(f"{key} must start with one of {allowed_prefixes}, got: {url!r}")
+
+
+@dataclass(frozen=True)
+class AutopilotConfig:
+    autopilot_enabled: bool
+    idle_earn_enabled: bool
+    dm_sync_enabled: bool
+    compute_sync_enabled: bool
+    autopilot_cron: str
+    autopilot_timezone: str
+    idle_required: bool
+    max_tasks_per_hour: int
+    max_runtime_seconds: int
+    max_token_spend_per_hour: int
+    allowed_models: tuple[str, ...]
+    min_bounty: float
+    max_bounty: float
+    hub_url: str
+    ws_url: str
+    autopilot_pause: bool
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "AutopilotConfig":
+        source = env if env is not None else os.environ
+
+        cfg = cls(
+            autopilot_enabled=_parse_bool(source.get("MEP_AUTOPILOT_ENABLED", "false"), "MEP_AUTOPILOT_ENABLED"),
+            idle_earn_enabled=_parse_bool(source.get("MEP_IDLE_EARN_ENABLED", "false"), "MEP_IDLE_EARN_ENABLED"),
+            dm_sync_enabled=_parse_bool(source.get("MEP_DM_SYNC_ENABLED", "false"), "MEP_DM_SYNC_ENABLED"),
+            compute_sync_enabled=_parse_bool(source.get("MEP_COMPUTE_SYNC_ENABLED", "false"), "MEP_COMPUTE_SYNC_ENABLED"),
+            autopilot_cron=source.get("MEP_AUTOPILOT_CRON", "*/5 * * * *").strip(),
+            autopilot_timezone=source.get("MEP_AUTOPILOT_TIMEZONE", "UTC").strip() or "UTC",
+            idle_required=_parse_bool(source.get("MEP_IDLE_REQUIRED", "true"), "MEP_IDLE_REQUIRED"),
+            max_tasks_per_hour=_parse_int(source.get("MEP_MAX_TASKS_PER_HOUR", "20"), "MEP_MAX_TASKS_PER_HOUR"),
+            max_runtime_seconds=_parse_int(source.get("MEP_MAX_RUNTIME_SECONDS", "600"), "MEP_MAX_RUNTIME_SECONDS"),
+            max_token_spend_per_hour=_parse_int(
+                source.get("MEP_MAX_TOKEN_SPEND_PER_HOUR", "1000"),
+                "MEP_MAX_TOKEN_SPEND_PER_HOUR",
+            ),
+            allowed_models=_parse_csv(source.get("MEP_ALLOWED_MODELS", "cli-agent,gemini,deepseek")),
+            min_bounty=_parse_float(source.get("MEP_MIN_BOUNTY", "0.0"), "MEP_MIN_BOUNTY"),
+            max_bounty=_parse_float(source.get("MEP_MAX_BOUNTY", "20.0"), "MEP_MAX_BOUNTY"),
+            hub_url=source.get("HUB_URL", "https://mep-hub.silentcopilot.ai").strip(),
+            ws_url=source.get("WS_URL", "wss://mep-hub.silentcopilot.ai").strip(),
+            autopilot_pause=_parse_bool(source.get("MEP_AUTOPILOT_PAUSE", "false"), "MEP_AUTOPILOT_PAUSE"),
+        )
+
+        _validate_cron(cfg.autopilot_cron)
+        _validate_url(cfg.hub_url, "HUB_URL", ("http://", "https://"))
+        _validate_url(cfg.ws_url, "WS_URL", ("ws://", "wss://"))
+
+        if cfg.max_tasks_per_hour < 0:
+            raise ConfigValidationError("MEP_MAX_TASKS_PER_HOUR must be >= 0")
+        if cfg.max_runtime_seconds <= 0:
+            raise ConfigValidationError("MEP_MAX_RUNTIME_SECONDS must be > 0")
+        if cfg.max_token_spend_per_hour < 0:
+            raise ConfigValidationError("MEP_MAX_TOKEN_SPEND_PER_HOUR must be >= 0")
+        if cfg.min_bounty > cfg.max_bounty:
+            raise ConfigValidationError("MEP_MIN_BOUNTY cannot be greater than MEP_MAX_BOUNTY")
+        if not cfg.allowed_models:
+            raise ConfigValidationError("MEP_ALLOWED_MODELS must contain at least one model name")
+
+        return cfg
+
+    def as_dict(self) -> dict:
+        return {
+            "autopilot_enabled": self.autopilot_enabled,
+            "autopilot_pause": self.autopilot_pause,
+            "jobs": {
+                "idle_earn_enabled": self.idle_earn_enabled,
+                "dm_sync_enabled": self.dm_sync_enabled,
+                "compute_sync_enabled": self.compute_sync_enabled,
+            },
+            "scheduler": {
+                "cron": self.autopilot_cron,
+                "timezone": self.autopilot_timezone,
+                "timezone_policy": "UTC schedule in v1; timezone for display/logging only",
+            },
+            "safety": {
+                "idle_required": self.idle_required,
+                "max_tasks_per_hour": self.max_tasks_per_hour,
+                "max_runtime_seconds": self.max_runtime_seconds,
+                "max_token_spend_per_hour": self.max_token_spend_per_hour,
+                "allowed_models": list(self.allowed_models),
+                "min_bounty": self.min_bounty,
+                "max_bounty": self.max_bounty,
+            },
+            "connectivity": {
+                "hub_url": self.hub_url,
+                "ws_url": self.ws_url,
+            },
+        }

--- a/node/mep_autopilot_daemon.py
+++ b/node/mep_autopilot_daemon.py
@@ -1,0 +1,96 @@
+import argparse
+import json
+import time
+from datetime import datetime, timezone
+
+from node.mep_autopilot_config import AutopilotConfig, ConfigValidationError
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def build_status_snapshot(config: AutopilotConfig) -> dict:
+    snapshot = config.as_dict()
+    snapshot["status"] = "paused" if config.autopilot_pause else "ready"
+    snapshot["runtime"] = {
+        "mode": "skeleton",
+        "timestamp_utc": _utc_now_iso(),
+        "note": "PR-A scaffold only. No autonomous DM/compute actions are executed yet.",
+    }
+    return snapshot
+
+
+def run_tick(config: AutopilotConfig) -> dict:
+    jobs = []
+    if config.idle_earn_enabled:
+        jobs.append("idle_earn")
+    if config.dm_sync_enabled:
+        jobs.append("dm_sync")
+    if config.compute_sync_enabled:
+        jobs.append("compute_sync")
+
+    if not config.autopilot_enabled:
+        decision = "autopilot_disabled"
+    elif config.autopilot_pause:
+        decision = "autopilot_paused"
+    elif not jobs:
+        decision = "no_jobs_enabled"
+    else:
+        decision = "jobs_planned_noop"
+
+    return {
+        "decision": decision,
+        "planned_jobs": jobs,
+        "timestamp_utc": _utc_now_iso(),
+    }
+
+
+def print_status(config: AutopilotConfig) -> None:
+    print(json.dumps(build_status_snapshot(config), indent=2, sort_keys=True))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="mep_autopilot_daemon")
+    parser.add_argument("--status", action="store_true", help="Print config/runtime status and exit")
+    parser.add_argument("--once", action="store_true", help="Run one scheduling tick and exit")
+    parser.add_argument(
+        "--sleep-seconds",
+        type=float,
+        default=30.0,
+        help="Loop sleep duration for skeleton mode (used when not --once)",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        config = AutopilotConfig.from_env()
+    except ConfigValidationError as exc:
+        print(f"[autopilot] config error: {exc}")
+        return 2
+
+    if args.status:
+        print_status(config)
+        return 0
+
+    if args.once:
+        print(json.dumps(run_tick(config), indent=2, sort_keys=True))
+        return 0
+
+    print("[autopilot] skeleton daemon started. Press Ctrl+C to stop.")
+    print_status(config)
+    try:
+        while True:
+            print(json.dumps(run_tick(config), sort_keys=True))
+            time.sleep(max(args.sleep_seconds, 0.1))
+    except KeyboardInterrupt:
+        print("\n[autopilot] stopped by user.")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/node/mep_status.py
+++ b/node/mep_status.py
@@ -1,0 +1,16 @@
+from node.mep_autopilot_config import AutopilotConfig, ConfigValidationError
+from node.mep_autopilot_daemon import print_status
+
+
+def main() -> int:
+    try:
+        config = AutopilotConfig.from_env()
+    except ConfigValidationError as exc:
+        print(f"[mep status] config error: {exc}")
+        return 2
+    print_status(config)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_autopilot_config.py
+++ b/tests/test_autopilot_config.py
@@ -22,5 +22,17 @@ def test_autopilot_config_rejects_invalid_boolean() -> None:
 
 
 def test_autopilot_config_rejects_min_bounty_above_max() -> None:
-    with pytest.raises(ConfigValidationError, match="cannot be greater"):
+    with pytest.raises(ConfigValidationError) as exc:
         AutopilotConfig.from_env({"MEP_MIN_BOUNTY": "10", "MEP_MAX_BOUNTY": "5"})
+    assert str(exc.value) == "MEP_MIN_BOUNTY cannot be greater than MEP_MAX_BOUNTY"
+
+
+def test_autopilot_config_rejects_negative_bounty_bounds() -> None:
+    with pytest.raises(ConfigValidationError) as exc:
+        AutopilotConfig.from_env({"MEP_MIN_BOUNTY": "-1", "MEP_MAX_BOUNTY": "5"})
+    assert str(exc.value) == "MEP_MIN_BOUNTY and MEP_MAX_BOUNTY must be >= 0"
+
+
+def test_autopilot_config_rejects_invalid_hub_url_prefix() -> None:
+    with pytest.raises(ConfigValidationError, match="HUB_URL must start with"):
+        AutopilotConfig.from_env({"HUB_URL": "ftp://invalid.example.com"})

--- a/tests/test_autopilot_config.py
+++ b/tests/test_autopilot_config.py
@@ -1,0 +1,26 @@
+import pytest
+
+from node.mep_autopilot_config import AutopilotConfig, ConfigValidationError
+
+
+def test_autopilot_config_defaults_are_valid() -> None:
+    cfg = AutopilotConfig.from_env({})
+    assert cfg.autopilot_enabled is False
+    assert cfg.autopilot_cron == "*/5 * * * *"
+    assert cfg.max_token_spend_per_hour == 1000
+    assert cfg.allowed_models
+
+
+def test_autopilot_config_rejects_bad_cron() -> None:
+    with pytest.raises(ConfigValidationError, match="must contain 5 fields"):
+        AutopilotConfig.from_env({"MEP_AUTOPILOT_CRON": "*/5 * *"})
+
+
+def test_autopilot_config_rejects_invalid_boolean() -> None:
+    with pytest.raises(ConfigValidationError, match="boolean-like"):
+        AutopilotConfig.from_env({"MEP_AUTOPILOT_ENABLED": "maybe"})
+
+
+def test_autopilot_config_rejects_min_bounty_above_max() -> None:
+    with pytest.raises(ConfigValidationError, match="cannot be greater"):
+        AutopilotConfig.from_env({"MEP_MIN_BOUNTY": "10", "MEP_MAX_BOUNTY": "5"})


### PR DESCRIPTION
## Summary\n- add 
ode/mep_autopilot_config.py with env-based config parsing and validation\n- add 
ode/mep_autopilot_daemon.py scaffold (--status, --once, loop skeleton)\n- add 
ode/mep_status.py convenience status command\n- add focused tests for config validation in 	ests/test_autopilot_config.py\n- document PR-A scaffold commands in APPENDIX.md\n\n## Scope\n- phase A skeleton only\n- no autonomous DM/compute execution yet\n\n## Validation\n- python -m ruff check node/mep_autopilot_config.py node/mep_autopilot_daemon.py node/mep_status.py tests/test_autopilot_config.py\n- python -m pytest tests/test_autopilot_config.py -q -rA\n- python -m node.mep_autopilot_daemon --status\n