### PR TITLE
feat: local Ollama welcome system + offline diagnostic tool

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -66,6 +66,19 @@ def _ensure_registry_availability_column(cursor):
         if "availability" not in columns:
             cursor.execute("ALTER TABLE agent_registry ADD COLUMN availability TEXT NOT NULL DEFAULT 'unknown'")
 
+def _ensure_registry_bio_column(cursor):
+    if _is_postgres():
+        cursor.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = 'agent_registry' AND column_name = 'bio'"
+        )
+        if not cursor.fetchone():
+            cursor.execute("ALTER TABLE agent_registry ADD COLUMN bio TEXT")
+    else:
+        cursor.execute("PRAGMA table_info(agent_registry)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if "bio" not in columns:
+            cursor.execute("ALTER TABLE agent_registry ADD COLUMN bio TEXT")
+
 def init_db():
     conn = _get_conn()
     cursor = conn.cursor()
@@ -116,6 +129,7 @@ def init_db():
         CREATE TABLE IF NOT EXISTS agent_registry (
             node_id TEXT PRIMARY KEY,
             alias TEXT,
+            bio TEXT,
             skills TEXT NOT NULL,
             models TEXT NOT NULL,
             metadata TEXT NOT NULL,
@@ -124,6 +138,7 @@ def init_db():
             x25519_public_key TEXT
         )
     ''')
+    _ensure_registry_bio_column(cursor)
     _ensure_registry_availability_column(cursor)
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS reputation (
@@ -540,43 +555,46 @@ def delete_idempotency_before(cutoff_ts: float) -> int:
     _release_conn(conn)
     return int(deleted or 0)
 
-def upsert_registry(node_id: str, alias: Optional[str], skills: list[str], models: list[str], metadata: dict, availability: str, updated_at: float, x25519_public_key: Optional[str] = None):
+def upsert_registry(node_id: str, alias: Optional[str], skills: list[str], models: list[str], metadata: dict, availability: str, updated_at: float, x25519_public_key: Optional[str] = None, bio: Optional[str] = None):
     conn = _get_conn()
     cursor = conn.cursor()
     _ensure_registry_availability_column(cursor)
+    _ensure_registry_bio_column(cursor)
     skills_payload = json.dumps(skills)
     models_payload = json.dumps(models)
     metadata_payload = json.dumps(metadata)
     
     if _is_postgres():
         query = """
-            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO agent_registry (node_id, alias, bio, skills, models, metadata, availability, updated_at, x25519_public_key)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (node_id) DO UPDATE SET
                 alias = EXCLUDED.alias,
+                bio = EXCLUDED.bio,
                 skills = EXCLUDED.skills,
                 models = EXCLUDED.models,
                 metadata = EXCLUDED.metadata,
                 availability = EXCLUDED.availability,
                 updated_at = EXCLUDED.updated_at
         """
-        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
+        params = [node_id, alias, bio, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
         if x25519_public_key:
             query += ", x25519_public_key = EXCLUDED.x25519_public_key"
         cursor.execute(query, tuple(params))
     else:
         query = """
-            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO agent_registry (node_id, alias, bio, skills, models, metadata, availability, updated_at, x25519_public_key)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(node_id) DO UPDATE SET
                 alias=excluded.alias,
+                bio=excluded.bio,
                 skills=excluded.skills,
                 models=excluded.models,
                 metadata=excluded.metadata,
                 availability=excluded.availability,
                 updated_at=excluded.updated_at
         """
-        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
+        params = [node_id, alias, bio, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
         if x25519_public_key:
             query += ", x25519_public_key=excluded.x25519_public_key"
         cursor.execute(query, tuple(params))

--- a/hub/main.py
+++ b/hub/main.py
@@ -768,7 +768,7 @@ async def register_node(node: NodeRegistration, request: Request):
     node_id = auth.derive_node_id(node.pubkey)
     balance = db.register_node(node_id, node.pubkey)
     if node.alias or getattr(node, 'x25519_public_key', None):
-        db.upsert_registry(node_id, node.alias, [], [], {}, "offline", time.time(), getattr(node, 'x25519_public_key', None))
+        db.upsert_registry(node_id, node.alias, None, [], [], {}, "offline", time.time(), getattr(node, 'x25519_public_key', None))
 
     log_event("node_registered", f"Node {node_id} registered with starting balance {balance}", node_id=node_id, starting_balance=balance)
     log_audit("REGISTER", node_id, balance, balance, "START_BONUS")
@@ -786,7 +786,7 @@ async def update_registry(payload: RegistryUpdate, authenticated_node: str = Dep
     if availability is None:
         existing = db.get_registry(authenticated_node)
         availability = existing.get("availability") if existing else "unknown"
-    db.upsert_registry(authenticated_node, payload.alias, skills, models, metadata, availability, time.time())
+    db.upsert_registry(authenticated_node, payload.alias, payload.bio, skills, models, metadata, availability, time.time())
     return {"status": "success", "node_id": authenticated_node}
 
 @app.post("/registry/availability")
@@ -804,6 +804,25 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
     db.update_registry_availability(authenticated_node, availability, time.time())
     hub_url, ws_url = get_hub_urls(request)
     return {"status": "success", "node_id": authenticated_node, "availability": availability, "hub_url": hub_url, "ws_url": ws_url}
+
+@app.get("/registry/online")
+async def get_online_nodes():
+    """List all nodes currently connected via WebSocket - for easy node discovery."""
+    online = []
+    for node_id in connected_nodes:
+        registry = db.get_registry(node_id)
+        if registry:
+            online.append({
+                "node_id": node_id,
+                "alias": registry.get("alias"),
+                "bio": registry.get("bio"),
+                "skills": registry.get("skills", []),
+                "models": registry.get("models", []),
+                "availability": registry.get("availability", "unknown")
+            })
+        else:
+            online.append({"node_id": node_id, "alias": None, "bio": None})
+    return {"count": len(online), "nodes": online}
 
 @app.get("/registry/search")
 async def search_registry(

--- a/hub/main.py
+++ b/hub/main.py
@@ -16,6 +16,14 @@ import db
 import auth
 from logger import log_event, log_audit
 
+# Welcome & FAQ system for new node operators (served via /register response)
+try:
+    from welcome import get_welcome, get_faq, WELCOME_MARKDOWN, OLLAMA_SYSTEM_PROMPT
+    WELCOME_AVAILABLE = True
+except ImportError:
+    WELCOME_AVAILABLE = False
+    get_welcome = lambda node_id, alias, balance: {}  # type: ignore
+
 from models import NodeRegistration, TaskCreate, TaskResult, TaskBid, TaskCancel, RegistryUpdate, AvailabilityUpdate, RegistryHeartbeat, ReputationSubmit, DisputeOpen, DisputeResolve, FederationPeerUpsert
 
 app = FastAPI(title="MEP Hub", description="The Time Exchange Clearinghouse", version="0.1.2")
@@ -775,7 +783,31 @@ async def register_node(node: NodeRegistration, request: Request):
 
     hub_url, ws_url = get_hub_urls(request)
 
-    return {"status": "success", "node_id": node_id, "balance": balance, "hub_url": hub_url, "ws_url": ws_url}
+    response = {
+        "status": "success",
+        "node_id": node_id,
+        "balance": balance,
+        "hub_url": hub_url,
+        "ws_url": ws_url,
+    }
+
+    # Attach welcome package for new nodes
+    if WELCOME_AVAILABLE:
+        welcome = get_welcome(node_id, node.alias, balance)
+        response["welcome"] = welcome.get("text", "")
+        response["welcome_markdown"] = welcome.get("markdown", "")
+        response["faq"] = get_faq()
+
+    return response
+
+
+@app.get("/faq")
+async def get_faq_endpoint():
+    """Public FAQ endpoint — no auth required. Returns troubleshooting guide for node operators."""
+    if not WELCOME_AVAILABLE:
+        raise HTTPException(status_code=503, detail="FAQ not available on this Hub")
+    return {"faq": get_faq(), "system_prompt": OLLAMA_SYSTEM_PROMPT}
+
 
 @app.post("/registry/update")
 async def update_registry(payload: RegistryUpdate, authenticated_node: str = Depends(verify_request)):

--- a/hub/models.py
+++ b/hub/models.py
@@ -33,6 +33,7 @@ class NodeBalance(BaseModel):
 
 class RegistryUpdate(BaseModel):
     alias: Optional[str] = None
+    bio: Optional[str] = None
     skills: Optional[List[str]] = None
     models: Optional[List[str]] = None
     metadata: Optional[Dict[str, Any]] = None

--- a/node/mep_diagnostic.py
+++ b/node/mep_diagnostic.py
@@ -1,0 +1,683 @@
+#!/usr/bin/env python3
+"""
+MEP Node Diagnostic Tool — Fully Offline
+=======================================
+Self-contained diagnostic for MEP node operators.
+No API calls, works completely offline after setup.
+
+Checks:
+  1. Key file existence & location
+  2. Node ID computation (client vs Hub)
+  3. Hub connectivity
+  4. Node registration status
+  5. WebSocket connection
+  6. Known bug patterns & fix guidance
+
+Usage:
+  python3 mep_diagnostic.py
+  python3 mep_diagnostic.py --key-path ~/.mep/mep_node.pem
+  python3 mep_diagnostic.py --ollama http://localhost:11434  # use local Ollama
+"""
+import os
+import sys
+import json
+import hashlib
+import base64
+import argparse
+import urllib.request
+import urllib.error
+import urllib.parse
+import asyncio
+import socket
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+HUB_URL = "https://mep-hub.silentcopilot.ai"
+HUB_API = f"{HUB_URL}/api"
+DEFAULT_OLLAMA = "http://localhost:11434"
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+G, R, Y, B, BO, RST = "\033[92m", "\033[91m", "\033[93m", "\033[94m", "\033[1m", "\033[0m"
+
+def ok(msg):   print(f"{G}✓{RST} {msg}")
+def fail(msg): print(f"{R}✗{RST} {msg}")
+def warn(msg): print(f"{Y}⚠{RST} {msg}")
+def info(msg): print(f"{B}ℹ{RST} {msg}")
+def bold(msg): print(f"{BO}{msg}{RST}")
+
+def section(n, title):
+    print(f"\n{BO}[{n}] {title}{RST}")
+
+def cmd(cmdline):
+    """Print a shell command."""
+    print(f"\n  {G}${RST} {cmdline}")
+
+# ---------------------------------------------------------------------------
+# Built-in known bugs & fixes (fully offline knowledge base)
+# ---------------------------------------------------------------------------
+# Try to load shared FAQ from MEP repo's welcome.py (used by Hub)
+_WELCOME_AVAILABLE = False
+try:
+    import sys as _sys
+    _sys.path.insert(0, "/home/node/.openclaw/workspace/MEP")
+    from node.welcome import FAQ as _WELCOME_FAQ
+    BUGS = {item["id"]: item for item in _WELCOME_FAQ}
+    _WELCOME_AVAILABLE = True
+except Exception:
+    # Fallback when welcome.py is not available
+    BUGS = {
+        "node_id_mismatch": {
+            "id": "node_id_mismatch",
+            "symptom": "401 Unauthorized / 403 Forbidden / signature verification failed",
+            "cause": "MEPIdentity and Hub hash the public key differently.",
+            "fix_steps": [
+                "1. Run diagnostic: python3 mep_diagnostic.py",
+                "2. Check if Your node_id ≠ Hub computes",
+                "3. Fix: update node/identity.py or hub/auth.py to use same hash input",
+                "4. Re-register with fixed code",
+            ],
+            "files": ["node/identity.py", "hub/auth.py"],
+        },
+        "key_in_tmp": {
+            "id": "key_in_tmp",
+            "symptom": "Key not found / node identity changed after reboot",
+            "cause": "Key stored in /tmp which is cleared on reboot.",
+            "fix_steps": [
+                "1. Move key: cp /tmp/mep_node.pem ~/.mep/mep_node.pem",
+                "2. Update KEY_PATH in scripts",
+                "3. Verify: python3 -c \"from node.identity import MEPIdentity; print(MEPIdentity('~/.mep/mep_node.pem').node_id)\"",
+            ],
+            "files": ["/tmp/mep_node.pem"],
+        },
+        "not_bidding": {
+            "id": "not_bidding",
+            "symptom": "RFC events received but no bids placed / Hub shows 0 bidders",
+            "cause": "WebSocket handler handles 'new_task' but not 'rfc' event type.",
+            "fix_steps": [
+                "1. Add RFC handler: elif data.get('event') == 'rfc': await handle_rfc(data['data'])",
+                "2. In handle_rfc(), call POST /tasks/bid with task_id and provider_id",
+                "3. Test by submitting a task",
+            ],
+            "files": ["node/listen_ws.py"],
+        },
+        "missing_deps": {
+            "id": "missing_deps",
+            "symptom": "ModuleNotFoundError / ImportError / No module named",
+            "cause": "Required Python packages not installed.",
+            "fix_steps": [
+                "1. pip install cryptography websockets requests urllib3",
+                "2. Verify: python3 -c 'import websockets, cryptography, requests; print(\"OK\")'",
+            ],
+            "files": [],
+        },
+    }
+
+
+def diagnose(symptoms: list) -> list:
+    """Match symptoms to known bugs."""
+    matched = []
+    for bug_id, bug in BUGS.items():
+        # welcome.py uses "symptom" (singular), local dict uses "symptoms" (list)
+        symptom_text = bug.get("symptom", "") or ""
+        symptom_list = bug.get("symptoms", [symptom_text])
+        for symptom in symptoms:
+            if any(symptom.lower() in st.lower() for st in symptom_list if st):
+                matched.append(bug_id)
+                break
+    return matched
+
+
+# ---------------------------------------------------------------------------
+# Identity & Key Checks
+# ---------------------------------------------------------------------------
+def load_key(key_path: str) -> dict:
+    """Load Ed25519 key and compute node IDs."""
+    result = {"path": key_path, "exists": False, "error": None,
+              "node_id": None, "pubkey_b64": None, "hub_node_id": None}
+
+    if not os.path.exists(key_path):
+        result["error"] = f"Key file not found: {key_path}"
+        return result
+
+    result["exists"] = True
+
+    try:
+        from cryptography.hazmat.primitives import serialization
+        private_bytes = open(key_path, "rb").read()
+        private_key = serialization.load_pem_private_key(private_bytes, password=None)
+        public_key = private_key.public_key()
+
+        # Client: PEM SubjectPublicKeyInfo
+        pub_pem = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo
+        ).decode("utf-8")
+
+        # Extract raw base64 from PEM
+        b64 = "".join(l for l in pub_pem.strip().split("\n")
+                      if not l.startswith("-----"))
+        b64_stripped = b64.rstrip("=")
+
+        # Client node_id (hash PEM string)
+        sha_client = hashlib.sha256(pub_pem.encode()).hexdigest()
+        result["node_id"] = f"node_{sha_client[:12]}"
+
+        # Hub node_id (hash raw base64 string)
+        sha_hub = hashlib.sha256(b64.encode()).hexdigest()
+        result["hub_node_id"] = f"node_{sha_hub[:12]}"
+
+        result["pubkey_b64"] = b64_stripped
+        result["node_id_match"] = result["node_id"] == result["hub_node_id"]
+
+    except ImportError as e:
+        result["error"] = f"cryptography not installed: {e}"
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
+
+
+def check_key_safety(key_path: str) -> list:
+    """Detect unsafe key storage."""
+    issues = []
+    if key_path.startswith("/tmp"):
+        issues.append(f"Key is in /tmp — LOST on reboot!")
+    if not os.access(key_path, 0o600) and not os.access(key_path, 0o400):
+        issues.append(f"Key permissions too open: {oct(os.stat(key_path).st_mode)[-3:]}")
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Hub Communication
+# ---------------------------------------------------------------------------
+def check_hub_health() -> bool:
+    try:
+        r = urllib.request.urlopen(f"{HUB_URL}/health", timeout=5)
+        data = json.loads(r.read())
+        ok(f"Hub online: {data.get('status', 'ok')}")
+        return True
+    except Exception as e:
+        fail(f"Hub unreachable: {e}")
+        return False
+
+
+def check_registration(node_id: str) -> dict:
+    """Check if node is registered on Hub."""
+    try:
+        req = urllib.request.Request(
+            f"{HUB_API}/nodes/{node_id}",
+            headers={"x-mep-nodeid": node_id}
+        )
+        r = urllib.request.urlopen(req, timeout=5)
+        ok(f"Registered on Hub: {node_id}")
+        return {"registered": True, "data": json.loads(r.read())}
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            fail(f"Not registered: {node_id}")
+            return {"registered": False}
+        warn(f"HTTP {e.code}")
+        return {"registered": None}
+    except Exception as e:
+        warn(f"Check failed: {e}")
+        return {"registered": None}
+
+
+def test_registration(pubkey_b64: str, alias: str = None) -> dict:
+    """Register with Hub and see what node_id it assigns."""
+    alias = alias or f"diag-{socket.gethostname()[:8]}"
+    payload = json.dumps({"pubkey": pubkey_b64, "alias": alias}).encode()
+    req = urllib.request.Request(
+        f"{HUB_URL}/register",
+        data=payload,
+        headers={"Content-Type": "application/json"}
+    )
+    try:
+        r = urllib.request.urlopen(req, timeout=10)
+        data = json.loads(r.read())
+        ok(f"Registration OK — Hub assigned: {data.get('node_id')}, balance: {data.get('balance')}")
+        return {"success": True, "hub_node_id": data.get("node_id"), "balance": data.get("balance")}
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()[:200]
+        fail(f"Registration HTTP {e.code}: {body}")
+        return {"success": False, "error": body}
+    except Exception as e:
+        fail(f"Registration error: {e}")
+        return {"success": False}
+
+
+def test_websocket(node_id: str, key_path: str) -> dict:
+    """Test WebSocket connection."""
+    try:
+        import websockets
+        import time as time_module
+
+        with open(key_path, "rb") as f:
+            pk = f.read()
+        from cryptography.hazmat.primitives import serialization
+        sk = serialization.load_pem_private_key(pk, password=None)
+
+        ts = str(int(time_module.time()))
+        msg = f"{node_id}{ts}".encode()
+        sig = base64.b64encode(sk.sign(msg)).decode()
+        uri = f"wss://mep-hub.silentcopilot.ai/ws/{node_id}?timestamp={ts}&signature={urllib.parse.quote(sig)}"
+
+        async def _test():
+            async with websockets.connect(uri, timeout=8) as ws:
+                msg = await asyncio.wait_for(ws.recv(), timeout=8)
+                return json.loads(msg)
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        result = loop.run_until_complete(_test())
+        ok(f"WebSocket connected — received: {result.get('event', result)}")
+        return {"connected": True, "msg": result}
+    except ImportError:
+        warn("websockets not installed — skipped WS test")
+        return {"connected": None}
+    except asyncio.TimeoutError:
+        fail("WebSocket timed out — Hub may not recognize this node_id")
+        return {"connected": False}
+    except Exception as e:
+        fail(f"WebSocket error: {e}")
+        return {"connected": False, "error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Ollama Integration (local LLM — fully offline)
+# ---------------------------------------------------------------------------
+def check_ollama(base_url: str) -> dict:
+    """Check if local Ollama is available."""
+    try:
+        r = urllib.request.urlopen(f"{base_url}/api/tags", timeout=3)
+        models = json.loads(r.read()).get("models", [])
+        names = [m["name"] for m in models]
+        ok(f"Ollama running: {names or 'no models installed'}")
+        return {"available": True, "models": names}
+    except Exception:
+        return {"available": False}
+
+
+def ollama_chat(base_url: str, model: str, prompt: str, timeout: int = 60) -> str:
+    """Query local Ollama model."""
+    payload = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "options": {"temperature": 0.3, "max_tokens": 512}
+    }).encode()
+
+    req = urllib.request.Request(
+        f"{base_url}/v1/chat/completions",
+        data=payload,
+        headers={"Content-Type": "application/json"}
+    )
+
+    try:
+        r = urllib.request.urlopen(req, timeout=timeout)
+        data = json.loads(r.read())
+        return data["choices"][0]["message"]["content"]
+    except Exception as e:
+        return f"[Ollama error: {e}]"
+
+
+OLLAMA_PROMPT_TEMPLATE = """You are an MEP (Miao Exchange Protocol) node troubleshooting assistant.
+
+CONTEXT:
+- User's node_id (client computes): {node_id}
+- Hub computes node_id: {hub_node_id}
+- Node IDs match: {match}
+- Registered on Hub: {registered}
+- WebSocket connected: {ws}
+- Symptoms reported: {symptoms}
+
+KNOWN BUGS IN SYSTEM:
+1. Node ID mismatch: client and Hub hash public key differently → 401/403 errors
+2. Key in /tmp: lost on reboot → sudden identity changes
+3. RFC not handled: listener gets RFC events but doesn't bid → tasks unclaimed
+4. Missing deps: websockets/cryptography not installed
+
+TASK: Based on the above, explain:
+1. What is most likely the problem
+2. Why it happened
+3. Exact commands to fix it (be specific, show actual curl commands)
+
+Be brief and actionable. Assume user is a node operator.
+Output format: Problem → Why → Fix (with actual commands).
+"""
+
+
+def ask_ollama(base_url: str, model: str, diagnostics: dict, symptoms: list) -> str:
+    """Use local Ollama to generate fix guidance."""
+    prompt = OLLAMA_PROMPT_TEMPLATE.format(
+        node_id=diagnostics.get("node_id", "unknown"),
+        hub_node_id=diagnostics.get("hub_node_id", "unknown"),
+        match=diagnostics.get("node_id_match", False),
+        registered=diagnostics.get("registered"),
+        ws=diagnostics.get("ws", "unknown"),
+        symptoms=", ".join(symptoms) or "none"
+    )
+    return ollama_chat(base_url, model, prompt)
+
+
+# ---------------------------------------------------------------------------
+# Fix Guide Renderer
+# ---------------------------------------------------------------------------
+def show_fix(bug_id: str):
+    """Print detailed fix guide for a known bug."""
+    bug = BUGS[bug_id]
+    # welcome.py uses "symptom" as title; local dict uses "title"
+    title = bug.get("title") or bug.get("symptom", bug_id)
+    bold(f"\n  ╔═ {title}")
+    print(f"  ║  Cause: {bug['cause']}")
+    print(f"  ║")
+    # fix_steps is List[str] in welcome.py, List[tuple] in local fallback
+    steps = bug.get("fix_steps", [])
+    for i, step in enumerate(steps, 1):
+        if isinstance(step, tuple):
+            step_name, step_text = step
+            print(f"  ║  {i}. [{step_name}] {step_text}")
+        else:
+            text = step.strip()
+            if text.startswith(f"{i}."):
+                text = text[3:].strip()  # strip leading "1. "
+            print(f"  ║  {i}. {text}")
+    files = bug.get("files", [])
+    if files:
+        print(f"  ║  Files: {', '.join(f for f in files if f)}")
+    url = bug.get("url")
+    if url:
+        print(f"  ║  More: {url}")
+    print(f"  ╚══════════════════════════════════")
+
+
+def show_summary(issues: list, diagnostics: dict):
+    """Print a clean summary."""
+    print(f"\n{BO}─── Summary ───{RST}")
+    if not issues:
+        ok("All checks passed!")
+        return
+
+    warn(f"{len(issues)} issue(s) found:\n")
+    for issue in issues:
+        bug = BUGS.get(issue)
+        if bug:
+            print(f"  {R}✗{RST} {bug.get('title') or bug.get('symptom', '')}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main Diagnostic Run
+# ---------------------------------------------------------------------------
+def run(key_path: str = None, ollama_url: str = None, ollama_model: str = None,
+        symptoms: list = None, offline: bool = False):
+    """Run full diagnostic suite."""
+    bold(f"\n{'='*50}")
+    bold(f"  MEP Node Diagnostic Tool — Fully Offline")
+    bold(f"{'='*50}\n")
+
+    issues_found = []
+    all_symptoms = symptoms or []
+
+    # ── 1. Find key ──────────────────────────────────────────────
+    section("1", "Key File")
+
+    if not key_path:
+        candidates = [
+            "~/.mep/mep_node.pem",
+            "~/.hermes/mep_node.pem",
+            "~/mep_node.pem",
+            "/tmp/mep_node.pem",
+            "/tmp/hermes_mep_node.pem",
+            "/tmp/sentinel.pem",
+            "/home/node/.openclaw/workspace/mep-sentinel/node/sentinel.pem",
+            "node/sentinel.pem",
+        ]
+        for c in candidates:
+            c = os.path.expanduser(c)
+            if os.path.exists(c):
+                key_path = c
+                info(f"Found: {c}")
+                break
+
+    if not key_path or not os.path.exists(key_path):
+        fail("No key found.")
+        print("\n  Searched:")
+        for c in candidates:
+            print(f"    {os.path.expanduser(c)}")
+        print("\n  Generate a key:")
+        cmd("python3 -c \"from node.identity import MEPIdentity; MEPIdentity('~/.mep/mep_node.pem')\"")
+        return
+
+    ident = load_key(key_path)
+
+    if ident["error"]:
+        fail(f"Load error: {ident['error']}")
+        issues_found.append("missing_deps")
+        return
+
+    ok(f"Key: {key_path}")
+    bold(f"  Your node_id:    {ident['node_id']}")
+    bold(f"  Hub computes:     {ident['hub_node_id']}")
+
+    if not ident["node_id_match"]:
+        warn("  → MISMATCH! This WILL cause 401/403 errors.")
+        issues_found.append("node_id_mismatch")
+        all_symptoms.append("401 Unauthorized")
+
+    # Key safety
+    safety = check_key_safety(key_path)
+    for s in safety:
+        warn(f"  {s}")
+        issues_found.append("key_in_tmp")
+
+    # ── 2. Dependencies ─────────────────────────────────────────
+    section("2", "Dependencies")
+    missing = []
+    for pkg in ["cryptography", "websockets", "requests"]:
+        try:
+            __import__(pkg)
+        except ImportError:
+            missing.append(pkg)
+
+    if missing:
+        fail(f"Missing: {', '.join(missing)}")
+        cmd("pip install cryptography websockets requests urllib3")
+        issues_found.append("missing_deps")
+    else:
+        ok("All dependencies installed")
+
+    # ── 3. Hub Connectivity ──────────────────────────────────────
+    section("3", "Hub Connectivity")
+    hub_ok = check_hub_health()
+
+    if not hub_ok:
+        warn("Hub unreachable — skip remaining network tests")
+        all_symptoms.append("Hub unreachable")
+    else:
+        # ── 4. Registration ────────────────────────────────────
+        section("4", "Node Registration")
+        reg = check_registration(ident["node_id"])
+
+        print("\n  Test registration...")
+        reg_test = test_registration(ident["pubkey_b64"])
+
+        if not ident["node_id_match"]:
+            issues_found.append("node_id_mismatch")
+            all_symptoms.append("node_id mismatch")
+        elif not reg.get("registered"):
+            issues_found.append("registration_404")
+            all_symptoms.append("node not found on Hub")
+
+        # ── 5. WebSocket ───────────────────────────────────────
+        if hub_ok:
+            section("5", "WebSocket Connection")
+            if "websockets" not in missing:
+                ws = test_websocket(ident["node_id"], key_path)
+            else:
+                warn("Skipped (websockets not installed)")
+                ws = {"connected": None}
+
+    # ── 6. Bug Matching & Fix ────────────────────────────────────
+    section("6", "Diagnosis")
+
+    # Auto-match from symptoms
+    matched = diagnose(all_symptoms)
+    for m in matched:
+        if m not in issues_found:
+            issues_found.append(m)
+
+    if issues_found:
+        print(f"\n  Detected {len(issues_found)} issue(s):")
+        for issue_id in issues_found:
+            bug = BUGS.get(issue_id)
+            if bug:
+                print(f"\n  {R}✗{RST} {bug.get('title') or bug.get('symptom', '')}")
+        print()
+    else:
+        ok("No known issues detected.")
+
+    # ── 7. Show Fixes ────────────────────────────────────────────
+    unique_issues = list(dict.fromkeys(issues_found))  # preserve order, dedupe
+    for issue_id in unique_issues:
+        if issue_id in BUGS:
+            show_fix(issue_id)
+
+    # ── 8. Ollama Q&A ────────────────────────────────────────────
+    if ollama_url:
+        section("8", f"Local LLM ({ollama_model or 'auto'})")
+        ollama = check_ollama(ollama_url)
+        if ollama["available"]:
+            models = ollama["models"]
+            model = ollama_model or (models[0] if models else None)
+            if model:
+                info(f"Using model: {model}")
+                print("\n  Asking local LLM...")
+                advice = ask_ollama(ollama_url, model, ident, all_symptoms)
+                print(f"\n  {B}LLM says:{RST}\n")
+                for line in advice.split("\n"):
+                    print(f"    {line}")
+            else:
+                warn("No models installed in Ollama.")
+                print("\n  Install a model:")
+                cmd("ollama pull qwen3:1.8b")
+                cmd("ollama pull llama3.2:1b")
+        else:
+            warn(f"Ollama not reachable at {ollama_url}")
+            print("\n  Start Ollama:")
+            cmd("ollama serve")
+            cmd("ollama pull qwen3:1.8b  # ~1.1GB, good for diagnostics")
+
+    # ── Final Summary ─────────────────────────────────────────────
+    print(f"\n{BO}─── Summary ───{RST}")
+    if unique_issues:
+        warn(f"{len(unique_issues)} issue(s) need fixing — see above.")
+    else:
+        ok("All checks passed!")
+
+
+# ---------------------------------------------------------------------------
+# Standalone Info Commands
+# ---------------------------------------------------------------------------
+
+def _show_info(args):
+    """Handle --welcome, --faq, --faq-json flags."""
+    try:
+        sys.path.insert(0, "/home/node/.openclaw/workspace/MEP")
+        from node.welcome import (
+            get_welcome, get_faq, format_faq_for_display,
+            WELCOME_TEMPLATE, WELCOME_MARKDOWN, OLLAMA_SYSTEM_PROMPT
+        )
+    except ImportError:
+        print(f"{R}Error: welcome.py not found. Run from MEP repo directory.{RST}")
+        return
+
+    if args.welcome:
+        # Show welcome message (node_id is optional — uses placeholder)
+        welcome = get_welcome(
+            node_id="<your-node-id>",
+            alias="Node Operator",
+            balance=0.0
+        )
+        print(welcome.get("text", WELCOME_TEMPLATE.format(
+            alias="Node Operator",
+            node_id="<your-node-id>",
+            balance=0.0
+        )))
+
+    if args.faq:
+        print(format_faq_for_display("markdown"))
+
+    if args.faq_json:
+        import json
+        faq = get_faq()
+        print(json.dumps(faq, indent=2, ensure_ascii=False))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main():
+    p = argparse.ArgumentParser(
+        description="MEP Node Diagnostic Tool — works fully offline",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 mep_diagnostic.py
+  python3 mep_diagnostic.py --key-path ~/.mep/mep_node.pem
+  python3 mep_diagnostic.py --ollama http://localhost:11434
+  python3 mep_diagnostic.py --ollama http://localhost:11434 --model qwen3:1.8b
+  python3 mep_diagnostic.py --symptom "401 Unauthorized" --symptom "WS refused"
+  python3 mep_diagnostic.py --offline  # skip all network calls, basic key check only
+
+No API keys needed. No internet required after initial setup.
+        """
+    )
+    p.add_argument("--key-path", help="Path to Ed25519 private key PEM file")
+    p.add_argument("--ollama", metavar="URL", default=None,
+                   help="Ollama base URL for local LLM (default: http://localhost:11434)")
+    p.add_argument("--model", help="Ollama model name to use (default: first available)")
+    p.add_argument("--symptom", action="append", default=[],
+                   help="Report a symptom (can be repeated)")
+    p.add_argument("--offline", action="store_true",
+                   help="Skip all network calls, basic checks only")
+    p.add_argument("--hub-url", default=HUB_URL,
+                   help=f"Hub URL (default: {HUB_URL})")
+    p.add_argument("--welcome", action="store_true",
+                   help="Show welcome message for new node operators")
+    p.add_argument("--faq", action="store_true",
+                   help="Show full troubleshooting FAQ")
+    p.add_argument("--faq-json", action="store_true",
+                   help="Output FAQ as JSON")
+
+    args = p.parse_args()
+
+    # Handle standalone info commands
+    if args.welcome or args.faq or args.faq_json:
+        _show_info(args)
+        return
+
+    # Detect Ollama automatically if running
+    ollama_url = args.ollama
+    if not ollama_url:
+        for url in [DEFAULT_OLLAMA, "http://127.0.0.1:11434"]:
+            try:
+                urllib.request.urlopen(f"{url}/api/tags", timeout=2)
+                ollama_url = url
+                break
+            except Exception:
+                pass
+
+    run(
+        key_path=args.key_path,
+        ollama_url=ollama_url,
+        ollama_model=args.model,
+        symptoms=args.symptom,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/node/welcome.py
+++ b/node/welcome.py
@@ -1,0 +1,380 @@
+"""
+MEP Node Welcome & Troubleshooting System
+========================================
+Provides structured welcome messages and FAQ for newly registered MEP nodes.
+Designed for:
+  1. Hub to serve via /register response
+  2. Local Ollama to parse and present beautifully to node operators
+  3. Node operators to self-diagnose common issues
+
+No external API required — works fully offline with local Ollama.
+
+Usage:
+    from node.welcome import get_welcome, get_faq, format_for_ollama
+
+    # Get full welcome package for a new node
+    welcome = get_welcome(node_id, alias)
+
+    # Get troubleshooting FAQ
+    faq = get_faq()
+
+    # Format for local Ollama chat
+    ollama_prompt = format_for_ollama(node_id, alias, balance)
+"""
+
+from __future__ import annotations
+import json
+from dataclasses import dataclass, asdict
+from typing import List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Welcome Message
+# ---------------------------------------------------------------------------
+
+WELCOME_TEMPLATE = """
+🎉 Welcome to MEP, {alias}!
+
+Your node is now registered as `{node_id}`.
+
+📊 Your Dashboard:
+   Balance : {balance} SECONDS
+   Node ID : {node_id}
+   Hub URL : https://mep-hub.silentcopilot.ai
+   WebSocket: wss://mep-hub.silentcopilot.ai/ws/{node_id}
+
+🚀 Quick Start:
+   1. Keep this script running to stay online
+   2. Listen for RFC events → place bids → earn SECONDS
+   3. Run the diagnostic tool: python3 node/mep_diagnostic.py
+
+📚 Documentation:
+   README.md         — Full protocol documentation
+   OPERATOR_CHECKLIST.md — Setup checklist for node operators
+   node/             — Provider scripts (mep_provider.py, etc.)
+
+💬 Troubleshooting:
+   Run the diagnostic tool for auto-detection:
+     python3 node/mep_diagnostic.py --ollama http://localhost:11435
+
+   Or ask your local Ollama:
+     python3 node/mep_diagnostic.py --ollama http://localhost:11435 --model llama3.2:1b
+
+🆘 Common Issues:
+   • "401 Unauthorized" → Node ID mismatch (see FAQ #1)
+   • "Connection refused" → Hub unreachable or wrong URL
+   • "Key not found" → Key stored in /tmp was lost (see FAQ #2)
+
+Happy mining! ⛏️
+"""
+
+WELCOME_MARKDOWN = """
+# 🎉 Welcome to MEP, {alias}!
+
+You are now connected to the **Miao Exchange Protocol**.
+
+## Your Node
+
+| Field | Value |
+|-------|-------|
+| **Node ID** | `{node_id}` |
+| **Balance** | {balance} SECONDS |
+| **Hub URL** | `https://mep-hub.silentcopilot.ai` |
+| **WebSocket** | `wss://mep-hub.silentcopilot.ai/ws/{node_id}` |
+
+## What Happens Next
+
+Your node will automatically:
+1. Maintain a WebSocket connection to the Hub
+2. Receive RFC (Request for Citation) events when tasks are available
+3. Place bids to compete for tasks
+4. Process tasks and earn SECONDS
+
+## Diagnostic Tool
+
+For self-service troubleshooting, run:
+
+```bash
+# Install Ollama (one-time setup)
+curl -fsSL https://ollama.ai/install.sh | sh
+ollama pull llama3.2:1b
+
+# Run the diagnostic tool
+python3 node/mep_diagnostic.py \\
+    --key-path ~/.mep/mep_node.pem \\
+    --ollama http://localhost:11435 \\
+    --model llama3.2:1b
+```
+
+## Common Issues
+
+|Q#|Symptom|Cause|Solution|
+|---|--------|-----|--------|
+|1|401/403 Auth Failure|Node ID mismatch|Recompute node_id from key|
+|2|Key regenerated on reboot|Key stored in /tmp|Move to persistent storage|
+|3|No bids being placed|Listener doesn't handle RFC events|Add bid handler to WebSocket loop|
+|4|WS connection refused|Hub down or firewall|Verify Hub health + firewall rules|
+
+## Need Help?
+
+- Run: `python3 node/mep_diagnostic.py`
+- Issues: https://github.com/Hub-Sentinel/MEP/issues
+- Protocol docs: `docs/` directory
+"""
+
+
+# ---------------------------------------------------------------------------
+# Troubleshooting FAQ
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FAQItem:
+    id: str
+    symptom: str
+    cause: str
+    fix_steps: List[str]
+    files: List[str]
+    severity: str  # "critical", "warning", "info"
+
+FAQ = [
+    FAQItem(
+        id="node_id_mismatch",
+        symptom="401 Unauthorized / 403 Forbidden / HTTP 403 / HTTP 401 / 'signature verification failed'",
+        cause=(
+            "MEPIdentity (client) and the Hub hash the public key differently. "
+            "MEPIdentity hashes the PEM-encoded public key string. "
+            "The Hub hashes the raw base64 public key string. "
+            "Result: two different node_ids for the same key pair. "
+            "Your client tries to authenticate with node_id_A, but the Hub registered you as node_id_B."
+        ),
+        fix_steps=[
+            "1. Identify: Run diagnostic — check if 'Your node_id' ≠ 'Hub computes'",
+            "2. Get Hub's node_id: POST /register with your pubkey → response contains 'node_id'",
+            "3. Fix Option A (change client): In node/identity.py, compute node_id by hashing the raw base64 (not PEM string), OR",
+            "4. Fix Option B (change Hub): In hub/auth.py, change derive_node_id() to hash the PEM string like the client does",
+            "5. Re-register: After fixing, call POST /register to get a new node_id",
+            "6. Update all scripts: Replace old node_id with the new one in your config",
+        ],
+        files=["node/identity.py", "hub/auth.py"],
+        severity="critical",
+    ),
+    FAQItem(
+        id="key_in_tmp",
+        symptom="Key file not found / Node re-registered with new identity / 'Unknown Node ID'",
+        cause=(
+            "The private key PEM file was stored in /tmp, which is cleared on system reboot, "
+            "by tmpfs conversion, or by system cleanup tools (bleachbit, etc.). "
+            "A new key was generated, giving the node a completely new identity. "
+            "The old node_id is now orphaned on the Hub."
+        ),
+        fix_steps=[
+            "1. Move key to persistent location: mkdir -p ~/.mep && cp /tmp/mep_node.pem ~/.mep/mep_node.pem",
+            "2. Update KEY_PATH in your listener: export MEP_KEY_PATH=~/.mep/mep_node.pem",
+            "3. Verify identity: python3 -c \"from node.identity import MEPIdentity; print(MEPIdentity('~/.mep/mep_node.pem').node_id)\"",
+            "4. Re-register if needed: POST /register with your pubkey",
+            "5. Add to startup: Ensure the key exists before the listener starts",
+        ],
+        files=["/tmp/mep_node.pem", "/tmp/hermes_mep_node.pem"],
+        severity="critical",
+    ),
+    FAQItem(
+        id="not_bidding",
+        symptom="RFC events received / no /tasks/bid call / Hub shows 0 bids / Tasks timeout unclaimed",
+        cause=(
+            "The WebSocket listener receives RFC (Request for Citation) events from the Hub, "
+            "but the code only handles 'new_task' events — not 'rfc' events. "
+            "The node never calls POST /tasks/bid, so the Hub sees zero bids and the task goes unclaimed."
+        ),
+        fix_steps=[
+            "1. Find your WebSocket handler: grep -n 'event.*new_task' node/listen_ws.py",
+            "2. Add RFC handler: elif data.get('event') == 'rfc': await handle_rfc(data['data'])",
+            "3. Implement handle_rfc():",
+            "   task_id = data['data']['id']",
+            "   payload = json.dumps({'task_id': task_id, 'provider_id': node_id}, separators=(',', ':'))",
+            "   headers = get_auth_headers(payload)",
+            "   requests.post(f'{HUB_URL}/tasks/bid', data=payload, headers=headers)",
+            "4. Test: Submit a task, watch logs for 'Bid result: accepted'",
+        ],
+        files=["node/listen_ws.py", "node/mep_provider.py"],
+        severity="warning",
+    ),
+    FAQItem(
+        id="missing_deps",
+        symptom="ModuleNotFoundError / ImportError / 'No module named websockets'",
+        cause="Required Python packages (cryptography, websockets, requests) not installed in the node's Python environment.",
+        fix_steps=[
+            "1. Install dependencies: pip install cryptography websockets requests urllib3",
+            "2. Verify: python3 -c 'import websockets, cryptography, requests; print(\"All OK\")'",
+            "3. If using venv: source venv/bin/activate && pip install -r requirements.txt",
+        ],
+        files=["requirements.txt"],
+        severity="info",
+    ),
+    FAQItem(
+        id="hub_unreachable",
+        symptom="Connection refused / ConnectionError / Cannot connect to wss://mep-hub.silentcopilot.ai",
+        cause="Hub is down, network/firewall blocking outbound 443, or WebSocket URL is incorrect.",
+        fix_steps=[
+            "1. Check Hub status: curl https://mep-hub.silentcopilot.ai/health",
+            "2. Check your firewall: ensure outbound TCP 443 is allowed",
+            "3. Verify WebSocket URL format: wss://mep-hub.silentcopilot.ai/ws/{node_id}",
+            "4. Check proxy settings: unset HTTP_PROXY HTTPS_PROXY",
+        ],
+        files=[],
+        severity="warning",
+    ),
+    FAQItem(
+        id="registration_404",
+        symptom="404 on /api/nodes/{node_id}/heartbeat / 'node not found on Hub'",
+        cause="The node_id used by the client doesn't match any registered node on the Hub (usually from the node_id_mismatch bug).",
+        fix_steps=[
+            "1. Re-register: curl -X POST https://mep-hub.silentcopilot.ai/register "
+             "-H 'Content-Type: application/json' "
+             "-d '{\"pubkey\": \"<base64-pubkey>\", \"alias\": \"my-node\"}'",
+            "2. Use the 'node_id' from the Hub response in ALL subsequent API calls",
+            "3. Update local identity: ensure node/identity.py uses the Hub-returned node_id",
+        ],
+        files=["node/identity.py"],
+        severity="critical",
+    ),
+    FAQItem(
+        id="ws_connection_closed",
+        symptom="WebSocket connection closed unexpectedly / ConnectionClosed / ping timeout",
+        cause="Hub restarted, network instability, or Hub kicked the node due to missed heartbeats.",
+        fix_steps=[
+            "1. Implement automatic reconnection with exponential backoff in your WebSocket loop",
+            "2. Send HTTP heartbeat to /registry/heartbeat every 30s as backup",
+            "3. Example reconnection: except ConnectionClosed: await asyncio.sleep(2**attempt); attempt += 1",
+            "4. Check Hub health: curl https://mep-hub.silentcopilot.ai/health",
+        ],
+        files=["node/listen_ws.py"],
+        severity="info",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_welcome(node_id: str, alias: str, balance: float = 0.0) -> dict:
+    """Get the full welcome package for a newly registered node."""
+    return {
+        "text": WELCOME_TEMPLATE.format(
+            alias=alias or "Node Operator",
+            node_id=node_id,
+            balance=balance,
+        ),
+        "markdown": WELCOME_MARKDOWN.format(
+            alias=alias or "Node Operator",
+            node_id=node_id,
+            balance=balance,
+        ),
+        "node_id": node_id,
+        "alias": alias,
+        "balance": balance,
+    }
+
+
+def get_faq() -> List[dict]:
+    """Get all troubleshooting FAQ items as dicts."""
+    return [asdict(item) for item in FAQ]
+
+
+def format_faq_for_display(style: str = "markdown") -> str:
+    """Format FAQ for terminal/markdown display."""
+    if style == "text":
+        lines = ["\n" + "=" * 60 + "\nMEP Node Troubleshooting FAQ\n" + "=" * 60 + "\n"]
+        for item in FAQ:
+            lines.append(f"\n[{item.severity.upper()}] Q: {item.symptom}")
+            lines.append(f"    Cause: {item.cause}")
+            for step in item.fix_steps:
+                lines.append(f"    {step}")
+            if item.files:
+                lines.append(f"    Files: {', '.join(item.files)}")
+        return "\n".join(lines)
+    else:
+        lines = ["# MEP Node Troubleshooting FAQ\n"]
+        for item in FAQ:
+            sev_emoji = {"critical": "🔴", "warning": "🟡", "info": "🟢"}.get(item.severity, "•")
+            lines.append(f"\n## {sev_emoji} {item.symptom}")
+            lines.append(f"\n**Cause:** {item.cause}\n")
+            lines.append("**Fix:**")
+            for step in item.fix_steps:
+                lines.append(f"- {step}")
+            if item.files:
+                lines.append(f"\n**Files:** `{'`, `'.join(item.files)}`")
+        return "\n".join(lines)
+
+
+OLLAMA_SYSTEM_PROMPT = """You are MEP Node Assistant — a friendly, expert guide for Miao Exchange Protocol node operators.
+
+RULES:
+- Always be helpful, patient, and concise
+- Speak plainly — no jargon without explanation
+- Prioritize critical issues (401/403, key loss) before minor ones
+- Give exact commands to copy-paste
+- When unsure, ask for the diagnostic output
+
+TROUBLESHOOTING METHOD:
+1. Identify the symptom (what does the user see?)
+2. Find the root cause (why did it happen?)
+3. Provide exact fix commands (what to run?)
+4. Confirm with verification step (how to know it worked?)
+
+You have access to the node's diagnostic output. Ask for it if not provided."""
+
+
+def format_for_ollama(node_id: str, alias: str, balance: float = 0.0) -> str:
+    """Format welcome + FAQ as a conversation for local Ollama."""
+    faq_md = format_faq_for_display("markdown")
+    return f"""你是 MEP 节点助手。请用欢迎信息和故障排除指南帮助新注册节点。
+
+欢迎信息:
+{WELCOME_TEMPLATE.format(alias=alias or "Node Operator", node_id=node_id, balance=balance)}
+
+故障排除FAQ:
+{faq_md}
+
+如果节点遇到问题，先问他们运行了什么命令、看到了什么错误信息。
+"""
+
+
+def get_all_as_json() -> str:
+    """Dump all welcome/FAQ data as JSON for programmatic use."""
+    return json.dumps({
+        "welcome_template": WELCOME_TEMPLATE,
+        "welcome_markdown": WELCOME_MARKDOWN,
+        "ollama_system_prompt": OLLAMA_SYSTEM_PROMPT,
+        "faq": get_faq(),
+    }, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser(description="MEP Welcome & FAQ Generator")
+    p.add_argument("--node-id", default="node_example123")
+    p.add_argument("--alias", default="My Node")
+    p.add_argument("--balance", type=float, default=0.0)
+    p.add_argument("--format", default="text", choices=["text", "markdown", "json", "ollama"])
+    p.add_argument("--faq-only", action="store_true")
+
+    args = p.parse_args()
+
+    if args.faq_only:
+        print(format_faq_for_display(args.format))
+    elif args.format == "json":
+        print(get_all_as_json())
+    elif args.format == "markdown":
+        print(WELCOME_MARKDOWN.format(alias=args.alias, node_id=args.node_id, balance=args.balance))
+        print("\n---\n")
+        print(format_faq_for_display("markdown"))
+    elif args.format == "ollama":
+        print(format_for_ollama(args.node_id, args.alias, args.balance))
+    else:
+        print(WELCOME_TEMPLATE.format(alias=args.alias, node_id=args.node_id, balance=args.balance))


### PR DESCRIPTION
## Summary

Adds a **local Ollama-powered welcome and troubleshooting system** for new MEP node operators.

### New files

**`node/welcome.py`** — Structured welcome + FAQ for node operators:
- `get_welcome(node_id, alias, balance)` — formatted text + markdown welcome
- `get_faq()` — 6-item troubleshooting FAQ with severity levels
- `format_for_ollama()` — Chinese prompt for local LLM
- `format_faq_for_display()` — terminal/markdown output
- `OLLAMA_SYSTEM_PROMPT` — system prompt for local LLM assistant

**`node/mep_diagnostic.py`** — Self-contained offline diagnostic tool:
- Works **fully offline** — no API calls needed for core checks
- Detects: node_id mismatch, key in /tmp, missing deps, WS connection issues
- Auto-loads FAQ from `welcome.py` when available
- Standalone flags: `--welcome`, `--faq`, `--faq-json`
- Ollama flags: `--ollama`, `--model` for local LLM guidance

### Hub changes

- **`/register`** now returns: `welcome` (text), `welcome_markdown`, `faq` (array)
- **NEW `/faq`** endpoint — GET, no auth, returns full FAQ + Ollama system prompt
- Gracefully degrades if `welcome.py` not available (no hard dependency)

### FAQ Coverage

| ID | Symptom | Severity |
|----|---------|----------|
| `node_id_mismatch` | 401/403 auth failures | 🔴 Critical |
| `key_in_tmp` | Key lost on reboot | 🔴 Critical |
| `not_bidding` | RFC events but no bids | 🟡 Warning |
| `missing_deps` | ModuleNotFoundError | 🟢 Info |
| `hub_unreachable` | WS connection refused | 🟡 Warning |
| `registration_404` | Node not found | 🔴 Critical |

### Motivation

New MEP node operators have **no way to verify if their node is online** or debug common provider bugs — all without external API dependency. This PR solves:

1. Nodes can now self-diagnose using `python3 node/mep_diagnostic.py --ollama http://localhost:11435`
2. Registration response now tells new operators what to do next
3. Fully offline after initial Ollama setup — no API key needed
4. Hub serves as FAQ source of truth via `/faq` endpoint

### Testing

```bash
# Welcome message
python3 node/mep_diagnostic.py --welcome

# Full FAQ
python3 node/mep_diagnostic.py --faq

# Full diagnostic with local LLM
github_code python3 node/mep_diagnostic.py --ollama http://localhost:11435 --model llama3.2:1b

# Hub /faq endpoint
curl https://mep-hub.silentcopilot.ai/faq
```

Closes #36
