### PR TITLE
feat: passive node activity tracking with degraded state

### DIFF
--- a/hub/main.py
+++ b/hub/main.py
@@ -100,7 +100,7 @@ COMPLETED_TASK_CACHE_TTL_SECONDS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_TTL_S
 COMPLETED_TASK_CACHE_MAX_ITEMS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_MAX_ITEMS", "1000"))
 IDEMPOTENCY_TTL_SECONDS = int(os.getenv("MEP_IDEMPOTENCY_TTL_SECONDS", "86400"))
 TIMEOUT_POLICY = os.getenv("MEP_TIMEOUT_POLICY", "refund").lower()
-VALID_AVAILABILITY = {"online", "idle", "busy", "offline", "unknown"}
+VALID_AVAILABILITY = {"online", "idle", "busy", "offline", "degraded", "unknown"}
 DEFAULT_REGISTRY_MAX_AGE_MINUTES = float(os.getenv("MEP_REGISTRY_MAX_AGE_MINUTES", "0") or "0")
 ASSIGNMENT_REPUTATION_WEIGHT = float(os.getenv("MEP_ASSIGNMENT_REPUTATION_WEIGHT", "0.55"))
 ASSIGNMENT_AVAILABILITY_WEIGHT = float(os.getenv("MEP_ASSIGNMENT_AVAILABILITY_WEIGHT", "0.25"))
@@ -676,6 +676,7 @@ async def _maintenance_worker():
         try:
             await _evict_completed_tasks_cache()
             _sweep_idempotency_records()
+            await _sweep_node_activity()
         except Exception as exc:
             log_event("maintenance_sweep_failed", f"Maintenance sweep failed: {exc}")
         await asyncio.sleep(max(1, MAINTENANCE_SWEEP_INTERVAL_SECONDS))
@@ -802,6 +803,7 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
         existing = db.get_registry(authenticated_node)
         availability = existing.get("availability") if existing else "unknown"
     db.update_registry_availability(authenticated_node, availability, time.time())
+    await _track_node_activity(authenticated_node)
     hub_url, ws_url = get_hub_urls(request)
     return {"status": "success", "node_id": authenticated_node, "availability": availability, "hub_url": hub_url, "ws_url": ws_url}
 
@@ -1559,8 +1561,50 @@ async def websocket_endpoint(
     try:
         while True:
             await websocket.receive_text()
+            await _track_node_activity(node_id)
     except WebSocketDisconnect:
         async with node_lock:
             if connected_nodes.get(node_id) is websocket:
                 del connected_nodes[node_id]
         db.update_registry_availability(node_id, "offline", time.time())
+
+# ---------------------------------------------------------------------------
+# Node Activity Tracking (for passive degraded detection)
+# ---------------------------------------------------------------------------
+node_activity_lock = asyncio.Lock()
+node_last_activity: Dict[str, float] = {}
+
+DEGRADED_THRESHOLD_SECONDS = float(os.getenv("MEP_DEGRADED_THRESHOLD_SECONDS", "600"))
+
+
+async def _track_node_activity(node_id: str):
+    """Update last activity timestamp for a node. Called on heartbeat and WS activity."""
+    async with node_activity_lock:
+        node_last_activity[node_id] = time.time()
+
+
+def _get_node_degraded_nodes() -> list[str]:
+    """Return list of node_ids that are registered but haven't shown activity recently."""
+    now = time.time()
+    degraded = []
+    for node_id in node_last_activity:
+        # If node has no active WS and no recent activity
+        if node_id not in connected_nodes:
+            last = node_last_activity.get(node_id, 0)
+            if last > 0 and (now - last) > DEGRADED_THRESHOLD_SECONDS:
+                degraded.append(node_id)
+    return degraded
+
+
+async def _sweep_node_activity():
+    """Mark stale-but-registered nodes as degraded. Run in maintenance worker."""
+    now = time.time()
+    async with node_activity_lock:
+        for node_id, last_seen in list(node_last_activity.items()):
+            if node_id in connected_nodes:
+                continue  # actively connected, skip
+            if (now - last_seen) > DEGRADED_THRESHOLD_SECONDS:
+                existing = db.get_registry(node_id)
+                if existing and existing.get("availability") not in ("offline", "degraded"):
+                    db.update_registry_availability(node_id, "degraded", now)
+                    log_event("node_degraded", f"Node {node_id} marked degraded due to inactivity", node_id=node_id)


### PR DESCRIPTION
## Summary

Replaces the removed WS stale timeout enforcement (from PR #65) with passive health monitoring.

### Changes
- **`hub/main.py`** — +45 lines
  - `node_last_activity` dict tracks per-node activity timestamps
  - `_track_node_activity()` — called on every WS `receive_text` and `registry_heartbeat`
  - `_sweep_node_activity()` — runs in maintenance worker every 60s; marks registered-but-silent nodes as `degraded`
  - `VALID_AVAILABILITY` expanded to include `degraded`
  - Configurable via `MEP_DEGRADED_THRESHOLD_SECONDS` (default: 600s / 10 minutes)

### Why
After PR #65 removed the aggressive stale timeout, nodes that go silent (laptop sleep, network drop, crash) remain in registry with no health flag. The Hub has no visibility into node health between heartbeats.

`degraded` gives a passive health flag:
- **Connected WS** -> `online`
- **Registered but silent > 10 min** -> `degraded`
- **WS disconnected** -> `offline`

DMs route only to `online` nodes. `degraded` nodes won't receive task routing until they reconnect.

### Tests
54 passed - all existing tests pass.

### Note
Follow-up to PR #65. Threshold configurable via `MEP_DEGRADED_THRESHOLD_SECONDS` env var.