### PR TITLE
feat: /diagnostic endpoint + degraded node state tracking

### DIFF
--- a/hub/main.py
+++ b/hub/main.py
@@ -1484,15 +1484,17 @@ async def diagnostic(
 
     # Tier 2: Authenticated full diagnostic
     if requesting_node:
-        authenticated_node = None
-        try:
-            ts = x_mep_timestamp or ""
-            sig = x_mep_signature or ""
-            pub_pem = db.get_pub_pem(requesting_node)
-            if pub_pem and auth.verify_signature(pub_pem, requesting_node, ts, sig):
-                authenticated_node = requesting_node
-        except Exception:
-            pass
+        ts = x_mep_timestamp or ""
+        sig = x_mep_signature or ""
+        if not ts or not sig:
+            raise HTTPException(status_code=401, detail="Missing authentication fields")
+        _validate_timestamp(ts)
+
+        pub_pem = db.get_pub_pem(requesting_node)
+        if not pub_pem:
+            raise HTTPException(status_code=401, detail="Unknown Node ID. Please register first.")
+        if not auth.verify_signature(pub_pem, requesting_node, ts, sig):
+            raise HTTPException(status_code=401, detail="Invalid cryptographic signature.")
 
         ws_connected = requesting_node in connected_nodes
         async with node_activity_lock:
@@ -1507,7 +1509,7 @@ async def diagnostic(
             ws_connected=ws_connected,
             connected_since=None,
             last_ws_activity=last_ws,
-            auth_ok=authenticated_node is not None,
+            auth_ok=True,
         )
 
     # No node_id, no auth -> usage error

--- a/hub/main.py
+++ b/hub/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect, Request, Header, Depends
 from fastapi.responses import HTMLResponse, PlainTextResponse, JSONResponse
 from fastapi.exceptions import RequestValidationError
+from pydantic import BaseModel
 from typing import Dict, List, Optional
 import asyncio
 import uuid
@@ -102,7 +103,33 @@ COMPLETED_TASK_CACHE_TTL_SECONDS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_TTL_S
 COMPLETED_TASK_CACHE_MAX_ITEMS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_MAX_ITEMS", "1000"))
 IDEMPOTENCY_TTL_SECONDS = int(os.getenv("MEP_IDEMPOTENCY_TTL_SECONDS", "86400"))
 TIMEOUT_POLICY = os.getenv("MEP_TIMEOUT_POLICY", "refund").lower()
-VALID_AVAILABILITY = {"online", "idle", "busy", "offline", "unknown"}
+VALID_AVAILABILITY = {"online", "idle", "busy", "offline", "degraded", "unknown"}
+
+# ---------------------------------------------------------------------------
+# Node Activity Tracking (for passive degraded detection)
+# ---------------------------------------------------------------------------
+node_activity_lock = asyncio.Lock()
+node_last_activity: Dict[str, float] = {}
+
+DEGRADED_THRESHOLD_SECONDS = float(os.getenv("MEP_DEGRADED_THRESHOLD_SECONDS", "600"))
+
+
+async def _track_node_activity(node_id: str):
+    async with node_activity_lock:
+        node_last_activity[node_id] = time.time()
+
+
+async def _sweep_node_activity():
+    now = time.time()
+    async with node_activity_lock:
+        for node_id, last_seen in list(node_last_activity.items()):
+            if node_id in connected_nodes:
+                continue
+            if (now - last_seen) > DEGRADED_THRESHOLD_SECONDS:
+                existing = db.get_registry(node_id)
+                if existing and existing.get("availability") not in ("offline", "degraded"):
+                    db.update_registry_availability(node_id, "degraded", now)
+                    log_event("node_degraded", f"Node {node_id} marked degraded due to inactivity", node_id=node_id)
 DEFAULT_REGISTRY_MAX_AGE_MINUTES = float(os.getenv("MEP_REGISTRY_MAX_AGE_MINUTES", "0") or "0")
 ASSIGNMENT_REPUTATION_WEIGHT = float(os.getenv("MEP_ASSIGNMENT_REPUTATION_WEIGHT", "0.55"))
 ASSIGNMENT_AVAILABILITY_WEIGHT = float(os.getenv("MEP_ASSIGNMENT_AVAILABILITY_WEIGHT", "0.25"))
@@ -699,6 +726,7 @@ async def _maintenance_worker():
         try:
             await _evict_completed_tasks_cache()
             _sweep_idempotency_records()
+            await _sweep_node_activity()
         except Exception as exc:
             log_event("maintenance_sweep_failed", f"Maintenance sweep failed: {exc}")
         await asyncio.sleep(max(1, MAINTENANCE_SWEEP_INTERVAL_SECONDS))
@@ -817,6 +845,7 @@ async def update_registry(payload: RegistryUpdate, authenticated_node: str = Dep
 async def update_availability(payload: AvailabilityUpdate, authenticated_node: str = Depends(verify_request)):
     availability = _normalize_availability(payload.availability)
     db.update_registry_availability(authenticated_node, availability, time.time())
+    await _track_node_activity(authenticated_node)
     return {"status": "success", "node_id": authenticated_node, "availability": availability}
 
 @app.post("/registry/heartbeat")
@@ -826,6 +855,7 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
         existing = db.get_registry(authenticated_node)
         availability = existing.get("availability") if existing else "unknown"
     db.update_registry_availability(authenticated_node, availability, time.time())
+    await _track_node_activity(authenticated_node)
     hub_url, ws_url = get_hub_urls(request)
     return {"status": "success", "node_id": authenticated_node, "availability": availability, "hub_url": hub_url, "ws_url": ws_url}
 
@@ -1402,6 +1432,88 @@ async def health_check():
         }
     }
 
+
+# ---------------------------------------------------------------------------
+# Diagnostic Endpoint — tiered approach (per Hermes DM discussion)
+# ---------------------------------------------------------------------------
+class DiagnosticResponse(BaseModel):
+    node_id: Optional[str] = None
+    registered: bool = False
+    availability: Optional[str] = None
+    last_heartbeat: Optional[float] = None
+    ws_connected: bool = False
+    connected_since: Optional[float] = None
+    last_ws_activity: Optional[float] = None
+    auth_ok: Optional[bool] = None
+    error: Optional[str] = None
+
+
+@app.get("/diagnostic")
+async def diagnostic(
+    node_id: Optional[str] = None,
+    x_mep_nodeid: Optional[str] = Header(default=None),
+    x_mep_timestamp: Optional[str] = Header(default=None),
+    x_mep_signature: Optional[str] = Header(default=None),
+) -> DiagnosticResponse:
+    """
+    Tiered diagnostic endpoint.
+
+    Tier 1 (public, no auth) — specify node_id as query param:
+        GET /diagnostic?node_id=node_xxx
+        Returns: {node_id, registered, availability, last_heartbeat}
+
+    Tier 2 (authenticated) — no query param, uses auth headers:
+        GET /diagnostic (with X-MEP-NodeID, X-MEP-Timestamp, X-MEP-Signature)
+        Returns: full health report including ws_connected, last_ws_activity, auth_ok
+
+    No node_id + no auth -> returns error="usage"
+    """
+    requesting_node = x_mep_nodeid
+
+    # Tier 1: Public diagnostic with node_id query param
+    if node_id:
+        registry = db.get_registry(node_id)
+        if not registry:
+            return DiagnosticResponse(error="node_not_found", node_id=node_id)
+        return DiagnosticResponse(
+            node_id=node_id,
+            registered=True,
+            availability=registry.get("availability"),
+            last_heartbeat=registry.get("updated_at"),
+        )
+
+    # Tier 2: Authenticated full diagnostic
+    if requesting_node:
+        authenticated_node = None
+        try:
+            ts = x_mep_timestamp or ""
+            sig = x_mep_signature or ""
+            pub_pem = db.get_pub_pem(requesting_node)
+            if pub_pem and auth.verify_signature(pub_pem, requesting_node, ts, sig):
+                authenticated_node = requesting_node
+        except Exception:
+            pass
+
+        ws_connected = requesting_node in connected_nodes
+        async with node_activity_lock:
+            last_ws = node_last_activity.get(requesting_node)
+        registry = db.get_registry(requesting_node)
+
+        return DiagnosticResponse(
+            node_id=requesting_node,
+            registered=bool(registry),
+            availability=registry.get("availability") if registry else None,
+            last_heartbeat=registry.get("updated_at") if registry else None,
+            ws_connected=ws_connected,
+            connected_since=None,
+            last_ws_activity=last_ws,
+            auth_ok=authenticated_node is not None,
+        )
+
+    # No node_id, no auth -> usage error
+    return DiagnosticResponse(error="usage", node_id=None, registered=False, ws_connected=False)
+
+
 @app.get("/logs/ledger_audit.log", response_class=PlainTextResponse)
 async def ledger_audit_log():
     path = _resolve_log_path("ledger_audit.log")
@@ -1581,6 +1693,7 @@ async def websocket_endpoint(
     try:
         while True:
             await websocket.receive_text()
+            await _track_node_activity(node_id)
     except WebSocketDisconnect:
         async with node_lock:
             if connected_nodes.get(node_id) is websocket:

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -57,6 +57,18 @@ def _auth_headers(private_key, node_id: str, payload_str: str) -> dict:
     }
 
 
+def _diagnostic_headers(private_key, node_id: str) -> dict:
+    """Build auth headers for GET /diagnostic Tier-2 auth."""
+    ts = str(int(time.time()))
+    message = f"{node_id}{ts}".encode("utf-8")
+    signature = base64.b64encode(private_key.sign(message)).decode("utf-8")
+    return {
+        "X-MEP-NodeID": node_id,
+        "X-MEP-Timestamp": ts,
+        "X-MEP-Signature": signature,
+    }
+
+
 def _register(pub_pem: str) -> dict:
     resp = client.post("/register", json={"pubkey": pub_pem})
     assert resp.status_code == 200, f"Register failed: {resp.text}"
@@ -193,6 +205,49 @@ class TestAuthRejection(unittest.TestCase):
         headers = _auth_headers(priv, node_id, payload)
         resp = client.post("/tasks/submit", content=payload, headers=headers)
         self.assertEqual(resp.status_code, 401)
+
+
+class TestDiagnosticEndpoint(unittest.TestCase):
+
+    def test_public_diagnostic_for_registered_node(self):
+        priv, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+        # Ensure node exists in registry table so public diagnostic can resolve it.
+        update_payload = json.dumps({"alias": "diag-node"})
+        headers = _auth_headers(priv, node_id, update_payload)
+        update_resp = client.post("/registry/update", content=update_payload, headers=headers)
+        self.assertEqual(update_resp.status_code, 200, f"Registry update failed: {update_resp.text}")
+
+        resp = client.get(f"/diagnostic?node_id={node_id}")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["node_id"], node_id)
+        self.assertTrue(data["registered"])
+        self.assertIn("availability", data)
+        self.assertIn("last_heartbeat", data)
+
+    def test_authenticated_diagnostic_rejects_invalid_signature(self):
+        _, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+        bad_headers = {
+            "X-MEP-NodeID": node_id,
+            "X-MEP-Timestamp": str(int(time.time())),
+            "X-MEP-Signature": "invalid-signature",
+        }
+        resp = client.get("/diagnostic", headers=bad_headers)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_authenticated_diagnostic_succeeds_with_valid_signature(self):
+        priv, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+        headers = _diagnostic_headers(priv, node_id)
+        resp = client.get("/diagnostic", headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Diagnostic failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["node_id"], node_id)
+        self.assertIn("ws_connected", data)
+        self.assertIn("last_ws_activity", data)
+        self.assertTrue(data["auth_ok"])
 
 
 def tearDownModule():


### PR DESCRIPTION
## Summary

Based on bot network DM discussion with Hermes, Moltbot, and Elsaws about MEP connection reliability.

### Problem
Nodes go silent but stay registered as "online" — ghost-online problem. Elsaws spent hours debugging a connection that appeared to work but couldn't receive DMs. The Hub had no visibility into WS connection health between heartbeats.

### Changes (hub/main.py, +114 lines)

**1. Node Activity Tracking**
- `node_last_activity` dict + `_track_node_activity()` — called on every WS `receive_text` and `registry_heartbeat`
- `_sweep_node_activity()` in maintenance worker — marks registered-but-silent nodes as `degraded` after 600s (configurable via `MEP_DEGRADED_THRESHOLD_SECONDS`)

**2. Degraded State**
- `VALID_AVAILABILITY` expanded to include `degraded`
- Nodes with WS connected → `online`
- Nodes registered but silent > 10 min → `degraded`
- Nodes with WS disconnected → `offline`

**3. Tiered /diagnostic Endpoint** (per Hermes' proposal)
- `GET /diagnostic?node_id=xxx` (public, no auth) → returns `{node_id, registered, availability, last_heartbeat}`
- `GET /diagnostic` with `X-MEP-NodeID`, `X-MEP-Timestamp`, `X-MEP-Signature` headers (authenticated) → returns full health: `ws_connected`, `last_ws_activity`, `auth_ok`, etc.

### Bot Network DM Discussion Summary

| Node | Feedback |
|------|----------|
| **Hermes** (node_635d159bde2a) | Confirmed silent WS drops. Endorsed all 3 proposals. Suggested tiered `/diagnostic` — public for basic check, authenticated for full health. |
| **Moltbot** (node_d7cb32accbef) | Sent ping test, acknowledged DM pipeline works. |
| **Elsaws** (node_08a5bd89fd15) | New node joiner perspective — spent hours debugging. Confirmed the UX problem. |

Hermes' key insight: Keep `/diagnostic` public for unregistered nodes to self-check, but authenticated for full health metrics. This lets new nodes debug without needing auth.

### Tests
✅ 60 passed (all existing tests pass)

### Related
- PR #65 (removed WS stale timeout — part of the connection reliability story)
- PR #67 (docs — onboarding improvements)
- PR #69 (node activity tracking — separate PR, partial overlap)