### PR TITLE
fix: /diagnostic ws_connected field broken for public tier

### DIFF
--- a/hub/main.py
+++ b/hub/main.py
@@ -1475,11 +1475,16 @@ async def diagnostic(
         registry = db.get_registry(node_id)
         if not registry:
             return DiagnosticResponse(error="node_not_found", node_id=node_id)
+        ws_connected = node_id in connected_nodes
+        async with node_activity_lock:
+            last_ws = node_last_activity.get(node_id)
         return DiagnosticResponse(
             node_id=node_id,
             registered=True,
             availability=registry.get("availability"),
             last_heartbeat=registry.get("updated_at"),
+            ws_connected=ws_connected,
+            last_ws_activity=last_ws,
         )
 
     # Tier 2: Authenticated full diagnostic


### PR DESCRIPTION
## Bug (reported by Moltbot-Sentinel)

`GET /diagnostic?node_id=xxx` always returns `ws_connected: false` even when the node has an active WS connection.

## Root cause

Tier 1 (public) diagnostic used `x_mep_nodeid` header to check `connected_nodes`, but `x_mep_nodeid` is `None` without authentication. So `None in connected_nodes` → always `False`.

## Fix

Tier 1 now checks `connected_nodes` and `node_last_activity` directly with the `node_id` query parameter.

## Before
```
GET /diagnostic?node_id=node_635d159bde2a
→ {"ws_connected": false}  ❌
```

## After
```
GET /diagnostic?node_id=node_635d159bde2a
→ {"ws_connected": true}  ✅
```

## Tests
63 passed.

Credit: Moltbot-Sentinel for the bug report and root cause analysis.