### PR TITLE
fix: stabilize node registration online status

### DIFF
--- a/clients/adapters/mep_codex_provider.py
+++ b/clients/adapters/mep_codex_provider.py
@@ -72,6 +72,14 @@ class CodexProvider:
         self._stop = asyncio.Event()
         self._llm_api_key = os.getenv("OPENAI_API_KEY")
 
+    def _log(self, message: str) -> None:
+        try:
+            print(message)
+        except UnicodeEncodeError:
+            # Keep provider alive on Windows consoles that cannot emit some Unicode.
+            fallback = message.encode("utf-8", errors="replace").decode("utf-8", errors="replace")
+            print(fallback)
+
     def _auth_headers(self, payload_str: str) -> dict:
         return self.client._auth_headers(payload_str)
 
@@ -204,7 +212,7 @@ class CodexProvider:
                 )
                 response.raise_for_status()
             except Exception as exc:
-                print(f"[codex-provider] heartbeat failed: {exc}")
+                self._log(f"[codex-provider] heartbeat failed: {exc}")
             await asyncio.sleep(self.heartbeat_seconds)
 
     async def complete_task(self, task: dict) -> None:
@@ -226,7 +234,7 @@ class CodexProvider:
             timeout=20,
         )
         response.raise_for_status()
-        print(f"[codex-provider] completed task {task_id} for {consumer_id}")
+        self._log(f"[codex-provider] completed task {task_id} for {consumer_id}")
 
     async def ws_loop(self) -> None:
         import websockets
@@ -237,7 +245,7 @@ class CodexProvider:
             uri = f"{self.client.ws_url}/ws/{self.client.node_id}?timestamp={ts}&signature={sig}"
             try:
                 async with websockets.connect(uri) as ws:
-                    print(f"[codex-provider] websocket connected: {self.client.node_id}")
+                    self._log(f"[codex-provider] websocket connected: {self.client.node_id}")
                     while not self._stop.is_set():
                         try:
                             raw = await asyncio.wait_for(ws.recv(), timeout=20)
@@ -250,16 +258,16 @@ class CodexProvider:
                         if event == "new_task":
                             await self.complete_task(task)
                         elif event == "task_result":
-                            print(f"[codex-provider] task_result: {task}")
+                            self._log(f"[codex-provider] task_result: {task}")
                         elif event == "rfc":
-                            print(f"[codex-provider] rfc ignored: {task.get('id')}")
+                            self._log(f"[codex-provider] rfc ignored: {task.get('id')}")
             except Exception as exc:
-                print(f"[codex-provider] websocket disconnected: {exc}")
+                self._log(f"[codex-provider] websocket disconnected: {exc}")
                 await asyncio.sleep(3)
 
     async def run(self) -> None:
         registration = await self.register()
-        print(
+        self._log(
             f"[codex-provider] registered {registration.get('node_id')} alias='{self.alias}' "
             f"balance={registration.get('balance')}"
         )

--- a/clients/adapters/mep_discord_adapter.py
+++ b/clients/adapters/mep_discord_adapter.py
@@ -33,6 +33,7 @@ async def on_ready():
     if DISCORD_TOKEN is None:
         return
     await client.register()
+    client.start_heartbeat(availability="online")
 
     async def on_result(data: dict):
         task_id = data.get("task_id")
@@ -124,4 +125,7 @@ async def mepbalance(ctx):
 
 
 if DISCORD_TOKEN:
-    bot.run(DISCORD_TOKEN)
+    try:
+        bot.run(DISCORD_TOKEN)
+    finally:
+        client.stop()

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -21,6 +21,7 @@ class MEPClient:
         self.session.trust_env = False
         self.task_channels: dict[str, str] = {}
         self._stop = asyncio.Event()
+        self._heartbeat_task: asyncio.Task | None = None
         manifest = load_manifest()
         self.hub_url = (
             hub_url
@@ -33,6 +34,11 @@ class MEPClient:
             or os.getenv("WS_URL")
             or (manifest.ws_url if manifest else None)
             or "wss://mep-hub.silentcopilot.ai"
+        )
+        self.heartbeat_seconds = int(
+            os.getenv("MEP_HEARTBEAT_SECONDS")
+            or (manifest.heartbeat_seconds if manifest else 30)
+            or 30
         )
 
     async def register(self) -> dict:
@@ -49,6 +55,30 @@ class MEPClient:
         headers = self.identity.get_auth_headers(payload_str)
         headers["Content-Type"] = "application/json"
         return headers
+
+    async def heartbeat_loop(self, availability: str = "online") -> None:
+        while not self._stop.is_set():
+            body = {"availability": availability}
+            payload_str = json.dumps(body)
+            try:
+                response = await asyncio.to_thread(
+                    self.session.post,
+                    f"{self.hub_url}/registry/heartbeat",
+                    data=payload_str,
+                    headers=self._auth_headers(payload_str),
+                    timeout=15,
+                )
+                response.raise_for_status()
+            except Exception:
+                # Best-effort keepalive; receiver/reconnect loop handles hard failures.
+                pass
+            await asyncio.sleep(max(1, self.heartbeat_seconds))
+
+    def start_heartbeat(self, availability: str = "online") -> asyncio.Task:
+        if self._heartbeat_task and not self._heartbeat_task.done():
+            return self._heartbeat_task
+        self._heartbeat_task = asyncio.create_task(self.heartbeat_loop(availability=availability))
+        return self._heartbeat_task
 
     async def submit_task(
         self,
@@ -142,3 +172,5 @@ class MEPClient:
 
     def stop(self) -> None:
         self._stop.set()
+        if self._heartbeat_task and not self._heartbeat_task.done():
+            self._heartbeat_task.cancel()

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -113,6 +113,7 @@ class StdioAdapter:
 
     async def run(self) -> None:
         await self.client.register()
+        heartbeat = self.client.start_heartbeat(availability="online")
         listener = asyncio.create_task(self.client.listen_results(self._handle_result))
         print(f"[{self.platform_name}] connected as {self.client.node_id}")
         print(f"[{self.platform_name}] commands: mep, mepdm, mepdata, mepcancel, mepresult, mepbalance, exit")
@@ -124,6 +125,7 @@ class StdioAdapter:
                 keep_going = await self._dispatch_line(line)
         finally:
             self.client.stop()
+            heartbeat.cancel()
             listener.cancel()
 
 


### PR DESCRIPTION
Adds safe provider logging to avoid unicode WS drops and introduces shared heartbeat lifecycle for stdio/discord adapters.