### PR TITLE
fix: bidding task timeout sweep with refund - PR #83 v3

### DIFF
--- a/docs/PR_83_BiddingTimeoutFix.md
+++ b/docs/PR_83_BiddingTimeoutFix.md
@@ -1,0 +1,39 @@
+# PR #83: Bidding Task Timeout Fix
+
+## Problem
+- 1,400+ tasks stuck in "bidding" status forever
+- Only "assigned" tasks timeout - "bidding" never expires
+- Bounty stays locked in escrow
+
+## Solution
+Add bidding task sweep with automatic escrow refund.
+
+## Changes
+
+### hub/db.py
+- `get_bidding_tasks_before(cutoff_ts)` - query all bidding tasks older than cutoff
+- `expire_task_if_bidding(task_id)` - mark bidding task as expired
+
+### hub/main.py  
+- `_sweep_bidding_timeouts()` - sweep and refund stuck bidding tasks
+- Runs in `_assignment_timeout_worker()` every 60s
+- Uses same 1-hour timeout as assigned tasks
+
+## Refund Logic
+```
+1. Find bidding tasks older than 1 hour
+2. Mark each as "expired" in DB
+3. Call refund_escrow(task_id) - returns bounty to consumer
+4. If no escrow found, add balance directly
+5. Remove from in-memory active_tasks
+6. Log audit trail: BIDDING_TIMEOUT_REFUND
+```
+
+## Testing (before restart)
+- `SELECT COUNT(*) FROM tasks WHERE status='bidding'` → 1,486
+
+## Testing (after restart + 1 hour)
+- Check bidding count decreases
+- Check balances return to consumers
+
+## NOTE: Uses same sweeping as assigned tasks. After hub restart, tasks will start expiring after 1 hour.

--- a/hub/db.py
+++ b/hub/db.py
@@ -44,7 +44,20 @@ def _row_to_dict(cursor, row):
     columns = [desc[0] for desc in cursor.description]
     return dict(zip(columns, row))
 
+def _ensure_registry_bio_column(cursor):
+    """Add bio column to agent_registry if it doesn't exist (migration)."""
+    if _is_postgres():
+        cursor.execute("SELECT column_name FROM information_schema.columns WHERE table_name = 'agent_registry' AND column_name = 'bio'")
+        if not cursor.fetchone():
+            cursor.execute("ALTER TABLE agent_registry ADD COLUMN bio TEXT")
+    else:
+        cursor.execute("PRAGMA table_info(agent_registry)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if "bio" not in columns:
+            cursor.execute("ALTER TABLE agent_registry ADD COLUMN bio TEXT")
+
 def _ensure_registry_availability_column(cursor):
+    _ensure_registry_bio_column(cursor)
     if _is_postgres():
         cursor.execute("SELECT column_name FROM information_schema.columns WHERE table_name = 'agent_registry' AND column_name = 'x25519_public_key'")
         if not cursor.fetchone():
@@ -440,6 +453,25 @@ def get_assigned_tasks_before(cutoff_ts: float) -> list:
     _release_conn(conn)
     return result
 
+def expire_task_if_bidding(task_id: str, updated_at: float) -> bool:
+    """Expire a bidding task (no provider accepted)"""
+    conn = _get_conn()
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute(
+            "UPDATE tasks SET status = 'expired', provider_id = NULL, updated_at = %s WHERE task_id = %s AND status = 'bidding'",
+            (updated_at, task_id)
+        )
+    else:
+        cursor.execute(
+            "UPDATE tasks SET status = 'expired', provider_id = NULL, updated_at = ? WHERE task_id = ? AND status = 'bidding'",
+            (updated_at, task_id)
+        )
+    updated = cursor.rowcount
+    conn.commit()
+    _release_conn(conn)
+    return updated > 0
+
 def expire_task_if_assigned(task_id: str, updated_at: float) -> bool:
     conn = _get_conn()
     cursor = conn.cursor()
@@ -556,7 +588,7 @@ def delete_idempotency_before(cutoff_ts: float) -> int:
     _release_conn(conn)
     return int(deleted or 0)
 
-def upsert_registry(node_id: str, alias: Optional[str], skills: list[str], models: list[str], metadata: dict, availability: str, updated_at: float, x25519_public_key: Optional[str] = None):
+def upsert_registry(node_id: str, alias: Optional[str], skills: list[str], models: list[str], metadata: dict, availability: str, updated_at: float, x25519_public_key: Optional[str] = None, bio: Optional[str] = None):
     conn = _get_conn()
     cursor = conn.cursor()
     _ensure_registry_availability_column(cursor)
@@ -566,33 +598,35 @@ def upsert_registry(node_id: str, alias: Optional[str], skills: list[str], model
     
     if _is_postgres():
         query = """
-            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key, bio)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (node_id) DO UPDATE SET
                 alias = EXCLUDED.alias,
                 skills = EXCLUDED.skills,
                 models = EXCLUDED.models,
                 metadata = EXCLUDED.metadata,
                 availability = EXCLUDED.availability,
-                updated_at = EXCLUDED.updated_at
+                updated_at = EXCLUDED.updated_at,
+                bio = EXCLUDED.bio
         """
-        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
+        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key, bio]
         if x25519_public_key:
             query += ", x25519_public_key = EXCLUDED.x25519_public_key"
         cursor.execute(query, tuple(params))
     else:
         query = """
-            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key, bio)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(node_id) DO UPDATE SET
                 alias=excluded.alias,
                 skills=excluded.skills,
                 models=excluded.models,
                 metadata=excluded.metadata,
                 availability=excluded.availability,
-                updated_at=excluded.updated_at
+                updated_at=excluded.updated_at,
+                bio=excluded.bio
         """
-        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
+        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key, bio]
         if x25519_public_key:
             query += ", x25519_public_key=excluded.x25519_public_key"
         cursor.execute(query, tuple(params))
@@ -660,7 +694,7 @@ def get_registry(node_id: str) -> Optional[dict]:
     result["metadata"] = json.loads(result["metadata"]) if result.get("metadata") else {}
     return result
 
-def search_registry(alias: Optional[str], skill: Optional[str], model: Optional[str], availability: Optional[str], min_score: Optional[float], min_reviews: Optional[int], min_updated_at: Optional[float], limit: int) -> list[dict]:
+def search_registry(alias: Optional[str], skill: Optional[str], model: Optional[str], availability: Optional[str], min_score: Optional[float], min_reviews: Optional[float], min_updated_at: Optional[float], limit: int, bio: Optional[str] = None) -> list[dict]:
     conn = _get_conn()
     if not _is_postgres():
         conn.row_factory = sqlite3.Row
@@ -686,6 +720,13 @@ def search_registry(alias: Optional[str], skill: Optional[str], model: Optional[
         else:
             conditions.append("agent_registry.alias LIKE ?")
             params.append(f"%{alias}%")
+    if bio:
+        if _is_postgres():
+            conditions.append("agent_registry.bio ILIKE %s")
+            params.append(f"%{bio}%")
+        else:
+            conditions.append("agent_registry.bio LIKE ?")
+            params.append(f"%{bio}%")
     if skill:
         if _is_postgres():
             conditions.append("skills ILIKE %s")
@@ -1046,3 +1087,21 @@ def cleanup_expired_pending_dms() -> int:
     return removed
 
 init_db()
+
+def get_bidding_tasks_before(cutoff_ts: float) -> list:
+    """Get bidding tasks older than cutoff - for cleanup"""
+    conn = _get_conn()
+    if not _is_postgres():
+        conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute("SELECT task_id, consumer_id, payload, bounty, updated_at FROM tasks WHERE status = 'bidding' AND updated_at < %s", (cutoff_ts,))
+    else:
+        cursor.execute("SELECT task_id, consumer_id, payload, bounty, updated_at FROM tasks WHERE status = 'bidding' AND updated_at < ?", (cutoff_ts,))
+    rows = cursor.fetchall()
+    if _is_postgres():
+        result = [_row_to_dict(cursor, row) for row in rows]
+    else:
+        result = [dict(row) for row in rows]
+    _release_conn(conn)
+    return result

--- a/hub/db.py
+++ b/hub/db.py
@@ -44,20 +44,7 @@ def _row_to_dict(cursor, row):
     columns = [desc[0] for desc in cursor.description]
     return dict(zip(columns, row))
 
-def _ensure_registry_bio_column(cursor):
-    """Add bio column to agent_registry if it doesn't exist (migration)."""
-    if _is_postgres():
-        cursor.execute("SELECT column_name FROM information_schema.columns WHERE table_name = 'agent_registry' AND column_name = 'bio'")
-        if not cursor.fetchone():
-            cursor.execute("ALTER TABLE agent_registry ADD COLUMN bio TEXT")
-    else:
-        cursor.execute("PRAGMA table_info(agent_registry)")
-        columns = [row[1] for row in cursor.fetchall()]
-        if "bio" not in columns:
-            cursor.execute("ALTER TABLE agent_registry ADD COLUMN bio TEXT")
-
 def _ensure_registry_availability_column(cursor):
-    _ensure_registry_bio_column(cursor)
     if _is_postgres():
         cursor.execute("SELECT column_name FROM information_schema.columns WHERE table_name = 'agent_registry' AND column_name = 'x25519_public_key'")
         if not cursor.fetchone():
@@ -453,6 +440,24 @@ def get_assigned_tasks_before(cutoff_ts: float) -> list:
     _release_conn(conn)
     return result
 
+def expire_task_if_assigned(task_id: str, updated_at: float) -> bool:
+    conn = _get_conn()
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute(
+            "UPDATE tasks SET status = 'expired', provider_id = NULL, updated_at = %s WHERE task_id = %s AND status = 'assigned'",
+            (updated_at, task_id)
+        )
+    else:
+        cursor.execute(
+            "UPDATE tasks SET status = 'expired', provider_id = NULL, updated_at = ? WHERE task_id = ? AND status = 'assigned'",
+            (updated_at, task_id)
+        )
+    updated = cursor.rowcount
+    conn.commit()
+    _release_conn(conn)
+    return updated > 0
+
 def expire_task_if_bidding(task_id: str, updated_at: float) -> bool:
     """Expire a bidding task (no provider accepted)"""
     conn = _get_conn()
@@ -472,23 +477,23 @@ def expire_task_if_bidding(task_id: str, updated_at: float) -> bool:
     _release_conn(conn)
     return updated > 0
 
-def expire_task_if_assigned(task_id: str, updated_at: float) -> bool:
+def get_bidding_tasks_before(cutoff_ts: float) -> list:
+    """Get bidding tasks older than cutoff - for timeout sweep"""
     conn = _get_conn()
+    if not _is_postgres():
+        conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
     if _is_postgres():
-        cursor.execute(
-            "UPDATE tasks SET status = 'expired', provider_id = NULL, updated_at = %s WHERE task_id = %s AND status = 'assigned'",
-            (updated_at, task_id)
-        )
+        cursor.execute("SELECT task_id, consumer_id, payload, bounty, updated_at FROM tasks WHERE status = 'bidding' AND updated_at < %s", (cutoff_ts,))
     else:
-        cursor.execute(
-            "UPDATE tasks SET status = 'expired', provider_id = NULL, updated_at = ? WHERE task_id = ? AND status = 'assigned'",
-            (updated_at, task_id)
-        )
-    updated = cursor.rowcount
-    conn.commit()
+        cursor.execute("SELECT task_id, consumer_id, payload, bounty, updated_at FROM tasks WHERE status = 'bidding' AND updated_at < ?", (cutoff_ts,))
+    rows = cursor.fetchall()
+    if _is_postgres():
+        result = [_row_to_dict(cursor, row) for row in rows]
+    else:
+        result = [dict(row) for row in rows]
     _release_conn(conn)
-    return updated > 0
+    return result
 
 def requeue_task_if_assigned(task_id: str, updated_at: float) -> bool:
     conn = _get_conn()
@@ -588,7 +593,7 @@ def delete_idempotency_before(cutoff_ts: float) -> int:
     _release_conn(conn)
     return int(deleted or 0)
 
-def upsert_registry(node_id: str, alias: Optional[str], skills: list[str], models: list[str], metadata: dict, availability: str, updated_at: float, x25519_public_key: Optional[str] = None, bio: Optional[str] = None):
+def upsert_registry(node_id: str, alias: Optional[str], skills: list[str], models: list[str], metadata: dict, availability: str, updated_at: float, x25519_public_key: Optional[str] = None):
     conn = _get_conn()
     cursor = conn.cursor()
     _ensure_registry_availability_column(cursor)
@@ -598,35 +603,33 @@ def upsert_registry(node_id: str, alias: Optional[str], skills: list[str], model
     
     if _is_postgres():
         query = """
-            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key, bio)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (node_id) DO UPDATE SET
                 alias = EXCLUDED.alias,
                 skills = EXCLUDED.skills,
                 models = EXCLUDED.models,
                 metadata = EXCLUDED.metadata,
                 availability = EXCLUDED.availability,
-                updated_at = EXCLUDED.updated_at,
-                bio = EXCLUDED.bio
+                updated_at = EXCLUDED.updated_at
         """
-        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key, bio]
+        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
         if x25519_public_key:
             query += ", x25519_public_key = EXCLUDED.x25519_public_key"
         cursor.execute(query, tuple(params))
     else:
         query = """
-            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key, bio)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO agent_registry (node_id, alias, skills, models, metadata, availability, updated_at, x25519_public_key)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(node_id) DO UPDATE SET
                 alias=excluded.alias,
                 skills=excluded.skills,
                 models=excluded.models,
                 metadata=excluded.metadata,
                 availability=excluded.availability,
-                updated_at=excluded.updated_at,
-                bio=excluded.bio
+                updated_at=excluded.updated_at
         """
-        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key, bio]
+        params = [node_id, alias, skills_payload, models_payload, metadata_payload, availability, updated_at, x25519_public_key]
         if x25519_public_key:
             query += ", x25519_public_key=excluded.x25519_public_key"
         cursor.execute(query, tuple(params))
@@ -694,7 +697,7 @@ def get_registry(node_id: str) -> Optional[dict]:
     result["metadata"] = json.loads(result["metadata"]) if result.get("metadata") else {}
     return result
 
-def search_registry(alias: Optional[str], skill: Optional[str], model: Optional[str], availability: Optional[str], min_score: Optional[float], min_reviews: Optional[float], min_updated_at: Optional[float], limit: int, bio: Optional[str] = None) -> list[dict]:
+def search_registry(alias: Optional[str], skill: Optional[str], model: Optional[str], availability: Optional[str], min_score: Optional[float], min_reviews: Optional[int], min_updated_at: Optional[float], limit: int) -> list[dict]:
     conn = _get_conn()
     if not _is_postgres():
         conn.row_factory = sqlite3.Row
@@ -720,13 +723,6 @@ def search_registry(alias: Optional[str], skill: Optional[str], model: Optional[
         else:
             conditions.append("agent_registry.alias LIKE ?")
             params.append(f"%{alias}%")
-    if bio:
-        if _is_postgres():
-            conditions.append("agent_registry.bio ILIKE %s")
-            params.append(f"%{bio}%")
-        else:
-            conditions.append("agent_registry.bio LIKE ?")
-            params.append(f"%{bio}%")
     if skill:
         if _is_postgres():
             conditions.append("skills ILIKE %s")
@@ -1087,21 +1083,3 @@ def cleanup_expired_pending_dms() -> int:
     return removed
 
 init_db()
-
-def get_bidding_tasks_before(cutoff_ts: float) -> list:
-    """Get bidding tasks older than cutoff - for cleanup"""
-    conn = _get_conn()
-    if not _is_postgres():
-        conn.row_factory = sqlite3.Row
-    cursor = conn.cursor()
-    if _is_postgres():
-        cursor.execute("SELECT task_id, consumer_id, payload, bounty, updated_at FROM tasks WHERE status = 'bidding' AND updated_at < %s", (cutoff_ts,))
-    else:
-        cursor.execute("SELECT task_id, consumer_id, payload, bounty, updated_at FROM tasks WHERE status = 'bidding' AND updated_at < ?", (cutoff_ts,))
-    rows = cursor.fetchall()
-    if _is_postgres():
-        result = [_row_to_dict(cursor, row) for row in rows]
-    else:
-        result = [dict(row) for row in rows]
-    _release_conn(conn)
-    return result

--- a/hub/main.py
+++ b/hub/main.py
@@ -350,11 +350,12 @@ async def _list_federation_peers() -> list[str]:
 
 def _build_registry_query(
     alias: Optional[str],
+    bio: Optional[str],
     skill: Optional[str],
     model: Optional[str],
     availability: Optional[str],
     min_score: Optional[float],
-    min_reviews: Optional[int],
+    min_reviews: Optional[float],
     max_age_minutes: Optional[float],
     limit: int
 ) -> dict:
@@ -367,6 +368,7 @@ def _build_registry_query(
         safe_max_age = max(0.0, max_age_minutes)
     min_updated_at = None if safe_max_age is None else time.time() - safe_max_age * 60.0
     normalized_alias = alias.strip().lower() if alias else None
+    normalized_bio = bio.strip().lower() if bio else None
     normalized_skill = skill.strip().lower() if skill else None
     normalized_model = model.strip().lower() if model else None
     normalized_availability = _normalize_availability(availability) if availability else None
@@ -376,6 +378,7 @@ def _build_registry_query(
         "safe_min_reviews": safe_min_reviews,
         "min_updated_at": min_updated_at,
         "normalized_alias": normalized_alias,
+        "normalized_bio": normalized_bio,
         "normalized_skill": normalized_skill,
         "normalized_model": normalized_model,
         "normalized_availability": normalized_availability
@@ -667,10 +670,38 @@ async def _sweep_assigned_timeouts():
                 del active_tasks[task["task_id"]]
         log_event("task_expired", f"Task {task['task_id'][:8]} expired after timeout", task_id=task["task_id"], consumer_id=task["consumer_id"], provider_id=task["provider_id"], bounty=task["bounty"])
 
+# NEW: Sweep bidding tasks that were never picked up
+async def _sweep_bidding_timeouts():
+    """Expire bidding tasks that never got a provider and refund bounty"""
+    if ASSIGNMENT_TIMEOUT_SECONDS <= 0:
+        return
+    cutoff = time.time() - ASSIGNMENT_TIMEOUT_SECONDS
+    expired_bidding = db.get_bidding_tasks_before(cutoff)
+    if not expired_bidding:
+        return
+    now = time.time()
+    for task in expired_bidding:
+        if not db.expire_task_if_bidding(task["task_id"], now):
+            continue
+        # Refund escrow to consumer for unassigned bidding tasks
+        if task.get("bounty", 0) > 0:
+            refunded = db.refund_escrow(task["task_id"], now)
+            if refunded is None:
+                # If no escrow, add balance directly
+                db.add_balance(task["consumer_id"], task["bounty"])
+            new_balance = db.get_balance(task["consumer_id"])
+            log_audit("BIDDING_TIMEOUT_REFUND", task["consumer_id"], task["bounty"], new_balance, task["task_id"])
+        async with task_lock:
+            if task["task_id"] in active_tasks:
+                del active_tasks[task["task_id"]]
+        log_event("task_expired_bidding", f"Task {task['task_id'][:8]} expired, refunded {task.get('bounty', 0)}", task_id=task["task_id"], consumer_id=task["consumer_id"], bounty=task.get("bounty", 0))
+    return result
+
 async def _assignment_timeout_worker():
     while True:
         try:
             await _sweep_assigned_timeouts()
+            await _sweep_bidding_timeouts()  # Add bidding sweep
         except Exception as exc:
             log_event("timeout_sweep_failed", f"Timeout sweep failed: {exc}")
         await asyncio.sleep(ASSIGNMENT_SWEEP_INTERVAL_SECONDS)
@@ -774,8 +805,8 @@ async def register_node(node: NodeRegistration, request: Request):
     # Registration derives the Node ID from the provided Public Key PEM
     node_id = auth.derive_node_id(node.pubkey)
     balance = db.register_node(node_id, node.pubkey)
-    if node.alias or getattr(node, 'x25519_public_key', None):
-        db.upsert_registry(node_id, node.alias, [], [], {}, "offline", time.time(), getattr(node, 'x25519_public_key', None))
+    if node.alias or getattr(node, 'x25519_public_key', None) or getattr(node, 'bio', None):
+        db.upsert_registry(node_id, node.alias, [], [], {}, "offline", time.time(), getattr(node, 'x25519_public_key', None), getattr(node, 'bio', None))
 
     log_event("node_registered", f"Node {node_id} registered with starting balance {balance}", node_id=node_id, starting_balance=balance)
     log_audit("REGISTER", node_id, balance, balance, "START_BONUS")
@@ -793,7 +824,7 @@ async def update_registry(payload: RegistryUpdate, authenticated_node: str = Dep
     if availability is None:
         existing = db.get_registry(authenticated_node)
         availability = existing.get("availability") if existing else "unknown"
-    db.upsert_registry(authenticated_node, payload.alias, skills, models, metadata, availability, time.time())
+    db.upsert_registry(authenticated_node, payload.alias, skills, models, metadata, availability, time.time(), bio=getattr(payload, 'bio', None))
     return {"status": "success", "node_id": authenticated_node}
 
 @app.post("/registry/availability")
@@ -838,6 +869,7 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
 @app.get("/registry/search")
 async def search_registry(
     alias: Optional[str] = None,
+    bio: Optional[str] = None,
     skill: Optional[str] = None,
     model: Optional[str] = None,
     availability: Optional[str] = None,
@@ -846,7 +878,7 @@ async def search_registry(
     max_age_minutes: Optional[float] = None,
     limit: int = 20
 ):
-    query = _build_registry_query(alias, skill, model, availability, min_score, min_reviews, max_age_minutes, limit)
+    query = _build_registry_query(alias, bio, skill, model, availability, min_score, min_reviews, max_age_minutes, limit)
     results = _search_registry_local(query)
     return {"count": len(results), "results": results}
 
@@ -878,6 +910,7 @@ async def remove_federation_peer(hub_url: str, x_mep_admin_key: Optional[str] = 
 @app.get("/federation/discovery")
 async def federation_discovery(
     alias: Optional[str] = None,
+    bio: Optional[str] = None,
     skill: Optional[str] = None,
     model: Optional[str] = None,
     availability: Optional[str] = None,
@@ -887,7 +920,7 @@ async def federation_discovery(
     limit: int = 20,
     include_local: bool = True
 ):
-    query = _build_registry_query(alias, skill, model, availability, min_score, min_reviews, max_age_minutes, min(limit, FEDERATION_REMOTE_LIMIT))
+    query = _build_registry_query(alias, bio, skill, model, availability, min_score, min_reviews, max_age_minutes, min(limit, FEDERATION_REMOTE_LIMIT))
     local_results = _search_registry_local(query) if include_local else []
     for item in local_results:
         item["source_hub"] = HUB_ID

--- a/hub/main.py
+++ b/hub/main.py
@@ -698,8 +698,6 @@ async def _assignment_timeout_worker():
             await _sweep_bidding_timeouts()
         except Exception as exc:
             log_event("timeout_sweep_failed", f"Timeout sweep failed: {exc}")
-        except Exception as exc:
-            log_event("timeout_sweep_failed", f"Timeout sweep failed: {exc}")
         await asyncio.sleep(ASSIGNMENT_SWEEP_INTERVAL_SECONDS)
 
 async def _maintenance_worker():

--- a/hub/main.py
+++ b/hub/main.py
@@ -350,12 +350,11 @@ async def _list_federation_peers() -> list[str]:
 
 def _build_registry_query(
     alias: Optional[str],
-    bio: Optional[str],
     skill: Optional[str],
     model: Optional[str],
     availability: Optional[str],
     min_score: Optional[float],
-    min_reviews: Optional[float],
+    min_reviews: Optional[int],
     max_age_minutes: Optional[float],
     limit: int
 ) -> dict:
@@ -368,7 +367,6 @@ def _build_registry_query(
         safe_max_age = max(0.0, max_age_minutes)
     min_updated_at = None if safe_max_age is None else time.time() - safe_max_age * 60.0
     normalized_alias = alias.strip().lower() if alias else None
-    normalized_bio = bio.strip().lower() if bio else None
     normalized_skill = skill.strip().lower() if skill else None
     normalized_model = model.strip().lower() if model else None
     normalized_availability = _normalize_availability(availability) if availability else None
@@ -378,7 +376,6 @@ def _build_registry_query(
         "safe_min_reviews": safe_min_reviews,
         "min_updated_at": min_updated_at,
         "normalized_alias": normalized_alias,
-        "normalized_bio": normalized_bio,
         "normalized_skill": normalized_skill,
         "normalized_model": normalized_model,
         "normalized_availability": normalized_availability
@@ -670,7 +667,6 @@ async def _sweep_assigned_timeouts():
                 del active_tasks[task["task_id"]]
         log_event("task_expired", f"Task {task['task_id'][:8]} expired after timeout", task_id=task["task_id"], consumer_id=task["consumer_id"], provider_id=task["provider_id"], bounty=task["bounty"])
 
-# NEW: Sweep bidding tasks that were never picked up
 async def _sweep_bidding_timeouts():
     """Expire bidding tasks that never got a provider and refund bounty"""
     if ASSIGNMENT_TIMEOUT_SECONDS <= 0:
@@ -687,7 +683,6 @@ async def _sweep_bidding_timeouts():
         if task.get("bounty", 0) > 0:
             refunded = db.refund_escrow(task["task_id"], now)
             if refunded is None:
-                # If no escrow, add balance directly
                 db.add_balance(task["consumer_id"], task["bounty"])
             new_balance = db.get_balance(task["consumer_id"])
             log_audit("BIDDING_TIMEOUT_REFUND", task["consumer_id"], task["bounty"], new_balance, task["task_id"])
@@ -695,13 +690,14 @@ async def _sweep_bidding_timeouts():
             if task["task_id"] in active_tasks:
                 del active_tasks[task["task_id"]]
         log_event("task_expired_bidding", f"Task {task['task_id'][:8]} expired, refunded {task.get('bounty', 0)}", task_id=task["task_id"], consumer_id=task["consumer_id"], bounty=task.get("bounty", 0))
-    return result
 
 async def _assignment_timeout_worker():
     while True:
         try:
             await _sweep_assigned_timeouts()
-            await _sweep_bidding_timeouts()  # Add bidding sweep
+            await _sweep_bidding_timeouts()
+        except Exception as exc:
+            log_event("timeout_sweep_failed", f"Timeout sweep failed: {exc}")
         except Exception as exc:
             log_event("timeout_sweep_failed", f"Timeout sweep failed: {exc}")
         await asyncio.sleep(ASSIGNMENT_SWEEP_INTERVAL_SECONDS)
@@ -805,8 +801,8 @@ async def register_node(node: NodeRegistration, request: Request):
     # Registration derives the Node ID from the provided Public Key PEM
     node_id = auth.derive_node_id(node.pubkey)
     balance = db.register_node(node_id, node.pubkey)
-    if node.alias or getattr(node, 'x25519_public_key', None) or getattr(node, 'bio', None):
-        db.upsert_registry(node_id, node.alias, [], [], {}, "offline", time.time(), getattr(node, 'x25519_public_key', None), getattr(node, 'bio', None))
+    if node.alias or getattr(node, 'x25519_public_key', None):
+        db.upsert_registry(node_id, node.alias, [], [], {}, "offline", time.time(), getattr(node, 'x25519_public_key', None))
 
     log_event("node_registered", f"Node {node_id} registered with starting balance {balance}", node_id=node_id, starting_balance=balance)
     log_audit("REGISTER", node_id, balance, balance, "START_BONUS")
@@ -824,7 +820,7 @@ async def update_registry(payload: RegistryUpdate, authenticated_node: str = Dep
     if availability is None:
         existing = db.get_registry(authenticated_node)
         availability = existing.get("availability") if existing else "unknown"
-    db.upsert_registry(authenticated_node, payload.alias, skills, models, metadata, availability, time.time(), bio=getattr(payload, 'bio', None))
+    db.upsert_registry(authenticated_node, payload.alias, skills, models, metadata, availability, time.time())
     return {"status": "success", "node_id": authenticated_node}
 
 @app.post("/registry/availability")
@@ -869,7 +865,6 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
 @app.get("/registry/search")
 async def search_registry(
     alias: Optional[str] = None,
-    bio: Optional[str] = None,
     skill: Optional[str] = None,
     model: Optional[str] = None,
     availability: Optional[str] = None,
@@ -878,7 +873,7 @@ async def search_registry(
     max_age_minutes: Optional[float] = None,
     limit: int = 20
 ):
-    query = _build_registry_query(alias, bio, skill, model, availability, min_score, min_reviews, max_age_minutes, limit)
+    query = _build_registry_query(alias, skill, model, availability, min_score, min_reviews, max_age_minutes, limit)
     results = _search_registry_local(query)
     return {"count": len(results), "results": results}
 
@@ -910,7 +905,6 @@ async def remove_federation_peer(hub_url: str, x_mep_admin_key: Optional[str] = 
 @app.get("/federation/discovery")
 async def federation_discovery(
     alias: Optional[str] = None,
-    bio: Optional[str] = None,
     skill: Optional[str] = None,
     model: Optional[str] = None,
     availability: Optional[str] = None,
@@ -920,7 +914,7 @@ async def federation_discovery(
     limit: int = 20,
     include_local: bool = True
 ):
-    query = _build_registry_query(alias, bio, skill, model, availability, min_score, min_reviews, max_age_minutes, min(limit, FEDERATION_REMOTE_LIMIT))
+    query = _build_registry_query(alias, skill, model, availability, min_score, min_reviews, max_age_minutes, min(limit, FEDERATION_REMOTE_LIMIT))
     local_results = _search_registry_local(query) if include_local else []
     for item in local_results:
         item["source_hub"] = HUB_ID


### PR DESCRIPTION
# PR #83 v3: Bidding Task Timeout

Clean implementation:

## Changes
- `hub/db.py`: `expire_task_if_bidding()`, `get_bidding_tasks_before()`
- `hub/main.py`: `_sweep_bidding_timeouts()` with escrow refund

## No unrelated changes