### PR TITLE
fix: bidding timeout sweep - PR #83 v6

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -458,6 +458,43 @@ def expire_task_if_assigned(task_id: str, updated_at: float) -> bool:
     _release_conn(conn)
     return updated > 0
 
+def expire_task_if_bidding(task_id: str, updated_at: float) -> bool:
+    """Expire a bidding task (no provider accepted)"""
+    conn = _get_conn()
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute(
+            "UPDATE tasks SET status = 'expired', provider_id = NULL, updated_at = %s WHERE task_id = %s AND status = 'bidding'",
+            (updated_at, task_id)
+        )
+    else:
+        cursor.execute(
+            "UPDATE tasks SET status = 'expired', provider_id = NULL, updated_at = ? WHERE task_id = ? AND status = 'bidding'",
+            (updated_at, task_id)
+        )
+    updated = cursor.rowcount
+    conn.commit()
+    _release_conn(conn)
+    return updated > 0
+
+def get_bidding_tasks_before(cutoff_ts: float) -> list:
+    """Get bidding tasks older than cutoff - for timeout sweep"""
+    conn = _get_conn()
+    if not _is_postgres():
+        conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute("SELECT task_id, consumer_id, payload, bounty, updated_at FROM tasks WHERE status = 'bidding' AND updated_at < %s", (cutoff_ts,))
+    else:
+        cursor.execute("SELECT task_id, consumer_id, payload, bounty, updated_at FROM tasks WHERE status = 'bidding' AND updated_at < ?", (cutoff_ts,))
+    rows = cursor.fetchall()
+    if _is_postgres():
+        result = [_row_to_dict(cursor, row) for row in rows]
+    else:
+        result = [dict(row) for row in rows]
+    _release_conn(conn)
+    return result
+
 def requeue_task_if_assigned(task_id: str, updated_at: float) -> bool:
     conn = _get_conn()
     cursor = conn.cursor()

--- a/hub/main.py
+++ b/hub/main.py
@@ -713,10 +713,34 @@ async def _sweep_assigned_timeouts():
                 del active_tasks[task["task_id"]]
         log_event("task_expired", f"Task {task['task_id'][:8]} expired after timeout", task_id=task["task_id"], consumer_id=task["consumer_id"], provider_id=task["provider_id"], bounty=task["bounty"])
 
+async def _sweep_bidding_timeouts():
+    """Expire bidding tasks that never got a provider and refund bounty"""
+    if ASSIGNMENT_TIMEOUT_SECONDS <= 0:
+        return
+    cutoff = time.time() - ASSIGNMENT_TIMEOUT_SECONDS
+    expired_bidding = db.get_bidding_tasks_before(cutoff)
+    if not expired_bidding:
+        return
+    now = time.time()
+    for task in expired_bidding:
+        if not db.expire_task_if_bidding(task["task_id"], now):
+            continue
+        if task.get("bounty", 0) > 0:
+            refunded = db.refund_escrow(task["task_id"], now)
+            if refunded is None:
+                db.add_balance(task["consumer_id"], task["bounty"])
+            new_balance = db.get_balance(task["consumer_id"])
+            log_audit("BIDDING_TIMEOUT_REFUND", task["consumer_id"], task["bounty"], new_balance, task["task_id"])
+        async with task_lock:
+            if task["task_id"] in active_tasks:
+                del active_tasks[task["task_id"]]
+        log_event("task_expired_bidding", f"Task {task['task_id'][:8]} expired", task_id=task["task_id"], consumer_id=task["consumer_id"])
+
 async def _assignment_timeout_worker():
     while True:
         try:
             await _sweep_assigned_timeouts()
+            await _sweep_bidding_timeouts()
         except Exception as exc:
             log_event("timeout_sweep_failed", f"Timeout sweep failed: {exc}")
         await asyncio.sleep(ASSIGNMENT_SWEEP_INTERVAL_SECONDS)

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -306,17 +306,19 @@ class TestBiddingTimeout(unittest.TestCase):
         conn.commit()
         db._release_conn(conn)
 
-        # Run the bidding timeout sweep manually
+        # Run the bidding timeout sweep
         import asyncio
         from main import _sweep_bidding_timeouts
         loop = asyncio.new_event_loop()
-        loop.run_until_complete(_sweep_bidding_timeouts())
-        loop.close()
+        try:
+            loop.run_until_complete(_sweep_bidding_timeouts())
+        finally:
+            loop.close()
 
-        # Verify task is now expired
-        resp = client.get(f"/tasks/{task_id}")
-        self.assertEqual(resp.json()["status"], "expired",
-                        "Task should be expired after timeout")
+        # Verify task status from DB helper (not /tasks/{task_id}, which does not exist)
+        task = db.get_task(task_id)
+        self.assertIsNotNone(task)
+        self.assertEqual(task["status"], "expired", "Task should be expired after timeout")
 
         # Verify consumer balance is restored (refunded)
         resp = client.get(f"/balance/{consumer_id}")

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -322,5 +322,3 @@ class TestBiddingTimeout(unittest.TestCase):
         resp = client.get(f"/balance/{consumer_id}")
         self.assertEqual(resp.json()["balance_seconds"], initial_balance,
                         "Consumer balance should be restored after refund")
-
-# Fixed version - replaces the above with proper DB access

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -298,11 +298,13 @@ class TestBiddingTimeout(unittest.TestCase):
         # (In real system, timeout worker does this after ASSIGNMENT_TIMEOUT_SECONDS)
         import time as t
         old_time = t.time() - 7200  # 2 hours ago (well beyond 1 hour timeout)
-        db.conn.execute(
+        conn = db._get_conn()
+        conn.execute(
             "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
             (old_time, task_id)
         )
-        db.conn.commit()
+        conn.commit()
+        db._release_conn(conn)
 
         # Run the bidding timeout sweep manually
         import asyncio
@@ -320,3 +322,5 @@ class TestBiddingTimeout(unittest.TestCase):
         resp = client.get(f"/balance/{consumer_id}")
         self.assertEqual(resp.json()["balance_seconds"], initial_balance,
                         "Consumer balance should be restored after refund")
+
+# Fixed version - replaces the above with proper DB access

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -260,3 +260,63 @@ def tearDownModule():
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestBiddingTimeout(unittest.TestCase):
+    """Test bidding task timeout + refund flow"""
+
+    def test_stale_bidding_task_expired_and_refunded(self):
+        """Verify stale bidding tasks are expired and bounty refunded to consumer"""
+        # Setup: consumer and provider
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        # Get initial balance
+        resp = client.get(f"/balance/{consumer_id}")
+        initial_balance = resp.json()["balance_seconds"]
+
+        # Submit task with bounty (escrow created)
+        bounty = 1.0
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "Stale task that will timeout",
+            "bounty": bounty,
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+        task_id = resp.json()["task_id"]
+
+        # Verify balance is escrowed (reduced by bounty)
+        resp = client.get(f"/balance/{consumer_id}")
+        self.assertLess(resp.json()["balance_seconds"], initial_balance,
+                       "Consumer balance should decrease by bounty")
+
+        # Simulate task aging: directly update task's updated_at in DB to be old
+        # (In real system, timeout worker does this after ASSIGNMENT_TIMEOUT_SECONDS)
+        import time as t
+        old_time = t.time() - 7200  # 2 hours ago (well beyond 1 hour timeout)
+        db.conn.execute(
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+            (old_time, task_id)
+        )
+        db.conn.commit()
+
+        # Run the bidding timeout sweep manually
+        import asyncio
+        from main import _sweep_bidding_timeouts
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_sweep_bidding_timeouts())
+        loop.close()
+
+        # Verify task is now expired
+        resp = client.get(f"/tasks/{task_id}")
+        self.assertEqual(resp.json()["status"], "expired",
+                        "Task should be expired after timeout")
+
+        # Verify consumer balance is restored (refunded)
+        resp = client.get(f"/balance/{consumer_id}")
+        self.assertEqual(resp.json()["balance_seconds"], initial_balance,
+                        "Consumer balance should be restored after refund")


### PR DESCRIPTION
# PR #83 v6: Bidding Task Timeout

Clean implementation:
- db.py: expire_task_if_bidding(), get_bidding_tasks_before()
- main.py: _sweep_bidding_timeouts() with escrow refund
- Syntax verified ✅
- Only 61 lines added across 2 files