### PR TITLE
Hub: consumer-defined timeout policy for expiry/refund sweeps

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -67,6 +67,19 @@ def _ensure_registry_availability_column(cursor):
         if "availability" not in columns:
             cursor.execute("ALTER TABLE agent_registry ADD COLUMN availability TEXT NOT NULL DEFAULT 'unknown'")
 
+def _ensure_tasks_expires_in_seconds_column(cursor):
+    if _is_postgres():
+        cursor.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = 'tasks' AND column_name = 'expires_in_seconds'"
+        )
+        if not cursor.fetchone():
+            cursor.execute("ALTER TABLE tasks ADD COLUMN expires_in_seconds INTEGER")
+    else:
+        cursor.execute("PRAGMA table_info(tasks)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if "expires_in_seconds" not in columns:
+            cursor.execute("ALTER TABLE tasks ADD COLUMN expires_in_seconds INTEGER")
+
 def init_db():
     conn = _get_conn()
     cursor = conn.cursor()
@@ -87,6 +100,7 @@ def init_db():
             status TEXT NOT NULL,
             target_node TEXT,
             model_requirement TEXT,
+            expires_in_seconds INTEGER,
             result_payload TEXT,
             payload_uri TEXT,
             result_uri TEXT,
@@ -94,6 +108,7 @@ def init_db():
             updated_at REAL NOT NULL
         )
     ''')
+    _ensure_tasks_expires_in_seconds_column(cursor)
     if not _is_postgres():
         try:
             cursor.execute("ALTER TABLE tasks ADD COLUMN payload_uri TEXT")
@@ -284,18 +299,30 @@ def deduct_balance(node_id: str, amount: float) -> bool:
     _release_conn(conn)
     return updated > 0
 
-def create_task(task_id: str, consumer_id: str, payload: str, bounty: float, status: str, target_node: Optional[str], model_requirement: Optional[str], created_at: float, result_payload: Optional[str] = None, payload_uri: Optional[str] = None):
+def create_task(
+    task_id: str,
+    consumer_id: str,
+    payload: str,
+    bounty: float,
+    status: str,
+    target_node: Optional[str],
+    model_requirement: Optional[str],
+    created_at: float,
+    result_payload: Optional[str] = None,
+    payload_uri: Optional[str] = None,
+    expires_in_seconds: Optional[int] = None,
+):
     conn = _get_conn()
     cursor = conn.cursor()
     if _is_postgres():
         cursor.execute(
-            "INSERT INTO tasks (task_id, consumer_id, provider_id, payload, bounty, status, target_node, model_requirement, result_payload, payload_uri, created_at, updated_at) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-            (task_id, consumer_id, None, payload, bounty, status, target_node, model_requirement, result_payload, payload_uri, created_at, created_at)
+            "INSERT INTO tasks (task_id, consumer_id, provider_id, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, created_at, updated_at) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            (task_id, consumer_id, None, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, created_at, created_at)
         )
     else:
         cursor.execute(
-            "INSERT INTO tasks (task_id, consumer_id, provider_id, payload, bounty, status, target_node, model_requirement, result_payload, payload_uri, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (task_id, consumer_id, None, payload, bounty, status, target_node, model_requirement, result_payload, payload_uri, created_at, created_at)
+            "INSERT INTO tasks (task_id, consumer_id, provider_id, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (task_id, consumer_id, None, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, created_at, created_at)
         )
     conn.commit()
     _release_conn(conn)
@@ -487,6 +514,80 @@ def get_bidding_tasks_before(cutoff_ts: float) -> list:
         cursor.execute("SELECT task_id, consumer_id, payload, bounty, updated_at FROM tasks WHERE status = 'bidding' AND updated_at < %s", (cutoff_ts,))
     else:
         cursor.execute("SELECT task_id, consumer_id, payload, bounty, updated_at FROM tasks WHERE status = 'bidding' AND updated_at < ?", (cutoff_ts,))
+    rows = cursor.fetchall()
+    if _is_postgres():
+        result = [_row_to_dict(cursor, row) for row in rows]
+    else:
+        result = [dict(row) for row in rows]
+    _release_conn(conn)
+    return result
+
+def get_assigned_tasks_for_timeout(now_ts: float, default_timeout: int, min_timeout: int, max_timeout: int) -> list:
+    conn = _get_conn()
+    if not _is_postgres():
+        conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute(
+            """
+            SELECT *
+            FROM tasks
+            WHERE status = 'assigned'
+              AND updated_at < (
+                %s - LEAST(GREATEST(COALESCE(expires_in_seconds, %s), %s), %s)
+              )
+            """,
+            (now_ts, default_timeout, min_timeout, max_timeout),
+        )
+    else:
+        cursor.execute(
+            """
+            SELECT *
+            FROM tasks
+            WHERE status = 'assigned'
+              AND updated_at < (
+                ? - MIN(MAX(COALESCE(expires_in_seconds, ?), ?), ?)
+              )
+            """,
+            (now_ts, default_timeout, min_timeout, max_timeout),
+        )
+    rows = cursor.fetchall()
+    if _is_postgres():
+        result = [_row_to_dict(cursor, row) for row in rows]
+    else:
+        result = [dict(row) for row in rows]
+    _release_conn(conn)
+    return result
+
+def get_bidding_tasks_for_timeout(now_ts: float, default_timeout: int, min_timeout: int, max_timeout: int) -> list:
+    conn = _get_conn()
+    if not _is_postgres():
+        conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute(
+            """
+            SELECT task_id, consumer_id, payload, bounty, updated_at, expires_in_seconds
+            FROM tasks
+            WHERE status = 'bidding'
+              AND updated_at < (
+                %s - LEAST(GREATEST(COALESCE(expires_in_seconds, %s), %s), %s)
+              )
+            """,
+            (now_ts, default_timeout, min_timeout, max_timeout),
+        )
+    else:
+        cursor.execute(
+            """
+            SELECT task_id, consumer_id, payload, bounty, updated_at, expires_in_seconds
+            FROM tasks
+            WHERE status = 'bidding'
+              AND updated_at < (
+                ? - MIN(MAX(COALESCE(expires_in_seconds, ?), ?), ?)
+              )
+            """,
+            (now_ts, default_timeout, min_timeout, max_timeout),
+        )
     rows = cursor.fetchall()
     if _is_postgres():
         result = [_row_to_dict(cursor, row) for row in rows]

--- a/hub/main.py
+++ b/hub/main.py
@@ -97,6 +97,9 @@ DISPUTE_WINDOW_SECONDS = int(os.getenv("MEP_DISPUTE_WINDOW_SECONDS", "86400"))
 DISPUTE_REASON_MIN_CHARS = int(os.getenv("MEP_DISPUTE_REASON_MIN_CHARS", "10"))
 DISPUTE_REASON_MAX_CHARS = int(os.getenv("MEP_DISPUTE_REASON_MAX_CHARS", "500"))
 ASSIGNMENT_TIMEOUT_SECONDS = int(os.getenv("MEP_ASSIGNMENT_TIMEOUT_SECONDS", "3600"))
+TASK_TIMEOUT_DEFAULT_SECONDS = int(os.getenv("MEP_TASK_TIMEOUT_DEFAULT_SECONDS", str(ASSIGNMENT_TIMEOUT_SECONDS)))
+TASK_TIMEOUT_MIN_SECONDS = int(os.getenv("MEP_TASK_TIMEOUT_MIN_SECONDS", "60"))
+TASK_TIMEOUT_MAX_SECONDS = int(os.getenv("MEP_TASK_TIMEOUT_MAX_SECONDS", "86400"))
 ASSIGNMENT_SWEEP_INTERVAL_SECONDS = int(os.getenv("MEP_ASSIGNMENT_SWEEP_INTERVAL_SECONDS", "60"))
 MAINTENANCE_SWEEP_INTERVAL_SECONDS = int(os.getenv("MEP_MAINTENANCE_SWEEP_INTERVAL_SECONDS", "60"))
 COMPLETED_TASK_CACHE_TTL_SECONDS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_TTL_SECONDS", "3600"))
@@ -104,6 +107,10 @@ COMPLETED_TASK_CACHE_MAX_ITEMS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_MAX_ITE
 IDEMPOTENCY_TTL_SECONDS = int(os.getenv("MEP_IDEMPOTENCY_TTL_SECONDS", "86400"))
 TIMEOUT_POLICY = os.getenv("MEP_TIMEOUT_POLICY", "refund").lower()
 VALID_AVAILABILITY = {"online", "idle", "busy", "offline", "degraded", "unknown"}
+
+if TASK_TIMEOUT_MIN_SECONDS > TASK_TIMEOUT_MAX_SECONDS:
+    TASK_TIMEOUT_MIN_SECONDS, TASK_TIMEOUT_MAX_SECONDS = TASK_TIMEOUT_MAX_SECONDS, TASK_TIMEOUT_MIN_SECONDS
+TASK_TIMEOUT_DEFAULT_SECONDS = max(TASK_TIMEOUT_MIN_SECONDS, min(TASK_TIMEOUT_DEFAULT_SECONDS, TASK_TIMEOUT_MAX_SECONDS))
 
 # ---------------------------------------------------------------------------
 # Node Activity Tracking (for passive degraded detection)
@@ -292,6 +299,7 @@ async def _load_active_tasks_from_db():
             "status": task["status"],
             "target_node": task["target_node"],
             "model_requirement": task["model_requirement"],
+            "expires_in_seconds": task.get("expires_in_seconds"),
             "provider_id": task["provider_id"],
             "payload_uri": task.get("payload_uri"),
             "secret_data": task.get("result_payload")
@@ -655,13 +663,17 @@ def _sweep_idempotency_records():
         log_event("idempotency_cleaned", f"Removed {removed} expired idempotency records", removed=removed)
 
 async def _sweep_assigned_timeouts():
-    if ASSIGNMENT_TIMEOUT_SECONDS <= 0:
-        return
-    cutoff = time.time() - ASSIGNMENT_TIMEOUT_SECONDS
-    expired_tasks = db.get_assigned_tasks_before(cutoff)
-    if not expired_tasks:
+    if TASK_TIMEOUT_DEFAULT_SECONDS <= 0:
         return
     now = time.time()
+    expired_tasks = db.get_assigned_tasks_for_timeout(
+        now,
+        TASK_TIMEOUT_DEFAULT_SECONDS,
+        TASK_TIMEOUT_MIN_SECONDS,
+        TASK_TIMEOUT_MAX_SECONDS,
+    )
+    if not expired_tasks:
+        return
     for task in expired_tasks:
         if TIMEOUT_POLICY == "rebroadcast" and not task["target_node"]:
             if not db.requeue_task_if_assigned(task["task_id"], now):
@@ -674,6 +686,7 @@ async def _sweep_assigned_timeouts():
                 "status": "bidding",
                 "target_node": task["target_node"],
                 "model_requirement": task["model_requirement"],
+                "expires_in_seconds": task.get("expires_in_seconds"),
                 "payload_uri": task.get("payload_uri"),
                 "secret_data": task.get("result_payload")
             }
@@ -715,13 +728,17 @@ async def _sweep_assigned_timeouts():
 
 async def _sweep_bidding_timeouts():
     """Expire bidding tasks that never got a provider and refund bounty"""
-    if ASSIGNMENT_TIMEOUT_SECONDS <= 0:
-        return
-    cutoff = time.time() - ASSIGNMENT_TIMEOUT_SECONDS
-    expired_bidding = db.get_bidding_tasks_before(cutoff)
-    if not expired_bidding:
+    if TASK_TIMEOUT_DEFAULT_SECONDS <= 0:
         return
     now = time.time()
+    expired_bidding = db.get_bidding_tasks_for_timeout(
+        now,
+        TASK_TIMEOUT_DEFAULT_SECONDS,
+        TASK_TIMEOUT_MIN_SECONDS,
+        TASK_TIMEOUT_MAX_SECONDS,
+    )
+    if not expired_bidding:
+        return
     for task in expired_bidding:
         if not db.expire_task_if_bidding(task["task_id"], now):
             continue
@@ -1032,6 +1049,11 @@ async def submit_task(
         raise HTTPException(status_code=400, detail="Insufficient SECONDS balance to pay for task")
     if task.bounty < 0 and not task.secret_data:
         raise HTTPException(status_code=400, detail="Data market tasks (bounty < 0) require secret_data")
+    if task.expires_in_seconds is not None:
+        task.expires_in_seconds = max(
+            TASK_TIMEOUT_MIN_SECONDS,
+            min(int(task.expires_in_seconds), TASK_TIMEOUT_MAX_SECONDS),
+        )
 
     task_id = str(uuid.uuid4())
     now = time.time()
@@ -1058,10 +1080,23 @@ async def submit_task(
         "status": "bidding",
         "target_node": task.target_node,
         "model_requirement": task.model_requirement,
+        "expires_in_seconds": task.expires_in_seconds,
         "payload_uri": normalized_payload_uri,
         "secret_data": task.secret_data
     }
-    db.create_task(task_id, task.consumer_id, payload, task.bounty, "bidding", task.target_node, task.model_requirement, now, result_payload=task.secret_data, payload_uri=normalized_payload_uri)
+    db.create_task(
+        task_id,
+        task.consumer_id,
+        payload,
+        task.bounty,
+        "bidding",
+        task.target_node,
+        task.model_requirement,
+        now,
+        result_payload=task.secret_data,
+        payload_uri=normalized_payload_uri,
+        expires_in_seconds=task.expires_in_seconds,
+    )
     async with task_lock:
         active_tasks[task_id] = task_data
 
@@ -1158,6 +1193,7 @@ async def cancel_task(
             "status": db_task["status"],
             "target_node": db_task["target_node"],
             "model_requirement": db_task["model_requirement"],
+            "expires_in_seconds": db_task.get("expires_in_seconds"),
             "provider_id": db_task["provider_id"],
             "payload_uri": db_task.get("payload_uri"),
             "secret_data": db_task.get("result_payload")

--- a/hub/models.py
+++ b/hub/models.py
@@ -11,6 +11,7 @@ class TaskCreate(BaseModel):
     bounty: float
     target_node: Optional[str] = None  # Direct messaging / specific bot targeting
     model_requirement: Optional[str] = None
+    expires_in_seconds: Optional[int] = Field(default=None, ge=1)
     secret_data: Optional[str] = None
     payload_uri: Optional[str] = None  # IPFS or HTTP link to payload
 

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -257,11 +257,6 @@ def tearDownModule():
     except OSError:
         pass
 
-
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestBiddingTimeout(unittest.TestCase):
     """Test bidding task timeout + refund flow"""
 
@@ -324,3 +319,55 @@ class TestBiddingTimeout(unittest.TestCase):
         resp = client.get(f"/balance/{consumer_id}")
         self.assertEqual(resp.json()["balance_seconds"], initial_balance,
                         "Consumer balance should be restored after refund")
+
+
+class TestConsumerDefinedTimeout(unittest.TestCase):
+    """Per-task consumer timeout should override global default within bounds."""
+
+    def test_consumer_timeout_expires_task_earlier(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+
+        resp = client.get(f"/balance/{consumer_id}")
+        initial_balance = resp.json()["balance_seconds"]
+
+        bounty = 1.0
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "Expire me quickly",
+            "bounty": bounty,
+            "expires_in_seconds": 60,
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+        task_id = resp.json()["task_id"]
+
+        # This is older than the consumer timeout (60s) but younger than global default (3600s).
+        old_time = time.time() - 120
+        conn = db._get_conn()
+        conn.execute(
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+            (old_time, task_id)
+        )
+        conn.commit()
+        db._release_conn(conn)
+
+        import asyncio
+        from main import _sweep_bidding_timeouts
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(_sweep_bidding_timeouts())
+        finally:
+            loop.close()
+
+        task = db.get_task(task_id)
+        self.assertIsNotNone(task)
+        self.assertEqual(task["status"], "expired")
+
+        resp = client.get(f"/balance/{consumer_id}")
+        self.assertEqual(resp.json()["balance_seconds"], initial_balance)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional per-task expires_in_seconds on TaskCreate
- store timeout policy on tasks (	asks.expires_in_seconds) with DB-safe column migration for sqlite/postgres
- apply consumer timeout in both assigned and bidding housekeeping sweeps using min/max/default guardrails
- keep existing refund semantics from PR #89 and add regression test for early expiry + refund

## Policy
- timeout source: consumer per task (expires_in_seconds)
- guardrails:
  - MEP_TASK_TIMEOUT_MIN_SECONDS (default 60)
  - MEP_TASK_TIMEOUT_MAX_SECONDS (default 86400)
  - MEP_TASK_TIMEOUT_DEFAULT_SECONDS (defaults to MEP_ASSIGNMENT_TIMEOUT_SECONDS, clamped to min/max)
- if consumer omits timeout, hub default applies

## Validation
- ran python tests/test_hub_api.py
- result: Ran 14 tests ... OK
