### PR TITLE
feat(hub): minimal real brainstorming session mode

### DIFF
--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -100,7 +100,70 @@ class MEPClient:
         )
         return {"status_code": response.status_code, "json": response.json()}
 
-    async def listen_results(self, on_result: Callable[[dict], Awaitable[None]]) -> None:
+    async def create_brainstorm_session(
+        self,
+        participants: list[str],
+        topic: Optional[str] = None,
+        max_messages: int = 200,
+    ) -> dict:
+        body: dict = {
+            "owner_id": self.node_id,
+            "participants": participants,
+            "max_messages": max_messages,
+        }
+        if topic:
+            body["topic"] = topic
+        payload_str = json.dumps(body)
+        headers = self._auth_headers(payload_str)
+        response = await asyncio.to_thread(
+            self.session.post,
+            f"{HUB_URL}/brainstorm/sessions/create",
+            data=payload_str,
+            headers=headers,
+            timeout=20,
+        )
+        return {"status_code": response.status_code, "json": response.json()}
+
+    async def post_brainstorm_message(
+        self,
+        session_id: str,
+        message: str,
+        reply_to_message_id: Optional[str] = None,
+    ) -> dict:
+        body: dict = {
+            "session_id": session_id,
+            "message": message,
+        }
+        if reply_to_message_id:
+            body["reply_to_message_id"] = reply_to_message_id
+        payload_str = json.dumps(body)
+        headers = self._auth_headers(payload_str)
+        response = await asyncio.to_thread(
+            self.session.post,
+            f"{HUB_URL}/brainstorm/sessions/post",
+            data=payload_str,
+            headers=headers,
+            timeout=20,
+        )
+        return {"status_code": response.status_code, "json": response.json()}
+
+    async def get_brainstorm_session(self, session_id: str, limit: int = 100) -> dict:
+        payload_str = ""
+        headers = self._auth_headers(payload_str)
+        response = await asyncio.to_thread(
+            self.session.get,
+            f"{HUB_URL}/brainstorm/sessions/{session_id}",
+            params={"limit": limit},
+            headers=headers,
+            timeout=20,
+        )
+        return {"status_code": response.status_code, "json": response.json()}
+
+    async def listen_results(
+        self,
+        on_result: Callable[[dict], Awaitable[None]],
+        on_event: Optional[Callable[[dict], Awaitable[None]]] = None,
+    ) -> None:
         while not self._stop.is_set():
             ts = str(int(time.time()))
             sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))
@@ -116,6 +179,8 @@ class MEPClient:
                             data = json.loads(msg)
                             if data.get("event") == "task_result":
                                 await on_result(data["data"])
+                            elif on_event is not None:
+                                await on_event(data)
                     finally:
                         if heartbeat_task:
                             heartbeat_task.cancel()

--- a/hub/main.py
+++ b/hub/main.py
@@ -19,7 +19,23 @@ import db
 import auth
 from logger import log_event, log_audit
 
-from models import NodeRegistration, TaskCreate, TaskResult, TaskBid, TaskCancel, RegistryUpdate, AvailabilityUpdate, RegistryHeartbeat, ReputationSubmit, DisputeOpen, DisputeResolve, FederationPeerUpsert, MeshAssembleRequest
+from models import (
+    NodeRegistration,
+    TaskCreate,
+    TaskResult,
+    TaskBid,
+    TaskCancel,
+    RegistryUpdate,
+    AvailabilityUpdate,
+    RegistryHeartbeat,
+    ReputationSubmit,
+    DisputeOpen,
+    DisputeResolve,
+    FederationPeerUpsert,
+    MeshAssembleRequest,
+    BrainstormSessionCreate,
+    BrainstormSessionPost,
+)
 
 app = FastAPI(title="MEP Hub", description="The Time Exchange Clearinghouse", version="0.1.2")
 
@@ -32,8 +48,10 @@ task_lock = asyncio.Lock()
 node_lock = asyncio.Lock()
 mesh_lock = asyncio.Lock()
 anti_loop_lock = asyncio.Lock()
+brainstorm_lock = asyncio.Lock()
 mesh_assemblies: Dict[str, dict] = {}
 anti_loop_channels: Dict[str, dict] = {}
+brainstorm_sessions: Dict[str, dict] = {}
 MAX_BODY_BYTES = 200_000
 MAX_PAYLOAD_CHARS = 20_000
 RATE_LIMIT_WINDOW = 10.0
@@ -443,6 +461,22 @@ async def _anti_loop_check_and_record(consumer_id: str, target_node: str, payloa
                 status_code=429,
                 detail=f"Anti-loop circuit break triggered for {channel}; cooldown {ANTI_LOOP_COOLDOWN_SECONDS}s",
             )
+
+
+def _normalize_brainstorm_participants(owner_id: str, participants: list[str]) -> list[str]:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for raw in participants:
+        node_id = str(raw or "").strip()
+        if not node_id:
+            continue
+        if node_id not in seen:
+            cleaned.append(node_id)
+            seen.add(node_id)
+    if owner_id not in seen:
+        cleaned.append(owner_id)
+        seen.add(owner_id)
+    return cleaned
 
 
 def _normalize_mesh_trigger(value: str) -> str:
@@ -1250,6 +1284,156 @@ async def mesh_status(assembly_id: str, authenticated_node: str = Depends(verify
         if unresolved:
             response["degraded_warning"] = f"Unfilled role(s): {', '.join(unresolved)}"
     return response
+
+
+@app.post("/brainstorm/sessions/create")
+async def brainstorm_create(
+    payload: BrainstormSessionCreate,
+    authenticated_node: str = Depends(verify_request),
+):
+    if authenticated_node != payload.owner_id:
+        raise HTTPException(status_code=403, detail="Cannot create session for another node")
+    participants = _normalize_brainstorm_participants(payload.owner_id, payload.participants)
+    if len(participants) < 2:
+        raise HTTPException(status_code=400, detail="Brainstorm session requires at least 2 participants")
+    now = time.time()
+    session_id = str(uuid.uuid4())
+    session = {
+        "session_id": session_id,
+        "owner_id": payload.owner_id,
+        "participants": participants,
+        "topic": (payload.topic or "").strip(),
+        "created_at": now,
+        "updated_at": now,
+        "status": "active",
+        "max_messages": int(payload.max_messages or 200),
+        "messages": [],
+        "message_seq": 0,
+    }
+    async with brainstorm_lock:
+        brainstorm_sessions[session_id] = session
+    log_event(
+        "brainstorm_session_created",
+        f"Brainstorm session {session_id[:8]} created by {payload.owner_id}",
+        session_id=session_id,
+        owner_id=payload.owner_id,
+        participant_count=len(participants),
+    )
+    return {
+        "status": "success",
+        "session_id": session_id,
+        "owner_id": payload.owner_id,
+        "participants": participants,
+        "topic": session["topic"],
+    }
+
+
+@app.post("/brainstorm/sessions/post")
+async def brainstorm_post(
+    payload: BrainstormSessionPost,
+    authenticated_node: str = Depends(verify_request),
+):
+    async with brainstorm_lock:
+        session = brainstorm_sessions.get(payload.session_id)
+        if not session or session.get("status") != "active":
+            raise HTTPException(status_code=404, detail="Brainstorm session not found or inactive")
+        participants = list(session.get("participants", []))
+        if authenticated_node not in participants:
+            raise HTTPException(status_code=403, detail="Node is not a participant of this session")
+        max_messages = int(session.get("max_messages", 200))
+        if len(session["messages"]) >= max_messages:
+            raise HTTPException(status_code=400, detail="Brainstorm session reached max messages")
+        message_id = f"{payload.session_id}:{int(session.get('message_seq', 0)) + 1}"
+        message = {
+            "message_id": message_id,
+            "session_id": payload.session_id,
+            "sender_id": authenticated_node,
+            "content": payload.message.strip(),
+            "reply_to_message_id": payload.reply_to_message_id,
+            "created_at": time.time(),
+        }
+        session["message_seq"] = int(session.get("message_seq", 0)) + 1
+        session["messages"].append(message)
+        session["updated_at"] = message["created_at"]
+
+    fanout_payload = {
+        "event": "brainstorm_message",
+        "data": {
+            "session_id": payload.session_id,
+            "topic": session.get("topic"),
+            "message": message,
+            "participants": participants,
+        },
+    }
+    delivered_to: list[str] = []
+    async with node_lock:
+        participant_sockets = [(node_id, connected_nodes.get(node_id)) for node_id in participants]
+    for node_id, ws in participant_sockets:
+        if not ws:
+            continue
+        try:
+            await ws.send_json(fanout_payload)
+            delivered_to.append(node_id)
+        except Exception as exc:
+            log_event(
+                "brainstorm_fanout_failed",
+                f"Failed fanout for session {payload.session_id[:8]} to {node_id}: {exc}",
+                session_id=payload.session_id,
+                node_id=node_id,
+            )
+            async with node_lock:
+                if connected_nodes.get(node_id) is ws:
+                    del connected_nodes[node_id]
+    return {"status": "success", "message_id": message_id, "delivered_to": delivered_to}
+
+
+@app.get("/brainstorm/sessions/{session_id}")
+async def brainstorm_get_session(
+    session_id: str,
+    limit: int = 100,
+    authenticated_node: str = Depends(verify_request),
+):
+    safe_limit = max(1, min(limit, 500))
+    async with brainstorm_lock:
+        session = brainstorm_sessions.get(session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Brainstorm session not found")
+        if authenticated_node not in session.get("participants", []):
+            raise HTTPException(status_code=403, detail="Node is not a participant of this session")
+        messages = list(session.get("messages", []))
+        payload = {
+            "session_id": session["session_id"],
+            "owner_id": session["owner_id"],
+            "participants": list(session.get("participants", [])),
+            "topic": session.get("topic"),
+            "status": session.get("status"),
+            "created_at": session.get("created_at"),
+            "updated_at": session.get("updated_at"),
+            "message_count": len(messages),
+            "messages": messages[-safe_limit:],
+        }
+    return payload
+
+
+@app.get("/brainstorm/sessions")
+async def brainstorm_list_sessions(authenticated_node: str = Depends(verify_request)):
+    now = time.time()
+    async with brainstorm_lock:
+        sessions = [
+            {
+                "session_id": session["session_id"],
+                "owner_id": session["owner_id"],
+                "participants": list(session.get("participants", [])),
+                "topic": session.get("topic"),
+                "status": session.get("status"),
+                "updated_at": session.get("updated_at"),
+                "message_count": len(session.get("messages", [])),
+            }
+            for session in brainstorm_sessions.values()
+            if authenticated_node in session.get("participants", [])
+        ]
+    sessions.sort(key=lambda item: float(item.get("updated_at") or now), reverse=True)
+    return {"count": len(sessions), "sessions": sessions}
 
 @app.get("/federation/peers")
 async def get_federation_peers():

--- a/hub/models.py
+++ b/hub/models.py
@@ -69,7 +69,7 @@ class MeshAssembleRequest(BaseModel):
 
 class BrainstormSessionCreate(BaseModel):
     owner_id: str
-    participants: List[str] = Field(..., min_length=2)
+    participants: List[str] = Field(..., min_length=1)
     topic: Optional[str] = None
     max_messages: Optional[int] = Field(default=200, ge=10, le=2000)
 

--- a/hub/models.py
+++ b/hub/models.py
@@ -65,3 +65,16 @@ class FederationPeerUpsert(BaseModel):
 class MeshAssembleRequest(BaseModel):
     trigger: str
     timeout_seconds: Optional[int] = Field(default=300, ge=1, le=3600)
+
+
+class BrainstormSessionCreate(BaseModel):
+    owner_id: str
+    participants: List[str] = Field(..., min_length=2)
+    topic: Optional[str] = None
+    max_messages: Optional[int] = Field(default=200, ge=10, le=2000)
+
+
+class BrainstormSessionPost(BaseModel):
+    session_id: str
+    message: str = Field(..., min_length=1, max_length=5000)
+    reply_to_message_id: Optional[str] = None

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -396,6 +396,68 @@ class TestMeshAssembly(unittest.TestCase):
         )
 
 
+class TestBrainstormSessions(unittest.TestCase):
+    def setUp(self):
+        main.brainstorm_sessions.clear()
+
+    def test_create_post_and_read_session(self):
+        owner_priv, owner_pub, owner_id = _make_identity()
+        p1_priv, p1_pub, p1_id = _make_identity()
+        p2_priv, p2_pub, p2_id = _make_identity()
+        _register(owner_pub)
+        _register(p1_pub)
+        _register(p2_pub)
+
+        create_payload = json.dumps(
+            {
+                "owner_id": owner_id,
+                "participants": [p1_id, p2_id],
+                "topic": "Loop-free architecture",
+            }
+        )
+        create_headers = _auth_headers(owner_priv, owner_id, create_payload)
+        create_resp = client.post("/brainstorm/sessions/create", content=create_payload, headers=create_headers)
+        self.assertEqual(create_resp.status_code, 200, f"Create failed: {create_resp.text}")
+        session_id = create_resp.json()["session_id"]
+
+        post_payload = json.dumps(
+            {
+                "session_id": session_id,
+                "message": "I suggest we add a shared session timeline.",
+            }
+        )
+        post_headers = _auth_headers(p1_priv, p1_id, post_payload)
+        post_resp = client.post("/brainstorm/sessions/post", content=post_payload, headers=post_headers)
+        self.assertEqual(post_resp.status_code, 200, f"Post failed: {post_resp.text}")
+
+        get_headers = _auth_headers(p2_priv, p2_id, "")
+        get_resp = client.get(f"/brainstorm/sessions/{session_id}", headers=get_headers)
+        self.assertEqual(get_resp.status_code, 200, f"Get failed: {get_resp.text}")
+        data = get_resp.json()
+        self.assertEqual(data["topic"], "Loop-free architecture")
+        self.assertEqual(data["message_count"], 1)
+        self.assertEqual(data["messages"][0]["sender_id"], p1_id)
+
+    def test_non_participant_cannot_post(self):
+        owner_priv, owner_pub, owner_id = _make_identity()
+        p1_priv, p1_pub, p1_id = _make_identity()
+        outsider_priv, outsider_pub, outsider_id = _make_identity()
+        _register(owner_pub)
+        _register(p1_pub)
+        _register(outsider_pub)
+
+        create_payload = json.dumps({"owner_id": owner_id, "participants": [p1_id]})
+        create_headers = _auth_headers(owner_priv, owner_id, create_payload)
+        create_resp = client.post("/brainstorm/sessions/create", content=create_payload, headers=create_headers)
+        self.assertEqual(create_resp.status_code, 200)
+        session_id = create_resp.json()["session_id"]
+
+        post_payload = json.dumps({"session_id": session_id, "message": "Intruding message"})
+        post_headers = _auth_headers(outsider_priv, outsider_id, post_payload)
+        post_resp = client.post("/brainstorm/sessions/post", content=post_payload, headers=post_headers)
+        self.assertEqual(post_resp.status_code, 403)
+
+
 def tearDownModule():
     """Clean up test database."""
     try:


### PR DESCRIPTION
## Summary
- add shared brainstorming sessions on Hub with participant auth
- add message posting + websocket fan-out to session participants
- add session read/list APIs for transcript access
- add client helpers for create/post/get session and generic event callback
- add focused API tests for create/post/read and participant authorization

## Why
This enables a real multi-bot brainstorming thread with shared context instead of isolated DM chains.

## Validation
- python -m pytest -q tests/test_hub_api.py