### PR TITLE
security: encrypt identity keys at rest + add regression tests

### DIFF
--- a/clients/shared/identity.py
+++ b/clients/shared/identity.py
@@ -13,6 +13,16 @@ def _derive_node_id(pub_pem: str) -> str:
     sha = hashlib.sha256(pub_pem.encode("utf-8")).hexdigest()
     return f"node_{sha[:12]}"
 
+ 
+def _identity_password_from_env() -> bytes | None:
+    raw = os.getenv("MEP_IDENTITY_KEY_PASSWORD") or os.getenv("MEP_KEY_PASSWORD")
+    if raw is None:
+        return None
+    value = raw.strip()
+    if not value:
+        return None
+    return value.encode("utf-8")
+
 
 @dataclass
 class MEPIdentity:
@@ -28,26 +38,37 @@ class MEPIdentity:
         if os.path.exists(key_path):
             with open(key_path, "rb") as f:
                 data = f.read()
-            if b"ENCRYPTED" not in data:
+            password = _identity_password_from_env()
+            is_encrypted = b"ENCRYPTED" in data
+            if not is_encrypted:
                 warnings.warn(
                     "MEP identity key is stored unencrypted at rest. Protect this file with strict filesystem permissions.",
                     RuntimeWarning,
                     stacklevel=2,
                 )
-            key = serialization.load_pem_private_key(data, password=None)
+            elif password is None:
+                raise ValueError(
+                    "Encrypted MEP identity key requires MEP_IDENTITY_KEY_PASSWORD (or MEP_KEY_PASSWORD)."
+                )
+            key = serialization.load_pem_private_key(data, password=password if is_encrypted else None)
             if not isinstance(key, ed25519.Ed25519PrivateKey):
                 raise ValueError("Unsupported private key type")
             return key
         key = ed25519.Ed25519PrivateKey.generate()
+        password = _identity_password_from_env()
+        if password is None:
+            encryption = serialization.NoEncryption()
+            warnings.warn(
+                "Generating unencrypted MEP identity key. Set MEP_IDENTITY_KEY_PASSWORD for encrypted at-rest key storage.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        else:
+            encryption = serialization.BestAvailableEncryption(password)
         pem = key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-        warnings.warn(
-            "Generating unencrypted MEP identity key. Use strict filesystem permissions or switch to encrypted-key handling for production.",
-            RuntimeWarning,
-            stacklevel=2,
+            encryption_algorithm=encryption,
         )
         with open(key_path, "wb") as f:
             f.write(pem)

--- a/tests/test_identity_key_encryption.py
+++ b/tests/test_identity_key_encryption.py
@@ -1,0 +1,41 @@
+import warnings
+
+import pytest
+
+from clients.shared.identity import MEPIdentity
+
+
+def test_creates_encrypted_key_when_password_is_set(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MEP_IDENTITY_KEY_PASSWORD", "super-secret-pass")
+    key_path = tmp_path / "identity.pem"
+
+    identity = MEPIdentity(str(key_path))
+
+    pem = key_path.read_bytes()
+    assert b"ENCRYPTED" in pem
+    assert identity.node_id.startswith("node_")
+
+
+def test_loading_encrypted_key_requires_password(tmp_path, monkeypatch) -> None:
+    key_path = tmp_path / "identity.pem"
+    monkeypatch.setenv("MEP_IDENTITY_KEY_PASSWORD", "super-secret-pass")
+    MEPIdentity(str(key_path))
+
+    monkeypatch.delenv("MEP_IDENTITY_KEY_PASSWORD", raising=False)
+    monkeypatch.delenv("MEP_KEY_PASSWORD", raising=False)
+
+    with pytest.raises(ValueError, match="Encrypted MEP identity key requires"):
+        MEPIdentity(str(key_path))
+
+
+def test_legacy_unencrypted_key_still_loads_with_warning(tmp_path, monkeypatch) -> None:
+    key_path = tmp_path / "identity.pem"
+    monkeypatch.delenv("MEP_IDENTITY_KEY_PASSWORD", raising=False)
+    monkeypatch.delenv("MEP_KEY_PASSWORD", raising=False)
+    MEPIdentity(str(key_path))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        MEPIdentity(str(key_path))
+
+    assert any("stored unencrypted at rest" in str(item.message) for item in caught)


### PR DESCRIPTION
## Summary\n- encrypt newly generated identity private keys at rest when MEP_IDENTITY_KEY_PASSWORD (fallback MEP_KEY_PASSWORD) is set\n- require password for loading encrypted key files\n- keep backward compatibility for legacy unencrypted keys with explicit warning\n- add focused tests for encrypted write/load and legacy compatibility\n\n## Security Context\n- addresses code review finding: plaintext private key storage in identity handling\n\n## Validation\n- python -m pytest tests/test_identity_key_encryption.py -q\n- result: 3 passed