### PR TITLE
ci: dedupe PR-triggered runs and keep valid workflow structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/**
-      - security/**
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary\n- dedupe CI runs by scoping push trigger to main only\n- keep PR validation on main and eat/** via pull_request trigger\n- preserve existing lint + protocol-core test matrix\n- ensure workflow remains valid with explicit jobs.test key\n\n## Why\n- avoids duplicate check runs on PR branches while keeping required protection checks\n\n## Behavior\n- PRs into eat/** or main: one CI run (from pull_request)\n- direct pushes to main: CI still runs\n- direct pushes to non-main branches: no duplicate push CI