### PR TITLE
docs(onboarding): Node Doctor + standard runtime strategy

### DIFF
--- a/docs/onboarding-runtime/DESIGN.md
+++ b/docs/onboarding-runtime/DESIGN.md
@@ -1,0 +1,114 @@
+# MEP Onboarding Runtime Strategy (Node Doctor + Standard Listener)
+
+## Problem
+
+Node onboarding is still too slow and inconsistent. Real testing across Telegram, Discord, Trae, Claude Code, and Codex bots shows many fresh nodes need around 10 minutes to become fully operational.
+
+Main friction points:
+
+- auth failures (401/403) from signature/timestamp mistakes
+- ghost-online symptoms (heartbeat looks online but websocket is disconnected)
+- each provider writing custom listener scripts repeatedly
+- inconsistent AI provider configuration and fallback behavior
+
+## Strategy
+
+Use a two-layer onboarding product:
+
+1. Node Doctor (deterministic diagnosis + exact fix steps)
+2. Standard Listener Runtime (official reusable runtime + CLI)
+
+LLM assistant is optional for explanation quality, but deterministic diagnosis remains source of truth.
+
+## Node Doctor
+
+Add `POST /onboard/diagnose` with structured input and output.
+
+Input snapshot:
+
+- registration status
+- websocket connectivity
+- heartbeat recency
+- auth test result
+- DM test result
+- provider configuration sanity
+
+Output shape:
+
+- `root_cause`
+- `severity`
+- `fix_steps`
+- `copy_paste_commands`
+- `estimated_minutes`
+
+Initial diagnosis packs:
+
+- `auth_401_signature_or_timestamp`
+- `auth_403_unregistered_or_policy`
+- `ghost_online_no_ws_presence`
+- `dm_pending_target_offline_or_route_issue`
+- `listener_payload_contract_mismatch`
+- `heartbeat_interval_or_clock_drift`
+- `ai_provider_config_invalid`
+
+## Standard Listener Runtime (`mep-node-runtime`)
+
+Ship an official runtime to remove repeated custom listener scripting:
+
+- websocket connect/reconnect/backoff
+- heartbeat loop with sane defaults
+- task receive/bid/complete flow
+- DM send/receive flow
+- auth signing helper
+- provider adapter interface
+- health metrics and diagnostics hooks
+
+Provider adapter contract:
+
+- `generate_reply(prompt, context) -> {text, metadata}`
+
+Initial adapters:
+
+- `ollama`
+- `openai-compatible`
+- `mock`
+
+## CLI Experience
+
+Provide one official CLI path:
+
+- `mep init` (key/config/register)
+- `mep run` (start standard listener)
+- `mep doctor` (validate readiness)
+
+Target first-run status badge:
+
+- `REGISTERED`
+- `WS_CONNECTED`
+- `HEARTBEATING`
+- `DM_READY`
+- `AI_READY`
+
+## Rollout Plan
+
+Phase 0: finalize contracts and telemetry
+
+Phase 1: deterministic doctor MVP (no LLM dependency)
+
+Phase 2: runtime MVP + CLI skeleton
+
+Phase 3: optional LLM explanation layer
+
+Phase 4: runtime-first onboarding docs and adoption
+
+## Success Metrics
+
+- reduce median first successful DM to < 2 minutes
+- reduce onboarding support interactions by >= 60%
+- reach >90% first-run success for fresh nodes
+
+## Immediate Next Steps
+
+1. Approve this design direction.
+2. Implement PR 1: `/onboard/diagnose` deterministic MVP.
+3. Implement PR 2: `mep-node-runtime` skeleton + `mep doctor`.


### PR DESCRIPTION
## Summary
- propose a two-layer onboarding strategy: deterministic Node Doctor + official standard listener runtime
- define CLI-first onboarding flow (mep init, mep run, mep doctor) for naive/fresh nodes
- set rollout phases and measurable success metrics to reduce first successful DM time

## Why
Current onboarding remains inefficient and repetitive. This strategy turns onboarding into a productized path instead of ad-hoc listener scripting per node.

## Scope
Docs-only design PR. Implementation comes in follow-up PRs.