### PR TITLE
feat(node): 2-minute onboarding runtime (init/run/status/doctor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ Want a guided first run that registers a node and submits starter tasks?
 python -m skills.quickstart_provider
 ```
 
+Need the fastest "fresh node" path (about 2 minutes)?
+
+```bash
+python -m node.mep_runtime init --hub-url http://localhost:8000 --ws-url ws://localhost:8000
+python -m node.mep_runtime status --hub-url http://localhost:8000
+python -m node.mep_runtime doctor --hub-url http://localhost:8000
+python -m node.mep_runtime run --hub-url http://localhost:8000 --ws-url ws://localhost:8000
+```
+
 </details>
 
 <a id="option-2-use-client-adapters"></a>

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Unified node runtime for fast onboarding (`init`, `run`, `status`, `doctor`)."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import time
+import urllib.parse
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import requests
+import websockets
+
+try:
+    from node.identity import MEPIdentity
+except ImportError:  # pragma: no cover - supports direct file execution
+    from identity import MEPIdentity
+
+
+DEFAULT_HUB_URL = os.getenv("HUB_URL", "http://localhost:8000")
+DEFAULT_WS_URL = os.getenv("WS_URL", "ws://localhost:8000")
+DEFAULT_KEY_DIR = os.getenv("MEP_KEY_DIR", os.path.join(os.path.expanduser("~"), ".mep"))
+DEFAULT_KEY_PATH = os.getenv("MEP_PROVIDER_KEY_PATH", os.path.join(DEFAULT_KEY_DIR, "mep_runtime.pem"))
+
+
+def _ensure_key_parent(path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+
+
+def _json_or_none(resp: requests.Response) -> Optional[dict[str, Any]]:
+    try:
+        return resp.json()
+    except ValueError:
+        return None
+
+
+def _safe_request(
+    method: str,
+    url: str,
+    *,
+    timeout: float = 10.0,
+    json_body: Optional[dict[str, Any]] = None,
+    data_body: Optional[str] = None,
+    headers: Optional[dict[str, str]] = None,
+) -> tuple[int, Optional[dict[str, Any]], str]:
+    try:
+        resp = requests.request(
+            method=method,
+            url=url,
+            timeout=timeout,
+            json=json_body,
+            data=data_body,
+            headers=headers,
+        )
+        body = _json_or_none(resp)
+        raw = resp.text[:500]
+        return resp.status_code, body, raw
+    except requests.RequestException as exc:
+        return 0, None, str(exc)
+
+
+def _status_badges(diag: dict[str, Any], *, ai_ready: bool) -> dict[str, bool]:
+    registered = bool(diag.get("registered"))
+    ws_connected = bool(diag.get("ws_connected"))
+    availability = str(diag.get("availability") or "").strip().lower()
+    live_availability = availability in {"online", "idle", "busy"}
+    return {
+        "REGISTERED": registered,
+        "WS_CONNECTED": ws_connected,
+        "HEARTBEATING": bool(diag.get("last_heartbeat")),
+        "DM_READY": live_availability and ws_connected,
+        "AI_READY": ai_ready,
+    }
+
+
+def _heartbeat_seconds_ago(diag: dict[str, Any]) -> Optional[float]:
+    last_heartbeat = diag.get("last_heartbeat")
+    if last_heartbeat is None:
+        return None
+    try:
+        return max(0.0, time.time() - float(last_heartbeat))
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_doctor_snapshot(
+    *,
+    node_id: str,
+    diag: dict[str, Any],
+    auth_status: str,
+    dm_status: str,
+    listener_contract_ok: Optional[bool],
+    ai_configured: bool,
+    clock_skew_seconds: Optional[float],
+) -> dict[str, Any]:
+    return {
+        "node_id": node_id,
+        "registered": bool(diag.get("registered")),
+        "ws_connected": bool(diag.get("ws_connected")),
+        "heartbeat_seconds_ago": _heartbeat_seconds_ago(diag),
+        "auth_status": auth_status,
+        "dm_status": dm_status,
+        "listener_contract_ok": listener_contract_ok,
+        "ai_configured": ai_configured,
+        "clock_skew_seconds": clock_skew_seconds,
+    }
+
+
+@dataclass
+class MockAdapter:
+    """Deterministic adapter used as default for fast, stable onboarding."""
+
+    def generate_reply(self, payload: str, task_data: dict[str, Any]) -> str:
+        snippet = (payload or "").strip().replace("\n", " ")[:120]
+        if not snippet:
+            snippet = "<empty>"
+        task_id = str(task_data.get("id", ""))[:8]
+        return (
+            "MOCK_ADAPTER_OK\n"
+            f"task={task_id}\n"
+            f"summary={snippet}\n"
+            "next=Switch adapter to ollama/openai-compatible after doctor is green."
+        )
+
+
+class RuntimeNode:
+    def __init__(self, identity: MEPIdentity, hub_url: str, ws_url: str, adapter: MockAdapter):
+        self.identity = identity
+        self.node_id = identity.node_id
+        self.hub_url = hub_url.rstrip("/")
+        self.ws_url = ws_url.rstrip("/")
+        self.adapter = adapter
+        self.running = True
+
+    def _auth_headers(self, payload: str) -> dict[str, str]:
+        headers = self.identity.get_auth_headers(payload)
+        headers["Content-Type"] = "application/json"
+        return headers
+
+    def register(self, alias: Optional[str]) -> tuple[bool, str]:
+        payload = {"pubkey": self.identity.pub_pem}
+        if alias:
+            payload["alias"] = alias
+        code, body, raw = _safe_request("POST", f"{self.hub_url}/register", json_body=payload)
+        if code == 200 and body:
+            return True, f"registered node_id={body.get('node_id', self.node_id)} balance={body.get('balance')}"
+        return False, f"register failed status={code} detail={raw}"
+
+    def bid(self, task_id: str) -> None:
+        payload = json.dumps({"task_id": task_id, "provider_id": self.node_id})
+        code, _body, raw = _safe_request(
+            "POST",
+            f"{self.hub_url}/tasks/bid",
+            data_body=payload,
+            headers=self._auth_headers(payload),
+            timeout=15.0,
+        )
+        if code != 200:
+            print(f"[mep run] bid failed task={task_id[:8]} status={code} detail={raw}")
+
+    def complete(self, task_id: str, result_payload: str) -> None:
+        payload = json.dumps(
+            {
+                "task_id": task_id,
+                "provider_id": self.node_id,
+                "result_payload": result_payload,
+            }
+        )
+        code, _body, raw = _safe_request(
+            "POST",
+            f"{self.hub_url}/tasks/complete",
+            data_body=payload,
+            headers=self._auth_headers(payload),
+            timeout=20.0,
+        )
+        if code == 200:
+            print(f"[mep run] completed task={task_id[:8]}")
+        else:
+            print(f"[mep run] complete failed task={task_id[:8]} status={code} detail={raw}")
+
+    async def process_task(self, task_data: dict[str, Any]) -> None:
+        task_id = str(task_data.get("id") or "")
+        payload = str(task_data.get("payload") or "")
+        result = self.adapter.generate_reply(payload, task_data)
+        self.complete(task_id, result)
+
+    def _ws_uri(self) -> str:
+        ts = str(int(time.time()))
+        sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))
+        return f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
+
+    async def run_forever(self) -> int:
+        ok, message = self.register(alias="mep-runtime")
+        print(f"[mep run] {message}")
+        if not ok:
+            return 2
+        while self.running:
+            uri = self._ws_uri()
+            try:
+                async with websockets.connect(uri) as ws:
+                    print(f"[mep run] connected ws node={self.node_id}")
+                    while self.running:
+                        msg = await asyncio.wait_for(ws.recv(), timeout=20.0)
+                        data = json.loads(msg)
+                        event = data.get("event")
+                        if event == "rfc":
+                            task = data.get("data", {})
+                            task_id = str(task.get("id") or "")
+                            if task_id:
+                                self.bid(task_id)
+                        elif event == "new_task":
+                            await self.process_task(data.get("data", {}))
+            except asyncio.TimeoutError:
+                continue
+            except KeyboardInterrupt:
+                self.running = False
+            except Exception as exc:  # noqa: BLE001
+                print(f"[mep run] websocket reconnect after error: {exc}")
+                await asyncio.sleep(3.0)
+        return 0
+
+
+def _print_badges(badges: dict[str, bool]) -> None:
+    parts = [f"{name}={'OK' if status else 'FAIL'}" for name, status in badges.items()]
+    print("[mep status] " + " | ".join(parts))
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    _ensure_key_parent(args.key_path)
+    identity = MEPIdentity(args.key_path)
+    print(f"[mep init] node_id={identity.node_id}")
+    if identity.generated_new_key:
+        print(f"[mep init] generated key={identity.key_path}")
+    payload = {"pubkey": identity.pub_pem, "alias": args.alias}
+    code, body, raw = _safe_request("POST", f"{args.hub_url.rstrip('/')}/register", json_body=payload)
+    if code != 200:
+        print(f"[mep init] register failed status={code} detail={raw}")
+        return 2
+    print(f"[mep init] register ok balance={body.get('balance') if body else '?'}")
+    status_args = argparse.Namespace(
+        hub_url=args.hub_url,
+        key_path=args.key_path,
+        adapter=args.adapter,
+        require_online=False,
+    )
+    return cmd_status(status_args)
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    identity = MEPIdentity(args.key_path)
+    node_id = identity.node_id
+    url = f"{args.hub_url.rstrip('/')}/diagnostic?node_id={node_id}"
+    code, body, raw = _safe_request("GET", url)
+    if code != 200 or not body:
+        print(f"[mep status] diagnostic failed status={code} detail={raw}")
+        return 2
+    badges = _status_badges(body, ai_ready=args.adapter == "mock")
+    _print_badges(badges)
+    if args.require_online:
+        return 0 if all(badges.values()) else 1
+    return 0
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    identity = MEPIdentity(args.key_path)
+    node_id = identity.node_id
+    diag_url = f"{args.hub_url.rstrip('/')}/diagnostic?node_id={node_id}"
+    code, diag, raw = _safe_request("GET", diag_url)
+    if code != 200 or not diag:
+        print(f"[mep doctor] diagnostic failed status={code} detail={raw}")
+        return 2
+
+    snapshot = _build_doctor_snapshot(
+        node_id=node_id,
+        diag=diag,
+        auth_status=args.auth_status,
+        dm_status=args.dm_status,
+        listener_contract_ok=args.listener_contract_ok,
+        ai_configured=args.adapter == "mock",
+        clock_skew_seconds=args.clock_skew_seconds,
+    )
+    code, result, raw = _safe_request(
+        "POST",
+        f"{args.hub_url.rstrip('/')}/onboard/diagnose",
+        json_body=snapshot,
+    )
+    if code != 200 or not result:
+        print(f"[mep doctor] diagnose failed status={code} detail={raw}")
+        return 2
+
+    print(f"[mep doctor] root_cause={result.get('root_cause')} severity={result.get('severity')}")
+    for step in result.get("fix_steps", []):
+        print(f"  - {step}")
+    for cmd in result.get("copy_paste_commands", []):
+        print(f"  $ {cmd}")
+    telemetry = result.get("telemetry") or {}
+    if telemetry:
+        print(
+            f"[mep doctor] telemetry total={telemetry.get('total_requests')} "
+            f"root_cause_count={telemetry.get('root_cause_count')}"
+        )
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    if args.adapter != "mock":
+        print("[mep run] only adapter=mock is supported in this phase")
+        return 2
+    _ensure_key_parent(args.key_path)
+    identity = MEPIdentity(args.key_path)
+    runtime = RuntimeNode(identity=identity, hub_url=args.hub_url, ws_url=args.ws_url, adapter=MockAdapter())
+    print(f"[mep run] adapter=mock node_id={identity.node_id}")
+    try:
+        return asyncio.run(runtime.run_forever())
+    except KeyboardInterrupt:
+        print("[mep run] stopped by user")
+        return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="MEP unified runtime for fast onboarding.")
+    parser.add_argument("--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL.")
+    parser.add_argument("--ws-url", default=DEFAULT_WS_URL, help="Hub websocket URL.")
+    parser.add_argument("--key-path", default=DEFAULT_KEY_PATH, help="Path to provider private key.")
+    parser.add_argument("--adapter", default="mock", choices=["mock"], help="Provider adapter.")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    init_p = sub.add_parser("init", help="Generate/load key and register node.")
+    init_p.add_argument("--alias", default="mep-runtime", help="Node alias for registration.")
+    init_p.set_defaults(func=cmd_init)
+
+    run_p = sub.add_parser("run", help="Run standardized listener runtime.")
+    run_p.set_defaults(func=cmd_run)
+
+    status_p = sub.add_parser("status", help="Show quick node readiness badges.")
+    status_p.add_argument("--require-online", action="store_true", help="Return non-zero unless all badges pass.")
+    status_p.set_defaults(func=cmd_status)
+
+    doctor_p = sub.add_parser("doctor", help="Run onboarding diagnostics against Hub.")
+    doctor_p.add_argument("--auth-status", default="ok", help="Override auth status signal.")
+    doctor_p.add_argument("--dm-status", default="ok", help="Override DM status signal.")
+    doctor_p.add_argument(
+        "--listener-contract-ok",
+        dest="listener_contract_ok",
+        action="store_true",
+        default=None,
+        help="Set listener contract signal to true.",
+    )
+    doctor_p.add_argument(
+        "--listener-contract-bad",
+        dest="listener_contract_ok",
+        action="store_false",
+        help="Set listener contract signal to false.",
+    )
+    doctor_p.add_argument("--clock-skew-seconds", type=float, default=None, help="Override local clock skew.")
+    doctor_p.set_defaults(func=cmd_doctor)
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 import requests
-import websockets
 
 try:
     from node.identity import MEPIdentity
@@ -194,6 +193,13 @@ class RuntimeNode:
         return f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
 
     async def run_forever(self) -> int:
+        try:
+            import websockets  # type: ignore
+        except ImportError:
+            print("[mep run] missing optional dependency: websockets")
+            print("[mep run] install with: pip install websockets")
+            return 2
+
         ok, message = self.register(alias="mep-runtime")
         print(f"[mep run] {message}")
         if not ok:

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -1,0 +1,106 @@
+import argparse
+import unittest
+from unittest.mock import patch
+
+from node import mep_runtime
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, json_data=None, text=""):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.text = text
+
+    def json(self):
+        if self._json_data is None:
+            raise ValueError("no json")
+        return self._json_data
+
+
+class TestNodeRuntimeHelpers(unittest.TestCase):
+    def test_status_badges_all_ok(self):
+        badges = mep_runtime._status_badges(
+            {"registered": True, "ws_connected": True, "last_heartbeat": 123.0, "availability": "online"},
+            ai_ready=True,
+        )
+        self.assertTrue(all(badges.values()))
+
+    def test_build_doctor_snapshot_includes_heartbeat_delta(self):
+        with patch("node.mep_runtime.time.time", return_value=1000.0):
+            snapshot = mep_runtime._build_doctor_snapshot(
+                node_id="node_1",
+                diag={"registered": True, "ws_connected": False, "last_heartbeat": 900.0},
+                auth_status="ok",
+                dm_status="ok",
+                listener_contract_ok=True,
+                ai_configured=True,
+                clock_skew_seconds=2.5,
+            )
+        self.assertEqual(snapshot["node_id"], "node_1")
+        self.assertEqual(snapshot["heartbeat_seconds_ago"], 100.0)
+        self.assertFalse(snapshot["ws_connected"])
+        self.assertEqual(snapshot["clock_skew_seconds"], 2.5)
+
+    def test_mock_adapter_is_deterministic(self):
+        adapter = mep_runtime.MockAdapter()
+        out = adapter.generate_reply("hello world", {"id": "123456789"})
+        self.assertIn("MOCK_ADAPTER_OK", out)
+        self.assertIn("task=12345678", out)
+        self.assertIn("summary=hello world", out)
+
+
+class TestNodeRuntimeCommands(unittest.TestCase):
+    def test_status_command_success(self):
+        args = argparse.Namespace(
+            hub_url="http://hub",
+            key_path="C:/tmp/test_key.pem",
+            adapter="mock",
+            require_online=False,
+        )
+        diag = {"registered": True, "ws_connected": True, "last_heartbeat": 100.0, "availability": "online"}
+        with (
+            patch("node.mep_runtime.MEPIdentity") as identity_cls,
+            patch("node.mep_runtime.requests.request", return_value=_FakeResponse(200, diag)),
+        ):
+            identity_cls.return_value.node_id = "node_test"
+            code = mep_runtime.cmd_status(args)
+        self.assertEqual(code, 0)
+
+    def test_doctor_command_posts_snapshot(self):
+        args = argparse.Namespace(
+            hub_url="http://hub",
+            key_path="C:/tmp/test_key.pem",
+            adapter="mock",
+            auth_status="ok",
+            dm_status="pending",
+            listener_contract_ok=False,
+            clock_skew_seconds=None,
+        )
+        diag = {"registered": True, "ws_connected": False, "last_heartbeat": 100.0, "availability": "offline"}
+        diagnosis = {
+            "root_cause": "dm_pending_target_offline_or_route_issue",
+            "severity": "medium",
+            "fix_steps": [],
+            "copy_paste_commands": [],
+            "telemetry": {"total_requests": 1, "root_cause_count": 1},
+        }
+        with (
+            patch("node.mep_runtime.MEPIdentity") as identity_cls,
+            patch("node.mep_runtime.requests.request") as request_mock,
+        ):
+            identity_cls.return_value.node_id = "node_test"
+            request_mock.side_effect = [
+                _FakeResponse(200, diag),
+                _FakeResponse(200, diagnosis),
+            ]
+            code = mep_runtime.cmd_doctor(args)
+            sent_payload = request_mock.call_args_list[1].kwargs["json"]
+
+        self.assertEqual(code, 0)
+        self.assertEqual(sent_payload["node_id"], "node_test")
+        self.assertFalse(sent_payload["listener_contract_ok"])
+        self.assertEqual(sent_payload["dm_status"], "pending")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unified runtime CLI: python -m node.mep_runtime with init, un, status, doctor
- implement mock-first adapter (dapter=mock) for deterministic onboarding and CI stability
- wire doctor to Hub POST /onboard/diagnose and status to GET /diagnostic
- add runtime-focused tests for status badges, doctor snapshot payload, and command behavior
- document fast fresh-node sequence in README

## Why
- reduce fresh-node onboarding friction by standardizing node bootstrap and diagnostics
- provide deterministic path before ollama/openai adapters to isolate runtime/auth/ws issues

## Validation
- python -m pytest tests/test_node_runtime.py -q (5 passed)
- python -m pytest tests/test_hub_api.py -q
