### PR TITLE
fix(node): onboarding UX improvements and dependency validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,11 @@ python -m skills.quickstart_provider
 Need the fastest "fresh node" path (about 2 minutes)?
 
 ```bash
-python -m node.mep_runtime init --hub-url http://localhost:8000 --ws-url ws://localhost:8000
-python -m node.mep_runtime status --hub-url http://localhost:8000
-python -m node.mep_runtime doctor --hub-url http://localhost:8000
-python -m node.mep_runtime run --hub-url http://localhost:8000 --ws-url ws://localhost:8000
+git clone https://github.com/WUAIBING/MEP.git && cd MEP
+pip install requests websockets cryptography
+cd node && python mep_runtime.py init --hub-url https://mep-hub.silentcopilot.ai
+cd node && python mep_runtime.py status --hub-url https://mep-hub.silentcopilot.ai
+cd node && python mep_runtime.py run --hub-url https://mep-hub.silentcopilot.ai --ws-url wss://mep-hub.silentcopilot.ai
 ```
 
 </details>

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -15,9 +15,48 @@ from typing import Any, Optional
 import requests
 
 try:
+    import websockets  # type: ignore
+except ImportError:
+    websockets = None
+
+try:
     from node.identity import MEPIdentity
 except ImportError:  # pragma: no cover - supports direct file execution
     from identity import MEPIdentity
+
+
+REQUIRED_PACKAGES = ["requests", "cryptography", "websockets"]
+
+
+def _check_dependencies() -> None:
+    missing_required = []
+    missing_optional = []
+
+    for pkg in REQUIRED_PACKAGES:
+        try:
+            __import__(pkg)
+        except ImportError:
+            missing_required.append(pkg)
+
+    if websockets is None:
+        missing_optional.append("websockets")
+
+    if missing_required:
+        print("[mep runtime] Missing required packages:", file=__import__("sys").stderr)
+        for pkg in missing_required:
+            print(f"  - {pkg}", file=__import__("sys").stderr)
+        print(file=__import__("sys").stderr)
+        print("Install with: pip install" + " ".join(missing_required), file=__import__("sys").stderr)
+        raise SystemExit(1)
+
+    if missing_optional:
+        print("[mep runtime] Missing optional packages:", file=__import__("sys").stdout)
+        for pkg in missing_optional:
+            print(f"  - {pkg}", file=__import__("sys").stdout)
+        print("Install with: pip install" + " ".join(missing_optional), file=__import__("sys").stdout)
+
+
+_check_dependencies()
 
 
 DEFAULT_HUB_URL = os.getenv("HUB_URL", "http://localhost:8000")
@@ -193,10 +232,8 @@ class RuntimeNode:
         return f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
 
     async def run_forever(self) -> int:
-        try:
-            import websockets  # type: ignore
-        except ImportError:
-            print("[mep run] missing optional dependency: websockets")
+        if websockets is None:
+            print("[mep run] missing required dependency: websockets")
             print("[mep run] install with: pip install websockets")
             return 2
 


### PR DESCRIPTION
## Summary

Improve the 2-minute onboarding experience based on live testing against mep-hub.silentcopilot.ai.

## Changes

### 1. Dependency Validation
Add  function that validates required packages on startup:

- Validates: , , usage: websockets [--version | <uri>]
- Shows clear error message with missing packages
- Provides exact  command

### 2. README Improvements
Updated onboarding instructions:

- Added  line explicitly
- Showed correct path: 
- Use live hub URL as example
- Removed redundant  command (endpoint not deployed yet)

## Testing

Tested against live hub:


Total time: ~10 seconds (well under 2 minutes)

## Validation

- python -m pytest tests/test_node_runtime.py -q (5 passed)

*Reviewed by Trae SOLO Bot*