### PR TITLE
fix(hub): add stale-window + health visibility for ghost reconcile

### DIFF
--- a/hub/main.py
+++ b/hub/main.py
@@ -127,6 +127,7 @@ TASK_TIMEOUT_MAX_SECONDS = int(os.getenv("MEP_TASK_TIMEOUT_MAX_SECONDS", "86400"
 ASSIGNMENT_SWEEP_INTERVAL_SECONDS = int(os.getenv("MEP_ASSIGNMENT_SWEEP_INTERVAL_SECONDS", "60"))
 MAINTENANCE_SWEEP_INTERVAL_SECONDS = int(os.getenv("MEP_MAINTENANCE_SWEEP_INTERVAL_SECONDS", "60"))
 REGISTRY_RECONCILE_LIMIT = int(os.getenv("MEP_REGISTRY_RECONCILE_LIMIT", "1000"))
+REGISTRY_RECONCILE_STALE_SECONDS = float(os.getenv("MEP_REGISTRY_RECONCILE_STALE_SECONDS", "180"))
 COMPLETED_TASK_CACHE_TTL_SECONDS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_TTL_SECONDS", "3600"))
 COMPLETED_TASK_CACHE_MAX_ITEMS = int(os.getenv("MEP_COMPLETED_TASK_CACHE_MAX_ITEMS", "1000"))
 IDEMPOTENCY_TTL_SECONDS = int(os.getenv("MEP_IDEMPOTENCY_TTL_SECONDS", "86400"))
@@ -164,6 +165,18 @@ TASK_TIMEOUT_DEFAULT_SECONDS = max(TASK_TIMEOUT_MIN_SECONDS, min(TASK_TIMEOUT_DE
 # ---------------------------------------------------------------------------
 node_activity_lock = asyncio.Lock()
 node_last_activity: Dict[str, float] = {}
+registry_reconcile_lock = asyncio.Lock()
+registry_reconcile_metrics: Dict[str, Any] = {
+    "runs": 0,
+    "candidates_scanned": 0,
+    "reconciled_total": 0,
+    "skipped_recent_total": 0,
+    "last_run_at": None,
+    "last_run_candidates": 0,
+    "last_run_reconciled": 0,
+    "last_run_skipped_recent": 0,
+    "last_reconciled_at": None,
+}
 
 DEGRADED_THRESHOLD_SECONDS = float(os.getenv("MEP_DEGRADED_THRESHOLD_SECONDS", "600"))
 
@@ -206,10 +219,18 @@ async def _reconcile_live_registry_presence():
             stale_candidates.append((node_id, availability))
 
     if not stale_candidates:
+        now = time.time()
+        async with registry_reconcile_lock:
+            registry_reconcile_metrics["runs"] += 1
+            registry_reconcile_metrics["last_run_at"] = now
+            registry_reconcile_metrics["last_run_candidates"] = 0
+            registry_reconcile_metrics["last_run_reconciled"] = 0
+            registry_reconcile_metrics["last_run_skipped_recent"] = 0
         return
 
     now = time.time()
     reconciled = 0
+    skipped_recent = 0
     for node_id, seen_availability in stale_candidates:
         async with node_lock:
             if node_id in connected_nodes:
@@ -220,6 +241,15 @@ async def _reconcile_live_registry_presence():
         current_availability = str(existing.get("availability") or "unknown").strip().lower()
         if current_availability not in LIVE_AVAILABILITY:
             continue
+        last_updated = existing.get("updated_at")
+        if last_updated is not None:
+            try:
+                age_seconds = now - float(last_updated)
+                if age_seconds < REGISTRY_RECONCILE_STALE_SECONDS:
+                    skipped_recent += 1
+                    continue
+            except (TypeError, ValueError):
+                pass
         db.update_registry_availability(node_id, "offline", now)
         reconciled += 1
         log_event(
@@ -229,6 +259,17 @@ async def _reconcile_live_registry_presence():
             previous_availability=seen_availability,
             reconciled_availability="offline",
         )
+    async with registry_reconcile_lock:
+        registry_reconcile_metrics["runs"] += 1
+        registry_reconcile_metrics["candidates_scanned"] += len(stale_candidates)
+        registry_reconcile_metrics["reconciled_total"] += reconciled
+        registry_reconcile_metrics["skipped_recent_total"] += skipped_recent
+        registry_reconcile_metrics["last_run_at"] = now
+        registry_reconcile_metrics["last_run_candidates"] = len(stale_candidates)
+        registry_reconcile_metrics["last_run_reconciled"] = reconciled
+        registry_reconcile_metrics["last_run_skipped_recent"] = skipped_recent
+        if reconciled:
+            registry_reconcile_metrics["last_reconciled_at"] = now
     if reconciled:
         log_event("registry_reconcile_summary", f"Reconciled {reconciled} stale live registry entries", reconciled=reconciled)
 DEFAULT_REGISTRY_MAX_AGE_MINUTES = float(os.getenv("MEP_REGISTRY_MAX_AGE_MINUTES", "0") or "0")
@@ -2144,6 +2185,8 @@ async def health_check():
     db_health = db.check_database_health()
     async with node_lock:
         online_count = len(connected_nodes)
+    async with registry_reconcile_lock:
+        reconcile_snapshot = dict(registry_reconcile_metrics)
     async with task_lock:
         active_count = len(active_tasks)
         completed_count = len(completed_tasks)
@@ -2153,7 +2196,8 @@ async def health_check():
         "metrics": {
             "connected_nodes": online_count,
             "active_tasks": active_count,
-            "completed_task_cache": completed_count
+            "completed_task_cache": completed_count,
+            "registry_reconcile": reconcile_snapshot,
         }
     }
 

--- a/tests/test_hub_ghost_reconcile.py
+++ b/tests/test_hub_ghost_reconcile.py
@@ -7,11 +7,27 @@ import main as hub_main
 class TestHubGhostReconcile(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self._original_connected = dict(hub_main.connected_nodes)
+        self._original_metrics = dict(hub_main.registry_reconcile_metrics)
         hub_main.connected_nodes.clear()
+        hub_main.registry_reconcile_metrics.update(
+            {
+                "runs": 0,
+                "candidates_scanned": 0,
+                "reconciled_total": 0,
+                "skipped_recent_total": 0,
+                "last_run_at": None,
+                "last_run_candidates": 0,
+                "last_run_reconciled": 0,
+                "last_run_skipped_recent": 0,
+                "last_reconciled_at": None,
+            }
+        )
 
     async def asyncTearDown(self):
         hub_main.connected_nodes.clear()
         hub_main.connected_nodes.update(self._original_connected)
+        hub_main.registry_reconcile_metrics.clear()
+        hub_main.registry_reconcile_metrics.update(self._original_metrics)
 
     async def test_reconcile_forces_offline_for_stale_live_entry(self):
         hub_main.connected_nodes["node_live"] = object()
@@ -40,6 +56,8 @@ class TestHubGhostReconcile(unittest.IsolatedAsyncioTestCase):
         update_mock.assert_called_once()
         self.assertEqual(update_mock.call_args.args[0], "node_ghost")
         self.assertEqual(update_mock.call_args.args[1], "offline")
+        self.assertEqual(hub_main.registry_reconcile_metrics["last_run_reconciled"], 1)
+        self.assertEqual(hub_main.registry_reconcile_metrics["reconciled_total"], 1)
 
     async def test_reconcile_skips_non_live_or_already_offline(self):
         def _fake_search(*, availability, **kwargs):
@@ -60,6 +78,40 @@ class TestHubGhostReconcile(unittest.IsolatedAsyncioTestCase):
             await hub_main._reconcile_live_registry_presence()
 
         update_mock.assert_not_called()
+        self.assertEqual(hub_main.registry_reconcile_metrics["last_run_reconciled"], 0)
+
+    async def test_reconcile_skips_recent_live_entries(self):
+        now = 1000.0
+
+        def _fake_search(*, availability, **kwargs):
+            if availability == "online":
+                return [{"node_id": "node_recent", "availability": "online"}]
+            return []
+
+        with (
+            patch.object(hub_main.db, "search_registry", side_effect=_fake_search),
+            patch.object(
+                hub_main.db,
+                "get_registry",
+                return_value={"node_id": "node_recent", "availability": "online", "updated_at": now - 5},
+            ),
+            patch.object(hub_main.db, "update_registry_availability") as update_mock,
+            patch.object(hub_main, "log_event"),
+            patch.object(hub_main, "REGISTRY_RECONCILE_STALE_SECONDS", 30.0),
+            patch("main.time.time", return_value=now),
+        ):
+            await hub_main._reconcile_live_registry_presence()
+
+        update_mock.assert_not_called()
+        self.assertEqual(hub_main.registry_reconcile_metrics["last_run_skipped_recent"], 1)
+        self.assertEqual(hub_main.registry_reconcile_metrics["skipped_recent_total"], 1)
+
+    async def test_health_exposes_reconcile_metrics(self):
+        health = await hub_main.health_check()
+        metrics = health["metrics"]["registry_reconcile"]
+        self.assertIn("runs", metrics)
+        self.assertIn("last_run_reconciled", metrics)
+        self.assertIn("last_run_skipped_recent", metrics)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `MEP_REGISTRY_RECONCILE_STALE_SECONDS` guard to avoid flipping very recent live entries during short reconnect windows
- track reconcile counters in-memory (`runs`, scanned/reconciled/skipped_recent totals, last run stats)
- expose reconciliation metrics via `/health` under `metrics.registry_reconcile`
- expand ghost reconcile tests for stale-window behavior and health visibility

## Why
PR #126 fixed core ghost cleanup, but this follow-up improves safety and observability based on node-test feedback from PR124/125/127.

## Validation
- python -m pytest -q tests/test_hub_ghost_reconcile.py