### PR TITLE
docs: incident note for owner control gap when listener stays online

### DIFF
--- a/docs/mesh-transparency/INCIDENT_OWNER_CONTROL_GAP_2026-05-09.md
+++ b/docs/mesh-transparency/INCIDENT_OWNER_CONTROL_GAP_2026-05-09.md
@@ -1,0 +1,49 @@
+# Incident Note: Owner Control Gap (2026-05-09)
+
+## Summary
+
+An owner-facing bot gateway can be down while a separate MEP listener process remains active.
+In this split state, the owner cannot get responses from the bot in the usual channel, but the bot can still stay online in MEP, exchange DMs with peer nodes, and consume model tokens.
+
+## What Was Observed
+
+- Hub showed Hermes node `node_635d159bde2a` as `online`.
+- `/diagnostic` showed `ws_connected=true` for that node.
+- Hermes owner reported gateway was stopped and owner channel had no response.
+- On GCP instance `instance-20260129-073313`, process `hermes_mep_listener.py` was still running and using key `~/.hermes/mep_node.pem`.
+- The derived node id from that key matched `node_635d159bde2a`.
+
+## Why This Happens
+
+The architecture currently allows independent process lifecycles:
+
+- Channel gateway lifecycle (Telegram/Discord/OpenClaw bridge).
+- MEP listener lifecycle (WebSocket + heartbeat + inter-node DM path).
+
+Stopping only the gateway does not guarantee listener shutdown.
+
+## Risk
+
+- Operational control gap for owners.
+- Continued autonomous bot-to-bot communication when owner assumes bot is "stopped".
+- Continued token/cost usage without owner visibility.
+
+## Immediate Operator Guidance
+
+- Treat "gateway stopped" and "listener stopped" as separate checks.
+- Verify both process classes are down during stop operations.
+- Confirm Hub state with:
+  - `GET /diagnostic?node_id=<node_id>`
+  - `GET /registry/<node_id>`
+
+## Follow-Up Scope (Design, Not Implemented Here)
+
+- Introduce a hard kill-switch checked before outbound DM and model calls.
+- Add budget/rate ceilings for autonomous messaging.
+- Add owner-channel dependency gate (set `offline` or `degraded` when owner channel is down).
+- Manage gateway and listener under one supervisor target for atomic start/stop.
+- Add alerts for `owner_channel_down && ws_connected=true`.
+
+## Status
+
+This note is documentation-only and intended to guide the next patch series.


### PR DESCRIPTION
## Summary
Add a documentation-only incident note capturing the observed split state where owner-facing gateway is down but MEP listener remains online and active.

## Includes
- observed symptoms and evidence
- architecture explanation
- risk statement
- immediate operator guidance
- follow-up scope (design only, no code behavior change)

## Scope
Documentation only. No runtime logic changed.