### PR TITLE
runtime: one-command up flow for fresh-node onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,16 @@ python -m skills.quickstart_provider
 Need the fastest "fresh node" path (about 2 minutes)?
 
 ```bash
-python -m node.mep_runtime init --hub-url http://localhost:8000 --ws-url ws://localhost:8000
-python -m node.mep_runtime status --hub-url http://localhost:8000
-python -m node.mep_runtime doctor --hub-url http://localhost:8000
-python -m node.mep_runtime run --hub-url http://localhost:8000 --ws-url ws://localhost:8000
+python -m node.mep_runtime --hub-url http://localhost:8000 --ws-url ws://localhost:8000 up
+```
+
+If you prefer step-by-step:
+
+```bash
+python -m node.mep_runtime --hub-url http://localhost:8000 --ws-url ws://localhost:8000 init
+python -m node.mep_runtime --hub-url http://localhost:8000 --ws-url ws://localhost:8000 status
+python -m node.mep_runtime --hub-url http://localhost:8000 --ws-url ws://localhost:8000 doctor
+python -m node.mep_runtime --hub-url http://localhost:8000 --ws-url ws://localhost:8000 run
 ```
 
 </details>

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unified node runtime for fast onboarding (`init`, `run`, `status`, `doctor`)."""
+"""Unified node runtime for fast onboarding (`init`, `up`, `run`, `status`, `doctor`)."""
 
 from __future__ import annotations
 
@@ -235,6 +235,18 @@ def _print_badges(badges: dict[str, bool]) -> None:
     print("[mep status] " + " | ".join(parts))
 
 
+def _print_listener_hint(args: argparse.Namespace) -> None:
+    cmd = (
+        "python -m node.mep_runtime "
+        f"--hub-url {args.hub_url} "
+        f"--ws-url {args.ws_url} "
+        f"--key-path {args.key_path} run"
+    )
+    print("[mep status] node is registered, but listener is not running.")
+    print("[mep status] start live listener with:")
+    print(f"  $ {cmd}")
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     _ensure_key_parent(args.key_path)
     identity = MEPIdentity(args.key_path)
@@ -249,6 +261,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     print(f"[mep init] register ok balance={body.get('balance') if body else '?'}")
     status_args = argparse.Namespace(
         hub_url=args.hub_url,
+        ws_url=args.ws_url,
         key_path=args.key_path,
         adapter=args.adapter,
         require_online=False,
@@ -266,6 +279,8 @@ def cmd_status(args: argparse.Namespace) -> int:
         return 2
     badges = _status_badges(body, ai_ready=args.adapter == "mock")
     _print_badges(badges)
+    if badges["REGISTERED"] and not badges["WS_CONNECTED"]:
+        _print_listener_hint(args)
     if args.require_online:
         return 0 if all(badges.values()) else 1
     return 0
@@ -327,6 +342,35 @@ def cmd_run(args: argparse.Namespace) -> int:
         return 0
 
 
+def cmd_up(args: argparse.Namespace) -> int:
+    print("[mep up] bootstrapping node with init -> doctor -> run")
+    init_args = argparse.Namespace(
+        hub_url=args.hub_url,
+        ws_url=args.ws_url,
+        key_path=args.key_path,
+        adapter=args.adapter,
+        alias=args.alias,
+    )
+    init_code = cmd_init(init_args)
+    if init_code != 0:
+        return init_code
+
+    doctor_args = argparse.Namespace(
+        hub_url=args.hub_url,
+        key_path=args.key_path,
+        adapter=args.adapter,
+        auth_status="ok",
+        dm_status="ok",
+        listener_contract_ok=None,
+        clock_skew_seconds=None,
+    )
+    doctor_code = cmd_doctor(doctor_args)
+    if doctor_code != 0:
+        print("[mep up] doctor failed; continuing to run listener for live connectivity")
+
+    return cmd_run(args)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="MEP unified runtime for fast onboarding.")
     parser.add_argument("--hub-url", default=DEFAULT_HUB_URL, help="Hub base URL.")
@@ -339,6 +383,10 @@ def build_parser() -> argparse.ArgumentParser:
     init_p = sub.add_parser("init", help="Generate/load key and register node.")
     init_p.add_argument("--alias", default="mep-runtime", help="Node alias for registration.")
     init_p.set_defaults(func=cmd_init)
+
+    up_p = sub.add_parser("up", help="One-command bootstrap: init + doctor + run.")
+    up_p.add_argument("--alias", default="mep-runtime", help="Node alias for registration.")
+    up_p.set_defaults(func=cmd_up)
 
     run_p = sub.add_parser("run", help="Run standardized listener runtime.")
     run_p.set_defaults(func=cmd_run)

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -17,89 +17,46 @@ class _FakeResponse:
         return self._json_data
 
 
-class TestNodeRuntimeHelpers(unittest.TestCase):
-    def test_status_badges_all_ok(self):
-        badges = mep_runtime._status_badges(
-            {"registered": True, "ws_connected": True, "last_heartbeat": 123.0, "availability": "online"},
-            ai_ready=True,
-        )
-        self.assertTrue(all(badges.values()))
-
-    def test_build_doctor_snapshot_includes_heartbeat_delta(self):
-        with patch("node.mep_runtime.time.time", return_value=1000.0):
-            snapshot = mep_runtime._build_doctor_snapshot(
-                node_id="node_1",
-                diag={"registered": True, "ws_connected": False, "last_heartbeat": 900.0},
-                auth_status="ok",
-                dm_status="ok",
-                listener_contract_ok=True,
-                ai_configured=True,
-                clock_skew_seconds=2.5,
-            )
-        self.assertEqual(snapshot["node_id"], "node_1")
-        self.assertEqual(snapshot["heartbeat_seconds_ago"], 100.0)
-        self.assertFalse(snapshot["ws_connected"])
-        self.assertEqual(snapshot["clock_skew_seconds"], 2.5)
-
-    def test_mock_adapter_is_deterministic(self):
-        adapter = mep_runtime.MockAdapter()
-        out = adapter.generate_reply("hello world", {"id": "123456789"})
-        self.assertIn("MOCK_ADAPTER_OK", out)
-        self.assertIn("task=12345678", out)
-        self.assertIn("summary=hello world", out)
-
-
-class TestNodeRuntimeCommands(unittest.TestCase):
-    def test_status_command_success(self):
+class TestRuntimeUx(unittest.TestCase):
+    def test_status_prints_listener_hint_when_ws_offline(self):
         args = argparse.Namespace(
             hub_url="http://hub",
+            ws_url="ws://hub",
             key_path="C:/tmp/test_key.pem",
             adapter="mock",
             require_online=False,
         )
-        diag = {"registered": True, "ws_connected": True, "last_heartbeat": 100.0, "availability": "online"}
+        diag = {"registered": True, "ws_connected": False, "last_heartbeat": 100.0, "availability": "offline"}
         with (
             patch("node.mep_runtime.MEPIdentity") as identity_cls,
             patch("node.mep_runtime.requests.request", return_value=_FakeResponse(200, diag)),
+            patch("builtins.print") as print_mock,
         ):
             identity_cls.return_value.node_id = "node_test"
             code = mep_runtime.cmd_status(args)
         self.assertEqual(code, 0)
+        printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list if call.args)
+        self.assertIn("listener is not running", printed)
+        self.assertIn("python -m node.mep_runtime", printed)
 
-    def test_doctor_command_posts_snapshot(self):
+    def test_up_runs_even_if_doctor_fails(self):
         args = argparse.Namespace(
             hub_url="http://hub",
+            ws_url="ws://hub",
             key_path="C:/tmp/test_key.pem",
             adapter="mock",
-            auth_status="ok",
-            dm_status="pending",
-            listener_contract_ok=False,
-            clock_skew_seconds=None,
+            alias="fresh-node",
         )
-        diag = {"registered": True, "ws_connected": False, "last_heartbeat": 100.0, "availability": "offline"}
-        diagnosis = {
-            "root_cause": "dm_pending_target_offline_or_route_issue",
-            "severity": "medium",
-            "fix_steps": [],
-            "copy_paste_commands": [],
-            "telemetry": {"total_requests": 1, "root_cause_count": 1},
-        }
         with (
-            patch("node.mep_runtime.MEPIdentity") as identity_cls,
-            patch("node.mep_runtime.requests.request") as request_mock,
+            patch("node.mep_runtime.cmd_init", return_value=0) as init_mock,
+            patch("node.mep_runtime.cmd_doctor", return_value=2) as doctor_mock,
+            patch("node.mep_runtime.cmd_run", return_value=0) as run_mock,
         ):
-            identity_cls.return_value.node_id = "node_test"
-            request_mock.side_effect = [
-                _FakeResponse(200, diag),
-                _FakeResponse(200, diagnosis),
-            ]
-            code = mep_runtime.cmd_doctor(args)
-            sent_payload = request_mock.call_args_list[1].kwargs["json"]
-
+            code = mep_runtime.cmd_up(args)
         self.assertEqual(code, 0)
-        self.assertEqual(sent_payload["node_id"], "node_test")
-        self.assertFalse(sent_payload["listener_contract_ok"])
-        self.assertEqual(sent_payload["dm_status"], "pending")
+        self.assertEqual(init_mock.call_count, 1)
+        self.assertEqual(doctor_mock.call_count, 1)
+        self.assertEqual(run_mock.call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Improve fresh-node UX by reducing command friction and clarifying offline status meaning.

## Changes
- add mep_runtime up command (init -> doctor -> run)
- keep up resilient: if doctor fails, continue to run listener
- add explicit status hint when node is registered but listener is not running
- update README quick path to use one-command up
- add tests for status hint and up fallback behavior

## Why
PR124 feedback showed fresh users interpret WS_CONNECTED=FAIL as setup failure after init/status/doctor. This PR makes the expected next step obvious and reduces onboarding friction.

## Validation
- python -m pytest -q tests/test_node_runtime.py (2 passed)
