### PR TITLE
fix(hub): prevent ghost live availability without websocket

### DIFF
--- a/hub/main.py
+++ b/hub/main.py
@@ -490,6 +490,16 @@ def _normalize_model_requirement(value: Optional[str]) -> Optional[str]:
     return normalized
 
 
+async def _coerce_live_availability(node_id: str, availability: Optional[str]) -> Optional[str]:
+    if availability is None or availability not in LIVE_AVAILABILITY:
+        return availability
+    async with node_lock:
+        has_live_websocket = node_id in connected_nodes
+    if has_live_websocket:
+        return availability
+    return "offline"
+
+
 def _interbot_require_object(data: Any, field_name: str) -> dict:
     if not isinstance(data, dict):
         raise HTTPException(status_code=400, detail=f"Inter-bot payload missing object: {field_name}")
@@ -1328,12 +1338,14 @@ async def update_registry(payload: RegistryUpdate, authenticated_node: str = Dep
     if availability is None:
         existing = db.get_registry(authenticated_node)
         availability = existing.get("availability") if existing else "unknown"
+    availability = await _coerce_live_availability(authenticated_node, availability)
     db.upsert_registry(authenticated_node, payload.alias, skills, models, metadata, availability, time.time())
     return {"status": "success", "node_id": authenticated_node}
 
 @app.post("/registry/availability")
 async def update_availability(payload: AvailabilityUpdate, authenticated_node: str = Depends(verify_request)):
     availability = _normalize_availability(payload.availability)
+    availability = await _coerce_live_availability(authenticated_node, availability)
     db.update_registry_availability(authenticated_node, availability, time.time())
     await _track_node_activity(authenticated_node)
     return {"status": "success", "node_id": authenticated_node, "availability": availability}
@@ -1344,10 +1356,7 @@ async def registry_heartbeat(payload: RegistryHeartbeat, request: Request, authe
     if availability is None:
         existing = db.get_registry(authenticated_node)
         availability = existing.get("availability") if existing else "unknown"
-    async with node_lock:
-        has_live_websocket = authenticated_node in connected_nodes
-    if availability in LIVE_AVAILABILITY and not has_live_websocket:
-        availability = "offline"
+    availability = await _coerce_live_availability(authenticated_node, availability)
     db.update_registry_availability(authenticated_node, availability, time.time())
     await _track_node_activity(authenticated_node)
     hub_url, ws_url = get_hub_urls(request)

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -473,6 +473,7 @@ class TestMeshAssembly(unittest.TestCase):
         conn.commit()
         db._release_conn(conn)
         main.mesh_assemblies.clear()
+        main.connected_nodes.clear()
 
     def _register_with_mesh_metadata(
         self,
@@ -485,6 +486,8 @@ class TestMeshAssembly(unittest.TestCase):
     ):
         priv, pub, node_id = _make_identity()
         _register(pub)
+        # Mesh role selection treats websocket presence as source of truth.
+        main.connected_nodes[node_id] = object()
         update_payload = json.dumps(
             {
                 "alias": alias,

--- a/tests/test_hub_ghost_reconcile.py
+++ b/tests/test_hub_ghost_reconcile.py
@@ -113,6 +113,50 @@ class TestHubGhostReconcile(unittest.IsolatedAsyncioTestCase):
         self.assertIn("last_run_reconciled", metrics)
         self.assertIn("last_run_skipped_recent", metrics)
 
+    async def test_registry_update_coerces_live_status_to_offline_without_ws(self):
+        payload = hub_main.RegistryUpdate(
+            alias="ghosty",
+            skills=["chat"],
+            models=["deepseek-v4"],
+            metadata={"k": "v"},
+            availability="online",
+        )
+        with (
+            patch.object(hub_main.db, "upsert_registry") as upsert_mock,
+            patch("main.time.time", return_value=1000.0),
+        ):
+            await hub_main.update_registry(payload, authenticated_node="node_ghost")
+
+        upsert_mock.assert_called_once()
+        self.assertEqual(upsert_mock.call_args.args[0], "node_ghost")
+        self.assertEqual(upsert_mock.call_args.args[5], "offline")
+
+    async def test_registry_update_keeps_live_status_when_ws_connected(self):
+        payload = hub_main.RegistryUpdate(availability="online")
+        hub_main.connected_nodes["node_live"] = object()
+        with (
+            patch.object(hub_main.db, "upsert_registry") as upsert_mock,
+            patch("main.time.time", return_value=1000.0),
+        ):
+            await hub_main.update_registry(payload, authenticated_node="node_live")
+
+        upsert_mock.assert_called_once()
+        self.assertEqual(upsert_mock.call_args.args[5], "online")
+
+    async def test_registry_availability_coerces_live_status_to_offline_without_ws(self):
+        payload = hub_main.AvailabilityUpdate(availability="busy")
+        with (
+            patch.object(hub_main.db, "update_registry_availability") as update_mock,
+            patch.object(hub_main, "_track_node_activity"),
+            patch("main.time.time", return_value=1000.0),
+        ):
+            response = await hub_main.update_availability(payload, authenticated_node="node_ghost")
+
+        update_mock.assert_called_once()
+        self.assertEqual(update_mock.call_args.args[0], "node_ghost")
+        self.assertEqual(update_mock.call_args.args[1], "offline")
+        self.assertEqual(response["availability"], "offline")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- enforce websocket truth for live availability (online/idle/busy)
- apply enforcement to /registry/update, /registry/availability, and /registry/heartbeat
- add regression tests for ghost-state prevention

## Validation
- python -m pytest tests/test_hub_ghost_reconcile.py -q
- 7 passed