### PR TITLE
feat(client): submit spec-shaped task envelopes

### DIFF
--- a/node/client.py
+++ b/node/client.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import websockets
 import requests
 import uuid
 import time
@@ -77,6 +76,8 @@ class ChronosNode:
 
     async def listen(self):
         """Persistent WebSocket connection."""
+        import websockets
+
         ts = str(int(time.time()))
         sig = self.identity.sign(self.node_id, ts)
         sig_safe = urllib.parse.quote(sig)
@@ -102,21 +103,54 @@ class ChronosNode:
             await asyncio.sleep(WS_HEARTBEAT_INTERVAL_SECONDS)
             await ws.send(json.dumps({"event": "heartbeat", "node_id": self.node_id, "ts": int(time.time())}))
 
-    async def submit_task(self, payload: str, bounty: float):
+    async def submit_task(self, payload: str, bounty: float, target_node: str | None = None, target_capability: str | None = None):
         """As a Consumer, create a task and lock SECONDS."""
-        payload_str = json.dumps({
-            "consumer_id": self.node_id,
-            "payload": payload,
-            "bounty": bounty
-        })
+        bounty_ns = int(abs(float(bounty)) * 1_000_000_000)
+        if bounty < 0:
+            market = "data"
+            payment_direction = "receiver_to_sender"
+        elif bounty == 0:
+            market = "chat"
+            payment_direction = "none"
+        else:
+            market = "compute"
+            payment_direction = "sender_to_receiver"
+
+        task_request = {
+            "source": {"node_id": self.node_id},
+            "intent": {"type": "analysis.request"},
+            "task": {
+                "instructions": payload,
+                "expected_output": {"result_type": "text"},
+            },
+            "economics": {
+                "bounty_ns": bounty_ns,
+                "currency": "MEP_NS",
+                "market": market,
+                "payment_direction": payment_direction,
+            },
+        }
+        if target_node or target_capability:
+            task_request["routing"] = {}
+            if target_node:
+                task_request["routing"]["target_node_id"] = target_node
+            if target_capability:
+                task_request["routing"]["target_capability"] = target_capability
+
+        payload_str = json.dumps(task_request)
         headers = self.identity.get_auth_headers(payload_str)
         headers["Content-Type"] = "application/json"
         resp = requests.post(f"{self.hub_url}/tasks/submit", data=payload_str, headers=headers)
-        if resp.status_code == 200:
-            task_id = resp.json()["task_id"]
+        try:
+            response_body = resp.json()
+        except ValueError:
+            response_body = {}
+        task_id = response_body.get("task_id")
+        if resp.status_code == 200 and response_body.get("status") == "success" and task_id:
             print(f"[Node {self.node_id} (Consumer)] Submitted Task {task_id[:6]} for {bounty}s")
         else:
-            print(f"Failed to submit task: {resp.text}")
+            detail = response_body.get("detail") or resp.text
+            print(f"Failed to submit task: {detail}")
 
 async def run_demo():
     # Setup two nodes

--- a/tests/test_node_client.py
+++ b/tests/test_node_client.py
@@ -1,0 +1,79 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import patch
+
+from node.client import ChronosNode
+
+
+class _FakeIdentity:
+    node_id = "node_consumer"
+    pub_pem = "pub"
+
+    def get_auth_headers(self, payload: str) -> dict:
+        return {"X-MEP-NodeID": self.node_id, "X-MEP-Signature": "sig"}
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, json_data=None, text=""):
+        self.status_code = status_code
+        self._json_data = json_data or {"status": "success", "task_id": "task_123456"}
+        self.text = text
+
+    def json(self) -> dict:
+        return self._json_data
+
+
+class TestChronosNodeSubmitTask(unittest.TestCase):
+    def test_submit_task_uses_spec_shaped_envelope(self):
+        with (
+            patch("node.client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("node.client.ReputationManager"),
+            patch("node.client.requests.post", return_value=_FakeResponse()) as post_mock,
+        ):
+            node = ChronosNode("unused.pem", hub_url="http://hub")
+            asyncio.run(
+                node.submit_task(
+                    "summarize this",
+                    bounty=1.5,
+                    target_node="node_provider",
+                    target_capability="text",
+                )
+            )
+
+        body = json.loads(post_mock.call_args.kwargs["data"])
+        self.assertEqual(body["source"], {"node_id": "node_consumer"})
+        self.assertEqual(body["task"]["instructions"], "summarize this")
+        self.assertEqual(body["task"]["expected_output"], {"result_type": "text"})
+        self.assertEqual(
+            body["economics"],
+            {
+                "bounty_ns": 1_500_000_000,
+                "currency": "MEP_NS",
+                "market": "compute",
+                "payment_direction": "sender_to_receiver",
+            },
+        )
+        self.assertEqual(
+            body["routing"],
+            {"target_node_id": "node_provider", "target_capability": "text"},
+        )
+
+    def test_submit_task_reports_200_error_body_without_task_id(self):
+        response = _FakeResponse(200, {"status": "error", "detail": "Target node not currently connected to Hub"})
+        with (
+            patch("node.client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("node.client.ReputationManager"),
+            patch("node.client.requests.post", return_value=response),
+            patch("builtins.print") as print_mock,
+        ):
+            node = ChronosNode("unused.pem", hub_url="http://hub")
+            asyncio.run(node.submit_task("hello", bounty=0.0, target_node="node_offline"))
+
+        printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list if call.args)
+        self.assertIn("Failed to submit task", printed)
+        self.assertIn("Target node not currently connected", printed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update the primary Python client to submit source/task/economics/routing instead of legacy consumer_id/payload/bounty fields
- convert client bounty SECONDS into canonical economics.bounty_ns / MEP_NS at the boundary
- add a unit test for the serialized client request body

## Validation
- python -m pytest tests\\test_node_client.py tests\\test_hub_api.py tests\\test_hub_ghost_reconcile.py -q