### PR TITLE
test(load): submit spec-shaped task envelopes

### DIFF
--- a/tests/load/mep_load_runner.py
+++ b/tests/load/mep_load_runner.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 import requests
-import websockets
 
 from clients.shared.identity import MEPIdentity
 
@@ -71,6 +70,32 @@ def _percentile_ms(values: list[float], p: float) -> Optional[float]:
     return round(values[idx] * 1000.0, 2)
 
 
+def build_task_request(node_id: str, payload: str, bounty: float) -> dict:
+    if bounty < 0:
+        market = "data"
+        payment_direction = "receiver_to_sender"
+    elif bounty == 0:
+        market = "chat"
+        payment_direction = "none"
+    else:
+        market = "compute"
+        payment_direction = "sender_to_receiver"
+    return {
+        "source": {"node_id": node_id},
+        "intent": {"type": "load.test.request"},
+        "task": {
+            "instructions": payload,
+            "expected_output": {"result_type": "text"},
+        },
+        "economics": {
+            "bounty_ns": int(abs(float(bounty)) * 1_000_000_000),
+            "currency": "MEP_NS",
+            "market": market,
+            "payment_direction": payment_direction,
+        },
+    }
+
+
 class VirtualNode:
     def __init__(
         self,
@@ -127,7 +152,7 @@ class VirtualNode:
         return response.status_code, data
 
     async def submit_task(self, payload: str, bounty: float) -> Optional[str]:
-        body = {"consumer_id": self.node_id, "payload": payload, "bounty": bounty}
+        body = build_task_request(self.node_id, payload, bounty)
         code, data = await self._post_json("/tasks/submit", body)
         if code == 200 and data.get("status") == "success":
             await self.metrics.inc("submits_ok")
@@ -172,6 +197,8 @@ class VirtualNode:
         await self._complete(task_id, result)
 
     async def connect_and_listen(self) -> None:
+        import websockets
+
         while not self.stop_event.is_set():
             ts = str(int(time.time()))
             sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))

--- a/tests/test_load_runner.py
+++ b/tests/test_load_runner.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+
+_LOAD_RUNNER_PATH = Path(__file__).parent / "load" / "mep_load_runner.py"
+_SPEC = importlib.util.spec_from_file_location("mep_load_runner", _LOAD_RUNNER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_LOAD_RUNNER = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_LOAD_RUNNER)
+build_task_request = _LOAD_RUNNER.build_task_request
+
+
+def test_load_runner_builds_spec_shaped_compute_task():
+    body = build_task_request("node_load", "work item", 2.5)
+
+    assert body["source"] == {"node_id": "node_load"}
+    assert body["intent"] == {"type": "load.test.request"}
+    assert body["task"] == {
+        "instructions": "work item",
+        "expected_output": {"result_type": "text"},
+    }
+    assert body["economics"] == {
+        "bounty_ns": 2_500_000_000,
+        "currency": "MEP_NS",
+        "market": "compute",
+        "payment_direction": "sender_to_receiver",
+    }
+
+
+def test_load_runner_builds_spec_shaped_data_task():
+    body = build_task_request("node_load", "data item", -0.25)
+
+    assert body["economics"] == {
+        "bounty_ns": 250_000_000,
+        "currency": "MEP_NS",
+        "market": "data",
+        "payment_direction": "receiver_to_sender",
+    }


### PR DESCRIPTION
## Summary
- update the load runner to submit source/task/economics envelopes instead of legacy consumer_id/payload/bounty bodies
- convert load-test bounty SECONDS into canonical economics.bounty_ns / MEP_NS
- add unit tests for compute and data market load-runner request bodies

## Validation
- python -m ruff check tests\\load\\mep_load_runner.py tests\\test_load_runner.py
- python -m pytest tests\\test_load_runner.py tests\\test_node_client.py tests\\test_hub_api.py tests\\test_hub_ghost_reconcile.py -q