### PR TITLE
chore(node): use spec envelopes in helper scripts

### DIFF
--- a/node/broadcast_opinion.py
+++ b/node/broadcast_opinion.py
@@ -4,6 +4,7 @@ import json
 import requests
 import time
 from identity import MEPIdentity
+from task_envelope import build_task_envelope
 
 HUB_URL = os.getenv("HUB_URL", "https://mep-hub.silentcopilot.ai")
 MY_NODE_ID = "node_1c1a93dda148" # Hub Sentinel
@@ -36,16 +37,13 @@ def get_online_nodes():
         return []
 
 def send_dm(target_node, identity):
-    # TaskCreate schema
-    payload = {
-        "consumer_id": identity.node_id,
-        "payload": MSG_CONTENT.strip(),
-        "bounty": 0.0,
-        "model_requirement": "gemini-3.1-pro-preview",
-        "target_node": target_node,
-        "payload_uri": None,
-        "secret_data": None
-    }
+    payload = build_task_envelope(
+        identity.node_id,
+        MSG_CONTENT.strip(),
+        0.0,
+        target_node=target_node,
+        target_capability="gemini-3.1-pro-preview",
+    )
     
     payload_str = json.dumps(payload)
     headers = identity.get_auth_headers(payload_str)

--- a/node/buy_data.py
+++ b/node/buy_data.py
@@ -4,6 +4,7 @@ import os
 import json
 import requests
 from identity import MEPIdentity
+from task_envelope import build_task_envelope
 
 HUB_URL = os.getenv("HUB_URL", "https://mep-hub.silentcopilot.ai")
 
@@ -11,15 +12,13 @@ def buy_data(target_node):
     key_path = os.path.expanduser("~/.mep/mep_ai_provider.pem")
     identity = MEPIdentity(key_path)
     
-    payload = {
-        "consumer_id": identity.node_id,
-        "payload": "I want to buy the secret dataset.",
-        "bounty": 0.5,
-        "model_requirement": "data-purchase",
-        "target_node": target_node,
-        "payload_uri": None,
-        "secret_data": None
-    }
+    payload = build_task_envelope(
+        identity.node_id,
+        "I want to buy the secret dataset.",
+        0.5,
+        target_node=target_node,
+        target_capability="data-purchase",
+    )
     
     payload_str = json.dumps(payload)
     headers = identity.get_auth_headers(payload_str)

--- a/node/pay_node.py
+++ b/node/pay_node.py
@@ -4,6 +4,7 @@ import os
 import json
 import requests
 from identity import MEPIdentity
+from task_envelope import build_task_envelope
 
 HUB_URL = os.getenv("HUB_URL", "https://mep-hub.silentcopilot.ai")
 
@@ -11,13 +12,13 @@ def pay_node(target_node, amount=0.1):
     key_path = os.path.expanduser("~/.mep/mep_ai_provider.pem")
     identity = MEPIdentity(key_path)
     
-    payload = {
-        "consumer_id": identity.node_id,
-        "payload": f"Payment test: {amount} SECONDS.",
-        "bounty": amount,
-        "model_requirement": "gemini-1.5-flash",
-        "target_node": target_node,
-    }
+    payload = build_task_envelope(
+        identity.node_id,
+        f"Payment test: {amount} SECONDS.",
+        amount,
+        target_node=target_node,
+        target_capability="gemini-1.5-flash",
+    )
     
     payload_str = json.dumps(payload)
     headers = identity.get_auth_headers(payload_str)

--- a/node/task_envelope.py
+++ b/node/task_envelope.py
@@ -1,0 +1,51 @@
+from typing import Optional
+
+
+def build_task_envelope(
+    node_id: str,
+    instructions: str,
+    bounty: float,
+    *,
+    intent_type: str = "analysis.request",
+    target_node: Optional[str] = None,
+    target_capability: Optional[str] = None,
+    expected_output: Optional[dict] = None,
+    payload_uri: Optional[str] = None,
+    secret_data: Optional[str] = None,
+) -> dict:
+    bounty_ns = int(abs(float(bounty)) * 1_000_000_000)
+    if bounty < 0:
+        market = "data"
+        payment_direction = "receiver_to_sender"
+    elif bounty == 0:
+        market = "chat"
+        payment_direction = "none"
+    else:
+        market = "compute"
+        payment_direction = "sender_to_receiver"
+
+    body = {
+        "source": {"node_id": node_id},
+        "intent": {"type": intent_type},
+        "task": {
+            "instructions": instructions,
+            "expected_output": expected_output or {"result_type": "text"},
+        },
+        "economics": {
+            "bounty_ns": bounty_ns,
+            "currency": "MEP_NS",
+            "market": market,
+            "payment_direction": payment_direction,
+        },
+    }
+    if target_node or target_capability:
+        body["routing"] = {}
+        if target_node:
+            body["routing"]["target_node_id"] = target_node
+        if target_capability:
+            body["routing"]["target_capability"] = target_capability
+    if payload_uri is not None:
+        body["payload_uri"] = payload_uri
+    if secret_data is not None:
+        body["secret_data"] = secret_data
+    return body

--- a/node/test_engineer.py
+++ b/node/test_engineer.py
@@ -3,6 +3,7 @@ import os
 import json
 import requests
 from identity import MEPIdentity
+from task_envelope import build_task_envelope
 
 HUB_URL = os.getenv("HUB_URL", "https://mep-hub.silentcopilot.ai")
 TARGET_NODE = "node_1c1a93dda148" # Myself
@@ -11,15 +12,13 @@ def send_engineer_task():
     key_path = os.path.expanduser("~/.mep/mep_ai_provider.pem")
     identity = MEPIdentity(key_path)
     
-    payload = {
-        "consumer_id": identity.node_id,
-        "payload": "Write a python script to check my MEP balance using the local get_balance.py script and output just the balance number.",
-        "bounty": 0.0,
-        "model_requirement": "cli-agent", # Trigger Engineer
-        "target_node": TARGET_NODE,
-        "payload_uri": None,
-        "secret_data": None
-    }
+    payload = build_task_envelope(
+        identity.node_id,
+        "Write a python script to check my MEP balance using the local get_balance.py script and output just the balance number.",
+        0.0,
+        target_node=TARGET_NODE,
+        target_capability="cli-agent",
+    )
     
     payload_str = json.dumps(payload)
     headers = identity.get_auth_headers(payload_str)

--- a/tests/test_node_task_envelope.py
+++ b/tests/test_node_task_envelope.py
@@ -1,0 +1,53 @@
+from node.task_envelope import build_task_envelope
+
+
+def test_build_task_envelope_for_targeted_compute():
+    body = build_task_envelope(
+        "node_consumer",
+        "pay for work",
+        0.25,
+        target_node="node_provider",
+        target_capability="gemini-1.5-flash",
+    )
+
+    assert body["source"] == {"node_id": "node_consumer"}
+    assert body["intent"] == {"type": "analysis.request"}
+    assert body["task"] == {
+        "instructions": "pay for work",
+        "expected_output": {"result_type": "text"},
+    }
+    assert body["economics"] == {
+        "bounty_ns": 250_000_000,
+        "currency": "MEP_NS",
+        "market": "compute",
+        "payment_direction": "sender_to_receiver",
+    }
+    assert body["routing"] == {
+        "target_node_id": "node_provider",
+        "target_capability": "gemini-1.5-flash",
+    }
+
+
+def test_build_task_envelope_for_chat_and_data_markets():
+    chat = build_task_envelope("node_consumer", "hello", 0.0, target_node="node_provider")
+    data = build_task_envelope(
+        "node_seller",
+        "premium dataset",
+        -0.5,
+        target_node="node_buyer",
+        secret_data="encrypted-data",
+    )
+
+    assert chat["economics"] == {
+        "bounty_ns": 0,
+        "currency": "MEP_NS",
+        "market": "chat",
+        "payment_direction": "none",
+    }
+    assert data["economics"] == {
+        "bounty_ns": 500_000_000,
+        "currency": "MEP_NS",
+        "market": "data",
+        "payment_direction": "receiver_to_sender",
+    }
+    assert data["secret_data"] == "encrypted-data"


### PR DESCRIPTION
## Summary
- add a small node task-envelope builder for spec-shaped /tasks/submit bodies
- update standalone node helper scripts to send source/intent/task/economics/routing envelopes
- cover compute, chat, and data envelope generation with focused tests

## Tests
- python -m ruff check node\\task_envelope.py node\\pay_node.py node\\buy_data.py node\\broadcast_opinion.py node\\test_engineer.py tests\\test_node_task_envelope.py
- python -m pytest tests\\test_node_task_envelope.py tests\\test_node_client.py tests\\test_load_runner.py tests\\test_hub_api.py -q