### PR TITLE
feat(client): submit spec envelopes from shared adapters

### DIFF
--- a/clients/adapters/mep_discord_adapter.py
+++ b/clients/adapters/mep_discord_adapter.py
@@ -56,7 +56,7 @@ async def mep(ctx, *, text: str):
         return
     response = await client.submit_task(payload, bounty, model, target)
     data = response["json"]
-    if response["status_code"] != 200:
+    if response["status_code"] != 200 or data.get("status") != "success":
         await ctx.send(f"Submit failed: {data}")
         return
     task_id = data.get("task_id")
@@ -69,7 +69,7 @@ async def mep(ctx, *, text: str):
 async def mepdm(ctx, target_node: str, *, message: str):
     response = await client.submit_task(message, 0.0, None, target_node)
     data = response["json"]
-    if response["status_code"] != 200:
+    if response["status_code"] != 200 or data.get("status") != "success":
         await ctx.send(f"DM failed: {data}")
         return
     task_id = data.get("task_id")
@@ -81,9 +81,9 @@ async def mepdm(ctx, target_node: str, *, message: str):
 @bot.command(name="mepdata")
 async def mepdata(ctx, price: float, *, payload: str):
     bounty = -abs(price)
-    response = await client.submit_task(payload, bounty, None, None)
+    response = await client.submit_task("Data offer available", bounty, secret_data=payload)
     data = response["json"]
-    if response["status_code"] != 200:
+    if response["status_code"] != 200 or data.get("status") != "success":
         await ctx.send(f"Data offer failed: {data}")
         return
     task_id = data.get("task_id")

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -6,9 +6,9 @@ import urllib.parse
 from typing import Awaitable, Callable, Optional
 
 import requests
-import websockets
 
 from clients.shared.identity import MEPIdentity
+from node.task_envelope import build_task_envelope
 
 HUB_URL = os.getenv("HUB_URL", "https://mep-hub.silentcopilot.ai")
 WS_URL = os.getenv("WS_URL", "wss://mep-hub.silentcopilot.ai")
@@ -42,18 +42,21 @@ class MEPClient:
         self,
         payload: str,
         bounty: float,
-        model_requirement: Optional[str],
-        target_node: Optional[str],
+        model_requirement: Optional[str] = None,
+        target_node: Optional[str] = None,
+        *,
+        payload_uri: Optional[str] = None,
+        secret_data: Optional[str] = None,
     ) -> dict:
-        body: dict = {
-            "consumer_id": self.node_id,
-            "payload": payload,
-            "bounty": bounty,
-        }
-        if model_requirement is not None:
-            body["model_requirement"] = model_requirement
-        if target_node is not None:
-            body["target_node"] = target_node
+        body = build_task_envelope(
+            self.node_id,
+            payload,
+            bounty,
+            target_node=target_node,
+            target_capability=model_requirement,
+            payload_uri=payload_uri,
+            secret_data=secret_data,
+        )
         payload_str = json.dumps(body)
         headers = self._auth_headers(payload_str)
         response = await asyncio.to_thread(
@@ -164,6 +167,8 @@ class MEPClient:
         on_result: Callable[[dict], Awaitable[None]],
         on_event: Optional[Callable[[dict], Awaitable[None]]] = None,
     ) -> None:
+        import websockets
+
         while not self._stop.is_set():
             ts = str(int(time.time()))
             sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -28,7 +28,7 @@ class StdioAdapter:
             return
         response = await self.client.submit_task(payload, bounty, model, target)
         data = response["json"]
-        if response["status_code"] != 200:
+        if response["status_code"] != 200 or data.get("status") != "success":
             print(f"[{self.platform_name}] submit failed: {data}")
             return
         print(f"[{self.platform_name}] submitted task {data.get('task_id')}")
@@ -36,16 +36,16 @@ class StdioAdapter:
     async def _send_dm(self, target_node: str, message: str) -> None:
         response = await self.client.submit_task(message, 0.0, None, target_node)
         data = response["json"]
-        if response["status_code"] != 200:
+        if response["status_code"] != 200 or data.get("status") != "success":
             print(f"[{self.platform_name}] dm failed: {data}")
             return
         print(f"[{self.platform_name}] sent dm task {data.get('task_id')} to {target_node}")
 
     async def _offer_data(self, price: str, payload: str) -> None:
         bounty = -abs(float(price))
-        response = await self.client.submit_task(payload, bounty, None, None)
+        response = await self.client.submit_task("Data offer available", bounty, secret_data=payload)
         data = response["json"]
-        if response["status_code"] != 200:
+        if response["status_code"] != 200 or data.get("status") != "success":
             print(f"[{self.platform_name}] data offer failed: {data}")
             return
         print(f"[{self.platform_name}] offered data task {data.get('task_id')} for {bounty} SECONDS")

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -1,0 +1,101 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import patch
+
+from clients.shared.mep_client import MEPClient
+
+
+class _FakeIdentity:
+    node_id = "node_consumer"
+    pub_pem = "pub"
+
+    def get_auth_headers(self, payload: str) -> dict:
+        return {"X-MEP-NodeID": self.node_id, "X-MEP-Signature": "sig"}
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json_data = json_data or {"status": "success", "task_id": "task_123456"}
+
+    def json(self) -> dict:
+        return self._json_data
+
+
+class TestSharedMEPClient(unittest.TestCase):
+    def test_submit_task_uses_spec_shaped_envelope(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+
+            response = asyncio.run(
+                client.submit_task(
+                    "summarize this",
+                    1.5,
+                    model_requirement="text",
+                    target_node="node_provider",
+                )
+            )
+
+        self.assertEqual(response["json"]["task_id"], "task_123456")
+        body = json.loads(session.post.call_args.kwargs["data"])
+        self.assertEqual(body["source"], {"node_id": "node_consumer"})
+        self.assertEqual(body["task"]["instructions"], "summarize this")
+        self.assertEqual(body["task"]["expected_output"], {"result_type": "text"})
+        self.assertEqual(
+            body["economics"],
+            {
+                "bounty_ns": 1_500_000_000,
+                "currency": "MEP_NS",
+                "market": "compute",
+                "payment_direction": "sender_to_receiver",
+            },
+        )
+        self.assertEqual(body["routing"], {"target_node_id": "node_provider", "target_capability": "text"})
+
+    def test_submit_task_can_send_secret_data_offer(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+
+            asyncio.run(client.submit_task("Data offer available", -0.25, secret_data="encrypted-data"))
+
+        body = json.loads(session.post.call_args.kwargs["data"])
+        self.assertEqual(
+            body["economics"],
+            {
+                "bounty_ns": 250_000_000,
+                "currency": "MEP_NS",
+                "market": "data",
+                "payment_direction": "receiver_to_sender",
+            },
+        )
+        self.assertEqual(body["secret_data"], "encrypted-data")
+
+    def test_submit_task_preserves_200_error_body(self):
+        response_body = {"status": "error", "detail": "Target node not currently connected to Hub"}
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse(200, response_body)
+            client = MEPClient("unused.pem")
+
+            response = asyncio.run(client.submit_task("hello", 0.0, target_node="node_offline"))
+
+        self.assertEqual(response["status_code"], 200)
+        self.assertEqual(response["json"], response_body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update clients/shared/MEPClient to submit spec-shaped task envelopes via node.task_envelope
- allow shared adapter data offers to include secret_data for negative-bounty data-market submissions
- make stdio and Discord adapters treat HTTP 200 error bodies as failed submits
- lazy-import websockets in the shared client listener so HTTP submit tests do not need optional WS runtime deps

## Tests
- python -m ruff check clients\\shared\\mep_client.py clients\\shared\\stdio_adapter.py clients\\adapters\\mep_discord_adapter.py tests\\test_shared_mep_client.py
- python -m pytest tests\\test_shared_mep_client.py tests\\test_node_task_envelope.py tests\\test_node_client.py tests\\test_load_runner.py tests\\test_hub_api.py -q