### PR TITLE
fix(runtime): gate data-market bidding by budget

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -134,6 +134,7 @@ class RuntimeNode:
         self.ws_url = ws_url.rstrip("/")
         self.adapter = adapter
         self.running = True
+        self.max_purchase_price = float(os.getenv("MEP_MAX_PURCHASE_PRICE", "0.0"))
 
     def _auth_headers(self, payload: str) -> dict[str, str]:
         headers = self.identity.get_auth_headers(payload)
@@ -160,6 +161,23 @@ class RuntimeNode:
         )
         if code != 200:
             print(f"[mep run] bid failed task={task_id[:8]} status={code} detail={raw}")
+
+    def should_bid(self, task_data: dict[str, Any]) -> bool:
+        try:
+            bounty = float(task_data.get("bounty") or 0.0)
+        except (TypeError, ValueError):
+            return False
+        if bounty >= 0:
+            return True
+        cost = abs(bounty)
+        if cost <= self.max_purchase_price:
+            return True
+        task_id = str(task_data.get("id") or "")
+        print(
+            f"[mep run] skip data-market task={task_id[:8]} "
+            f"cost={cost:.6f} max_purchase_price={self.max_purchase_price:.6f}"
+        )
+        return False
 
     def complete(self, task_id: str, result_payload: str) -> None:
         payload = json.dumps(
@@ -216,7 +234,7 @@ class RuntimeNode:
                         if event == "rfc":
                             task = data.get("data", {})
                             task_id = str(task.get("id") or "")
-                            if task_id:
+                            if task_id and self.should_bid(task):
                                 self.bid(task_id)
                         elif event == "new_task":
                             await self.process_task(data.get("data", {}))

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -17,6 +17,26 @@ class _FakeResponse:
         return self._json_data
 
 
+class _FakeIdentity:
+    node_id = "node_runtime"
+    pub_pem = "pub"
+
+    def get_auth_headers(self, payload: str) -> dict:
+        return {"X-MEP-NodeID": self.node_id, "X-MEP-Signature": "sig"}
+
+    def sign(self, node_id: str, timestamp: str) -> str:
+        return "sig"
+
+
+def _runtime_node() -> mep_runtime.RuntimeNode:
+    return mep_runtime.RuntimeNode(
+        identity=_FakeIdentity(),
+        hub_url="http://hub",
+        ws_url="ws://hub",
+        adapter=mep_runtime.MockAdapter(),
+    )
+
+
 class TestRuntimeUx(unittest.TestCase):
     def test_status_prints_listener_hint_when_ws_offline(self):
         args = argparse.Namespace(
@@ -57,6 +77,32 @@ class TestRuntimeUx(unittest.TestCase):
         self.assertEqual(init_mock.call_count, 1)
         self.assertEqual(doctor_mock.call_count, 1)
         self.assertEqual(run_mock.call_count, 1)
+
+
+class TestRuntimeBidPolicy(unittest.TestCase):
+    def test_compute_and_chat_tasks_are_bid_by_default(self):
+        node = _runtime_node()
+
+        self.assertTrue(node.should_bid({"id": "task_compute", "bounty": 1.0}))
+        self.assertTrue(node.should_bid({"id": "task_chat", "bounty": 0.0}))
+
+    def test_data_market_tasks_require_purchase_budget(self):
+        with patch.dict("os.environ", {"MEP_MAX_PURCHASE_PRICE": "0.25"}):
+            node = _runtime_node()
+
+        self.assertTrue(node.should_bid({"id": "task_data_ok", "bounty": -0.25}))
+        self.assertFalse(node.should_bid({"id": "task_data_expensive", "bounty": -0.5}))
+
+    def test_data_market_tasks_are_rejected_by_default(self):
+        with patch.dict("os.environ", {}, clear=True):
+            node = _runtime_node()
+
+        self.assertFalse(node.should_bid({"id": "task_data", "bounty": -0.01}))
+
+    def test_invalid_bounty_is_not_bid(self):
+        node = _runtime_node()
+
+        self.assertFalse(node.should_bid({"id": "task_bad", "bounty": "not-a-number"}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an explicit RuntimeNode.should_bid policy for RFCs
- keep compute and zero-bounty chat bid behavior unchanged
- reject negative-bounty data-market RFCs by default unless MEP_MAX_PURCHASE_PRICE allows the cost
- cover compute/chat acceptance, data-market budget acceptance/rejection, and invalid bounty rejection

## Tests
- python -m ruff check node\\mep_runtime.py tests\\test_node_runtime.py
- python -m pytest tests\\test_node_runtime.py tests\\test_max_purchase_price.py tests\\test_hub_api.py::TestThreeMarketSpecConformance -q