### PR TITLE
chore(runtime): label mock replies by market

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -118,11 +118,25 @@ class MockAdapter:
         if not snippet:
             snippet = "<empty>"
         task_id = str(task_data.get("id", ""))[:8]
+        try:
+            bounty = float(task_data.get("bounty") or 0.0)
+        except (TypeError, ValueError):
+            bounty = 0.0
+        if bounty == 0:
+            market = "chat"
+            next_step = "DM received by runtime listener."
+        elif bounty < 0:
+            market = "data"
+            next_step = "Data purchase acknowledged by runtime listener."
+        else:
+            market = "compute"
+            next_step = "Switch adapter to ollama/openai-compatible after doctor is green."
         return (
             "MOCK_ADAPTER_OK\n"
             f"task={task_id}\n"
+            f"market={market}\n"
             f"summary={snippet}\n"
-            "next=Switch adapter to ollama/openai-compatible after doctor is green."
+            f"next={next_step}"
         )
 
 

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -37,6 +37,21 @@ def _runtime_node() -> mep_runtime.RuntimeNode:
     )
 
 
+class TestMockAdapter(unittest.TestCase):
+    def test_mock_adapter_labels_compute_chat_and_data_markets(self):
+        adapter = mep_runtime.MockAdapter()
+
+        compute = adapter.generate_reply("compute payload", {"id": "task_compute", "bounty": 1.0})
+        chat = adapter.generate_reply("hello", {"id": "task_chat", "bounty": 0.0})
+        data = adapter.generate_reply("dataset", {"id": "task_data", "bounty": -0.25})
+
+        self.assertIn("market=compute", compute)
+        self.assertIn("market=chat", chat)
+        self.assertIn("DM received", chat)
+        self.assertIn("market=data", data)
+        self.assertIn("Data purchase acknowledged", data)
+
+
 class TestRuntimeUx(unittest.TestCase):
     def test_status_prints_listener_hint_when_ws_offline(self):
         args = argparse.Namespace(


### PR DESCRIPTION
## Summary
- make the default mock runtime response label compute, chat, and data markets
- give zero-bounty DMs and data purchases distinct acknowledgement text
- add focused unit coverage for market-aware mock replies

## Tests
- python -m ruff check node\\mep_runtime.py tests\\test_node_runtime.py
- python -m pytest tests\\test_node_runtime.py tests\\test_hub_api.py::TestThreeMarketSpecConformance -q