### PR TITLE
docs: add three-market testing readiness notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ I want to...
 - Concrete example: **earn `100 SECONDS` overnight = process about `20 tasks`**.
 - The exact bounty is set per task. Positive bounties pay providers, zero-bounty tasks are free chat, and negative bounties let consumers charge for valuable data.
 
+### Human Display vs Wire Precision
+
+Humans should think and read balances in `SECONDS`. Protocol messages use integer nanoseconds for precision:
+
+```text
+1 SECONDS = 1,000,000,000 MEP_NS
+```
+
+- User interfaces, CLI output, and onboarding docs should display `SECONDS`.
+- Signed task envelopes use `economics.bounty_ns` with `currency: "MEP_NS"`.
+- Raw `bounty_ns` values should only appear in protocol/debug views, clearly labeled as `MEP_NS`.
+- `bounty_ns` is non-negative. Direction is represented by `payment_direction`, not by a negative wire amount.
+
 ## Architecture At A Glance
 
 ```text
@@ -278,6 +291,27 @@ No. You can point a node or adapter at any reachable hub by setting `HUB_URL` an
 - **Spend:** you submit a positive-bounty task for others to do.
 - **Free:** zero-bounty targeted chat.
 - **Sell data:** negative bounty means the provider pays the consumer to receive valuable data.
+
+The signed wire envelope represents the same economics with non-negative `bounty_ns` plus `payment_direction`:
+
+- **Compute:** `market=compute`, `payment_direction=sender_to_receiver`.
+- **Chat:** `market=chat`, `bounty_ns=0`, `payment_direction=none`.
+- **Data:** `market=data`, `payment_direction=receiver_to_sender`.
+
+</details>
+
+<details>
+<summary><strong>How do I test all three markets locally?</strong></summary>
+
+Start a local hub, then run the 3-market smoke script:
+
+```bash
+export HUB_URL=http://localhost:8000
+export WS_URL=ws://localhost:8000
+python node/test_three_markets.py
+```
+
+The script exercises compute, targeted chat, and data-market purchase flows. It prints expected final balances so an operator can quickly confirm the ledger behavior.
 
 </details>
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,6 +52,45 @@ python node/test_three_markets.py
 python node/test_dm.py
 ```
 
+### 3-Market Smoke Test
+
+Use `node/test_three_markets.py` before real-world node-to-node testing. It submits current spec-shaped envelopes and exercises:
+
+- compute: sender pays receiver
+- chat/DM: targeted zero-bounty delivery
+- data: receiver pays sender for `secret_data`
+
+```bash
+export HUB_URL=http://localhost:8000
+export WS_URL=ws://localhost:8000
+python node/test_three_markets.py
+```
+
+Expected final balances start from the default 10 SECONDS registration bonus:
+
+- Alice: pays 5 SECONDS for compute, earns 2 SECONDS for data, ends near 7 SECONDS.
+- Bob: earns 5 SECONDS for compute, pays 2 SECONDS for data, ends near 13 SECONDS.
+
+### Data-Market Safety
+
+The standard runtime does not auto-buy negative-bounty data by default. To allow a runtime node to buy data during controlled tests, set:
+
+```bash
+export MEP_MAX_PURCHASE_PRICE=2.0
+```
+
+This means the node may auto-bid on data-market RFCs costing up to 2.0 SECONDS. Keep it unset or `0.0` for normal safety.
+
+### SECONDS vs MEP_NS
+
+Humans and ledger output use `SECONDS`. Spec-shaped task envelopes use integer nanoseconds:
+
+```text
+1 SECONDS = 1,000,000,000 MEP_NS
+```
+
+For example, `bounty_ns=500000000` means `0.5 SECONDS`. Test output should prefer `SECONDS`; raw `bounty_ns` should be clearly labeled when shown.
+
 ## Writing New Tests
 
 1. Create test files in `tests/` with the prefix `test_`


### PR DESCRIPTION
## Summary
- document SECONDS as the human-facing unit and bounty_ns/MEP_NS as wire precision
- document compute/chat/data payment_direction semantics in README
- add TESTING guidance for the 3-market smoke script and data-market safety budget

## Tests
- git diff --check
- verified README.md and TESTING.md contain the new testing-readiness sections