### PR TITLE
fix(ws): set Host header for WebSocket connections through nginx proxy

### DIFF
--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -168,13 +168,14 @@ class MEPClient:
         on_event: Optional[Callable[[dict], Awaitable[None]]] = None,
     ) -> None:
         import websockets
+        from urllib.parse import urlparse
 
         while not self._stop.is_set():
             ts = str(int(time.time()))
             sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))
             uri = f"{WS_URL}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
             try:
-                async with websockets.connect(uri) as ws:
+                async with websockets.connect(uri, host=urlparse(uri).hostname) as ws:
                     heartbeat_task: Optional[asyncio.Task] = None
                     if WS_HEARTBEAT_INTERVAL_SECONDS > 0:
                         heartbeat_task = asyncio.create_task(self._heartbeat_loop(ws))

--- a/node/client.py
+++ b/node/client.py
@@ -4,10 +4,8 @@ import requests
 import uuid
 import time
 import urllib.parse
-import websockets
 from reputation import ReputationManager
 from identity import MEPIdentity
-from ws_connect import ws_connect
 
 WS_HEARTBEAT_INTERVAL_SECONDS = 60
 
@@ -78,7 +76,7 @@ class ChronosNode:
 
     async def listen(self):
         """Persistent WebSocket connection."""
-        import websockets
+        from ws_connect import ws_connect
 
         ts = str(int(time.time()))
         sig = self.identity.sign(self.node_id, ts)

--- a/node/client.py
+++ b/node/client.py
@@ -4,8 +4,10 @@ import requests
 import uuid
 import time
 import urllib.parse
+import websockets
 from reputation import ReputationManager
 from identity import MEPIdentity
+from ws_connect import ws_connect
 
 WS_HEARTBEAT_INTERVAL_SECONDS = 60
 
@@ -82,7 +84,7 @@ class ChronosNode:
         sig = self.identity.sign(self.node_id, ts)
         sig_safe = urllib.parse.quote(sig)
         uri = f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig_safe}"
-        async with websockets.connect(uri) as ws:
+        async with ws_connect(uri) as ws:
             print(f"[Node {self.node_id}] Connected to Hub via WebSocket.")
             heartbeat_task = asyncio.create_task(self._heartbeat_loop(ws))
             try:

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -227,6 +227,7 @@ class RuntimeNode:
     async def run_forever(self) -> int:
         try:
             import websockets  # type: ignore
+            from ws_connect import ws_connect  # type: ignore
         except ImportError:
             print("[mep run] missing optional dependency: websockets")
             print("[mep run] install with: pip install websockets")
@@ -239,7 +240,7 @@ class RuntimeNode:
         while self.running:
             uri = self._ws_uri()
             try:
-                async with websockets.connect(uri) as ws:
+                async with ws_connect(uri) as ws:
                     print(f"[mep run] connected ws node={self.node_id}")
                     while self.running:
                         msg = await asyncio.wait_for(ws.recv(), timeout=20.0)

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -226,7 +226,9 @@ class RuntimeNode:
 
     async def run_forever(self) -> int:
         try:
-            import websockets  # type: ignore
+            from importlib.util import find_spec
+            if find_spec("websockets") is None:
+                raise ImportError("websockets not available")
             from ws_connect import ws_connect  # type: ignore
         except ImportError:
             print("[mep run] missing optional dependency: websockets")

--- a/node/ws_connect.py
+++ b/node/ws_connect.py
@@ -1,0 +1,22 @@
+"""Shared WebSocket connection helper.
+
+Ensures the Host header is set correctly when connecting through
+an nginx reverse proxy. Without an explicit host, the Python
+websockets library may include the port in the Host header
+(e.g. "Host: host:443") which nginx may reject with HTTP 403.
+
+Usage:
+    from ws_connect import ws_connect
+    async with ws_connect(uri) as ws:
+        ...
+"""
+
+from urllib.parse import urlparse
+import websockets
+
+
+def ws_connect(uri: str, **kwargs):
+    """Connect to a WebSocket URI, ensuring the Host header is correct."""
+    parsed = urlparse(uri)
+    kwargs.setdefault("host", parsed.hostname)
+    return websockets.connect(uri, **kwargs)

--- a/node/ws_connect.py
+++ b/node/ws_connect.py
@@ -12,11 +12,11 @@ Usage:
 """
 
 from urllib.parse import urlparse
-import websockets
 
 
 def ws_connect(uri: str, **kwargs):
     """Connect to a WebSocket URI, ensuring the Host header is correct."""
+    import websockets  # lazy import — websockets is optional
     parsed = urlparse(uri)
     kwargs.setdefault("host", parsed.hostname)
     return websockets.connect(uri, **kwargs)

--- a/tests/load/mep_load_runner.py
+++ b/tests/load/mep_load_runner.py
@@ -198,13 +198,14 @@ class VirtualNode:
 
     async def connect_and_listen(self) -> None:
         import websockets
+        from urllib.parse import urlparse
 
         while not self.stop_event.is_set():
             ts = str(int(time.time()))
             sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))
             uri = f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
             try:
-                self.ws = await websockets.connect(uri, ping_interval=20, ping_timeout=20)
+                self.ws = await websockets.connect(uri, ping_interval=20, ping_timeout=20, host=urlparse(uri).hostname)
                 while not self.stop_event.is_set():
                     raw = await self.ws.recv()
                     data = json.loads(raw)


### PR DESCRIPTION
## Problem

The Python `websockets` library may include the port in the Host header (e.g. `Host: host:443`) when connecting through an nginx reverse proxy. Some nginx configurations reject this with **HTTP 403**.

**Found during live MEP-hub DM testing** — spec DMs via HTTP `/tasks/submit` work perfectly, but WebSocket connections to `wss://mep-hub.silentcopilot.ai/ws/{node_id}` were consistently rejected with 403 from the sandbox IP.

## Root Cause

`websockets.connect(uri)` derives the Host header from the URI, which for `wss://host:443/path` becomes `host:443`. nginx on the hub server expects `host` (no port) and returns 403 for a mismatched Host header.

## Fix

Add explicit `host=` parameter extracted from the URI via `urlparse(uri).hostname`:

```python
from urllib.parse import urlparse
async with websockets.connect(uri, host=urlparse(uri).hostname) as ws:
    ...
```

### Files changed

| File | Change |
|------|--------|
| `node/ws_connect.py` | **New** — shared helper that wraps `websockets.connect` with correct Host header |
| `node/client.py` | Use `ws_connect()` helper |
| `node/mep_runtime.py` | Use `ws_connect()` helper |
| `clients/shared/mep_client.py` | Pass `host=urlparse(uri).hostname` directly |
| `tests/load/mep_load_runner.py` | Pass `host=urlparse(uri).hostname` directly |

## Validation

```
python -m pytest tests/test_node_client.py tests/test_node_runtime.py tests/test_shared_mep_client.py tests/test_load_runner.py tests/test_hub_api.py -q
# 52 passed ✅
```