### PR TITLE
fix(runtime): keep websocket alive on idle timeout

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -224,6 +224,25 @@ class RuntimeNode:
         sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))
         return f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
 
+    async def handle_ws_event(self, data: dict[str, Any]) -> None:
+        event = data.get("event")
+        if event == "rfc":
+            task = data.get("data", {})
+            task_id = str(task.get("id") or "")
+            if task_id and self.should_bid(task):
+                self.bid(task_id)
+        elif event == "new_task":
+            await self.process_task(data.get("data", {}))
+
+    async def _recv_loop(self, ws: Any) -> None:
+        while self.running:
+            try:
+                msg = await asyncio.wait_for(ws.recv(), timeout=20.0)
+            except asyncio.TimeoutError:
+                await ws.ping()
+                continue
+            await self.handle_ws_event(json.loads(msg))
+
     async def run_forever(self) -> int:
         try:
             import websockets  # type: ignore
@@ -241,19 +260,7 @@ class RuntimeNode:
             try:
                 async with websockets.connect(uri) as ws:
                     print(f"[mep run] connected ws node={self.node_id}")
-                    while self.running:
-                        msg = await asyncio.wait_for(ws.recv(), timeout=20.0)
-                        data = json.loads(msg)
-                        event = data.get("event")
-                        if event == "rfc":
-                            task = data.get("data", {})
-                            task_id = str(task.get("id") or "")
-                            if task_id and self.should_bid(task):
-                                self.bid(task_id)
-                        elif event == "new_task":
-                            await self.process_task(data.get("data", {}))
-            except asyncio.TimeoutError:
-                continue
+                    await self._recv_loop(ws)
             except KeyboardInterrupt:
                 self.running = False
             except Exception as exc:  # noqa: BLE001

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -1,4 +1,6 @@
 import argparse
+import asyncio
+import json
 import unittest
 from unittest.mock import patch
 
@@ -35,6 +37,21 @@ def _runtime_node() -> mep_runtime.RuntimeNode:
         ws_url="ws://hub",
         adapter=mep_runtime.MockAdapter(),
     )
+
+
+class _FakeWebSocket:
+    def __init__(self, messages):
+        self.messages = list(messages)
+        self.pings = 0
+
+    async def recv(self):
+        item = self.messages.pop(0)
+        if item == "timeout":
+            raise asyncio.TimeoutError
+        return item
+
+    async def ping(self):
+        self.pings += 1
 
 
 class TestMockAdapter(unittest.TestCase):
@@ -118,6 +135,19 @@ class TestRuntimeBidPolicy(unittest.TestCase):
         node = _runtime_node()
 
         self.assertFalse(node.should_bid({"id": "task_bad", "bounty": "not-a-number"}))
+
+
+class TestRuntimeWebSocketLoop(unittest.TestCase):
+    def test_idle_timeout_pings_without_reconnecting(self):
+        node = _runtime_node()
+        task_payload = json.dumps({"event": "rfc", "data": {"id": "task_compute", "bounty": 1.0}})
+        ws = _FakeWebSocket(["timeout", task_payload])
+
+        with patch.object(node, "bid", side_effect=lambda task_id: setattr(node, "running", False)) as bid_mock:
+            asyncio.run(node._recv_loop(ws))
+
+        self.assertEqual(ws.pings, 1)
+        bid_mock.assert_called_once_with("task_compute")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep the runtime WebSocket receive loop alive when an idle recv timeout occurs
- send a WebSocket ping on idle timeout instead of falling out to the reconnect path
- split WebSocket event dispatch into a testable helper and add a regression test

## Context
Live node-to-node DM testing against mep-hub.silentcopilot.ai showed repeated '[mep run] connected ws ...' log noise while the runtime was otherwise healthy. The receive timeout was being handled outside the active WebSocket context, so normal idle periods caused reconnects.

## Tests
- python -m ruff check node\\mep_runtime.py tests\\test_node_runtime.py
- python -m pytest tests\\test_node_runtime.py tests\\test_hub_api.py::TestThreeMarketSpecConformance -q