### PR TITLE
fix(ws): normalize default ports before connecting

### DIFF
--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -9,6 +9,7 @@ import requests
 
 from clients.shared.identity import MEPIdentity
 from node.task_envelope import build_task_envelope
+from node.ws_connect import ws_connect
 
 HUB_URL = os.getenv("HUB_URL", "https://mep-hub.silentcopilot.ai")
 WS_URL = os.getenv("WS_URL", "wss://mep-hub.silentcopilot.ai")
@@ -167,14 +168,12 @@ class MEPClient:
         on_result: Callable[[dict], Awaitable[None]],
         on_event: Optional[Callable[[dict], Awaitable[None]]] = None,
     ) -> None:
-        import websockets
-
         while not self._stop.is_set():
             ts = str(int(time.time()))
             sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))
             uri = f"{WS_URL}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
             try:
-                async with websockets.connect(uri) as ws:
+                async with ws_connect(uri) as ws:
                     heartbeat_task: Optional[asyncio.Task] = None
                     if WS_HEARTBEAT_INTERVAL_SECONDS > 0:
                         heartbeat_task = asyncio.create_task(self._heartbeat_loop(ws))

--- a/node/client.py
+++ b/node/client.py
@@ -76,13 +76,13 @@ class ChronosNode:
 
     async def listen(self):
         """Persistent WebSocket connection."""
-        import websockets
+        from ws_connect import ws_connect
 
         ts = str(int(time.time()))
         sig = self.identity.sign(self.node_id, ts)
         sig_safe = urllib.parse.quote(sig)
         uri = f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig_safe}"
-        async with websockets.connect(uri) as ws:
+        async with ws_connect(uri) as ws:
             print(f"[Node {self.node_id}] Connected to Hub via WebSocket.")
             heartbeat_task = asyncio.create_task(self._heartbeat_loop(ws))
             try:

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -245,7 +245,10 @@ class RuntimeNode:
 
     async def run_forever(self) -> int:
         try:
-            import websockets  # type: ignore
+            try:
+                from node.ws_connect import ws_connect
+            except ImportError:  # pragma: no cover - supports direct file execution
+                from ws_connect import ws_connect
         except ImportError:
             print("[mep run] missing optional dependency: websockets")
             print("[mep run] install with: pip install websockets")
@@ -258,7 +261,7 @@ class RuntimeNode:
         while self.running:
             uri = self._ws_uri()
             try:
-                async with websockets.connect(uri) as ws:
+                async with ws_connect(uri) as ws:
                     print(f"[mep run] connected ws node={self.node_id}")
                     await self._recv_loop(ws)
             except KeyboardInterrupt:

--- a/node/ws_connect.py
+++ b/node/ws_connect.py
@@ -1,0 +1,40 @@
+"""Shared WebSocket connection helpers."""
+
+from __future__ import annotations
+
+from urllib.parse import ParseResult, urlparse, urlunparse
+
+
+def normalize_ws_uri(uri: str) -> str:
+    """Remove explicit default ports so proxy Host checks see the canonical host."""
+    parsed = urlparse(uri)
+    if (parsed.scheme, parsed.port) not in {("ws", 80), ("wss", 443)}:
+        return uri
+
+    hostname = parsed.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    if parsed.username:
+        userinfo = parsed.username
+        if parsed.password:
+            userinfo = f"{userinfo}:{parsed.password}"
+        netloc = f"{userinfo}@{hostname}"
+    else:
+        netloc = hostname
+
+    normalized = ParseResult(
+        scheme=parsed.scheme,
+        netloc=netloc,
+        path=parsed.path,
+        params=parsed.params,
+        query=parsed.query,
+        fragment=parsed.fragment,
+    )
+    return urlunparse(normalized)
+
+
+def ws_connect(uri: str, **kwargs):
+    """Connect to a WebSocket URI after canonicalizing default ports."""
+    import websockets
+
+    return websockets.connect(normalize_ws_uri(uri), **kwargs)

--- a/tests/load/mep_load_runner.py
+++ b/tests/load/mep_load_runner.py
@@ -197,14 +197,14 @@ class VirtualNode:
         await self._complete(task_id, result)
 
     async def connect_and_listen(self) -> None:
-        import websockets
+        from node.ws_connect import ws_connect
 
         while not self.stop_event.is_set():
             ts = str(int(time.time()))
             sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))
             uri = f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
             try:
-                self.ws = await websockets.connect(uri, ping_interval=20, ping_timeout=20)
+                self.ws = await ws_connect(uri, ping_interval=20, ping_timeout=20)
                 while not self.stop_event.is_set():
                     raw = await self.ws.recv()
                     data = json.loads(raw)

--- a/tests/test_ws_connect.py
+++ b/tests/test_ws_connect.py
@@ -1,0 +1,13 @@
+from node.ws_connect import normalize_ws_uri
+
+
+def test_normalize_ws_uri_removes_default_wss_port():
+    uri = "wss://mep-hub.silentcopilot.ai:443/ws/node?timestamp=1&signature=sig"
+
+    assert normalize_ws_uri(uri) == "wss://mep-hub.silentcopilot.ai/ws/node?timestamp=1&signature=sig"
+
+
+def test_normalize_ws_uri_preserves_non_default_port():
+    uri = "ws://localhost:8000/ws/node?timestamp=1&signature=sig"
+
+    assert normalize_ws_uri(uri) == uri


### PR DESCRIPTION
## Summary
- add a shared WebSocket connector that strips explicit default ports from ws/wss URIs
- route active runtime/client/load-runner WebSocket connections through the helper
- add regression coverage for default-port normalization

## Why
Live hub testing suggested nginx may reject WebSocket handshakes when the URI contains an explicit default port, for example wss://host:443. In websockets 15, passing host= changes the TCP connection target, while the handshake Host header is built from the parsed URI. Normalizing wss://host:443 to wss://host before connect is the narrower client-side fix.

## Relation to PR #149
This is a smaller replacement for #149. It avoids the old runtime diff that predates PR #150 and avoids line-ending churn in clients/shared/mep_client.py.

## Tests
- python -m ruff check node\\ws_connect.py node\\mep_runtime.py node\\client.py clients\\shared\\mep_client.py tests\\load\\mep_load_runner.py tests\\test_ws_connect.py
- python -m pytest tests\\test_ws_connect.py tests\\test_node_runtime.py tests\\test_shared_mep_client.py tests\\test_load_runner.py -q