### PR TITLE
fix(ws): add exponential backoff on reconnect, hard backoff on 403

### DIFF
--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -168,12 +168,14 @@ class MEPClient:
         on_result: Callable[[dict], Awaitable[None]],
         on_event: Optional[Callable[[dict], Awaitable[None]]] = None,
     ) -> None:
+        backoff = 1.0
         while not self._stop.is_set():
             ts = str(int(time.time()))
             sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))
             uri = f"{WS_URL}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
             try:
                 async with ws_connect(uri) as ws:
+                    backoff = 1.0  # reset on successful connect
                     heartbeat_task: Optional[asyncio.Task] = None
                     if WS_HEARTBEAT_INTERVAL_SECONDS > 0:
                         heartbeat_task = asyncio.create_task(self._heartbeat_loop(ws))
@@ -189,8 +191,13 @@ class MEPClient:
                         if heartbeat_task:
                             heartbeat_task.cancel()
                             await asyncio.gather(heartbeat_task, return_exceptions=True)
-            except Exception:
-                await asyncio.sleep(2)
+            except Exception as exc:
+                err = str(exc)
+                if "403" in err or "InvalidStatus" in type(exc).__name__:
+                    backoff = min(backoff * 2, 60.0)
+                else:
+                    backoff = min(backoff * 1.5, 15.0)
+                await asyncio.sleep(backoff)
 
     async def _heartbeat_loop(self, ws) -> None:
         while not self._stop.is_set():

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -258,17 +258,27 @@ class RuntimeNode:
         print(f"[mep run] {message}")
         if not ok:
             return 2
+        backoff = 1.0
         while self.running:
             uri = self._ws_uri()
             try:
                 async with ws_connect(uri) as ws:
                     print(f"[mep run] connected ws node={self.node_id}")
+                    backoff = 1.0  # reset backoff on successful connect
                     await self._recv_loop(ws)
             except KeyboardInterrupt:
                 self.running = False
             except Exception as exc:  # noqa: BLE001
-                print(f"[mep run] websocket reconnect after error: {exc}")
-                await asyncio.sleep(3.0)
+                err = str(exc)
+                # 403 means the proxy/nginx is rate-limiting this IP — hard backoff
+                if "403" in err or "InvalidStatus" in type(exc).__name__:
+                    print(f"[mep run] WS rejected (403/rate-limit). Backing off {backoff:.0f}s: {err}")
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, 60.0)
+                else:
+                    print(f"[mep run] websocket reconnect after error: {exc}")
+                    await asyncio.sleep(max(backoff, 3.0))
+                    backoff = min(backoff * 1.5, 15.0)
         return 0
 
 


### PR DESCRIPTION
## Problem

During live DM testing on mep-hub.silentcopilot.ai, the WebSocket reconnect loop was retrying aggressively (flat 2-3s sleep) even when nginx was returning HTTP 403 (rate-limit). This caused log spam and wasted connection attempts.

## Fix

### Hard backoff on 403

```
403 → backoff * 2 (capped 60s)
```

403 from nginx means the IP is rate-limited. Hammering won't help.

### Gentler backoff on other errors

```
other → backoff * 1.5 (capped 15s)
```

### Reset on success

Backoff resets to 1s after a successful connect, so transient failures don't accumulate penalty.

## Files changed

| File | Change |
|------|--------|
| `node/mep_runtime.py` | Exponential backoff with 403 detection |
| `clients/shared/mep_client.py` | Same backoff for shared client listener |

## Inspiration

Suggested by Codex bot during live MEP-hub DM testing.

## Validation

```
python -m pytest tests/ -q
# 115 passed ✅
```