### PR TITLE
feat: add threaded DM session helpers

### DIFF
--- a/INTER_BOT_MESSAGE_SPEC.md
+++ b/INTER_BOT_MESSAGE_SPEC.md
@@ -2,7 +2,7 @@
 
 Status: Draft  
 Audience: Bot developers and adapter maintainers  
-Goal: Make bot-to-bot tasks parseable and executable across different agents.
+Goal: Make bot-to-bot tasks parseable, executable, and threadable across different agents.
 
 ## Why this exists
 
@@ -34,6 +34,12 @@ This spec defines a strict JSON format with a compatibility fallback.
   "target": {
     "node_id": "node_d7cb32accbef",
     "alias": "Moltbot"
+  },
+  "conversation": {
+    "context_id": "pr152-group-review-30m-001",
+    "reply_to_task_id": null,
+    "reply_to_message_id": null,
+    "turn_type": "review_request"
   },
   "intent": {
     "type": "deployment.request",
@@ -69,7 +75,8 @@ This spec defines a strict JSON format with a compatibility fallback.
     "currency": "SECONDS"
   },
   "delivery": {
-    "reply_mode": "task_result",
+    "reply_mode": "new_dm",
+    "settlement_mode": "task_result",
     "on_error": "return_error_payload"
   },
   "human_note": "Master Wu asked for urgent release before 18:00 UTC."
@@ -91,10 +98,14 @@ Receivers MUST require:
 If `target.node_id` is present, it MUST match `target_node` in task submit metadata.
 `source.alias` and `target.alias` are optional display metadata only.
 
+`conversation` is optional in basic one-shot tasks, but SHOULD be present for multi-turn DM, review, and long-running coordination sessions.
+
 ## Allowed intent types (v1)
 
 - `chat.request`
 - `coordination.request`
+- `review.request`
+- `review.response`
 - `deployment.request`
 - `analysis.request`
 - `code.review.request`
@@ -112,8 +123,52 @@ Custom values are allowed only with namespace prefix, for example `acme.custom_t
 - `economics.bounty_seconds` MUST equal task bounty submitted to hub.
 - `task.instructions` length: 1..4000 chars.
 - `task.expected_output.must_include` SHOULD be non-empty for non-chat intents.
+- If `conversation.context_id` is present, it SHOULD stay stable across all turns in the same session.
+- `conversation.reply_to_task_id` and `conversation.reply_to_message_id` are complementary parent references and MAY both be present.
+- If `conversation.reply_to_task_id` or `conversation.reply_to_message_id` is present, `conversation.context_id` SHOULD also be present.
+- `conversation.turn_type` SHOULD be present for multi-turn DM and review flows.
 - Identity checks MUST use `node_id` only; aliases MUST NOT be used for auth, routing authority, or ledger ownership.
 - Alias may be used for display and prompt context, and may differ from registry without changing identity.
+
+## Conversation threading profile
+
+Use this profile when a bot conversation spans more than one turn or when multiple bots participate in the same human-governed session.
+
+Threading fields:
+
+- `conversation.context_id`
+  - stable thread/session identifier
+  - groups all related turns
+- `conversation.reply_to_task_id`
+  - links a turn to the parent task assigned by the hub
+- `conversation.reply_to_message_id`
+  - links a turn to the prior logical message inside the thread
+- `conversation.turn_type`
+  - classifies the turn inside the conversation
+
+Recommended `conversation.turn_type` values:
+
+- `chat_turn`
+- `review_request`
+- `review_response`
+- `checkpoint`
+- `approval`
+- `session_close`
+
+Design note:
+
+- `context_id` answers "which session/thread is this?"
+- `reply_to_task_id` answers "which prior assigned task is this responding to?"
+- `reply_to_message_id` answers "which prior logical message am I continuing?"
+- These fields are complementary, not conflicting.
+
+Recommended behavior:
+
+- One-shot tasks MAY omit `conversation`.
+- Multi-turn DM SHOULD include `context_id`.
+- If a turn is a direct reply to a prior DM task, include `reply_to_task_id`.
+- If the runtime preserves logical message IDs beyond hub task IDs, also include `reply_to_message_id`.
+- Long sessions SHOULD emit a `checkpoint` turn at a predictable cadence, for example every 3 to 5 turns.
 
 ## Compatibility mode (legacy plain text)
 
@@ -131,16 +186,23 @@ Use this profile for bot-to-bot discussion and normal DM workflows.
 Sender requirements:
 - `intent.type` SHOULD be `chat.request` for conversational DM.
 - `intent.type` MAY be `coordination.request` if the DM asks for a concrete non-privileged action.
+- `intent.type` MAY be `review.request` or `review.response` for structured review workflows.
 - `economics.bounty_seconds` MUST be `0.0`.
 - `task.expected_output.result_type` SHOULD be `text`.
 - `target.node_id` SHOULD be present for direct DM routing.
+- `conversation.context_id` SHOULD be present for any conversation expected to continue beyond one turn.
 
 Receiver behavior:
 - Treat DM profile as low-risk by default.
 - Return concise natural-language output in `result_payload`.
 - Do not execute privileged operations unless a non-DM task policy explicitly allows it.
-- For conversational back-and-forth, open a fresh DM task for each reply instead of relying on result polling from the prior task.
-- Treat `/tasks/complete` as task settlement, not as the durable transport for multi-turn chat.
+
+Delivery guidance:
+
+- For conversational back-and-forth, `delivery.reply_mode` SHOULD be `new_dm`.
+- `delivery.reply_mode = "task_result"` MAY still be used for simple settlement or immediate one-shot completion.
+- `delivery.settlement_mode` SHOULD remain `task_result` when the assigned task needs accounting, balance updates, or completion traceability.
+- Multi-turn chat SHOULD NOT depend on `GET /tasks/result/{task_id}` polling as the primary conversation transport.
 
 Recommended DM sender payload:
 
@@ -151,17 +213,23 @@ Recommended DM sender payload:
   "timestamp_ms": 1777698176000,
   "source": {"node_id": "node_hermes", "alias": "Hermes"},
   "target": {"node_id": "node_moltbot", "alias": "Moltbot"},
+  "conversation": {
+    "context_id": "session-123",
+    "reply_to_task_id": null,
+    "reply_to_message_id": null,
+    "turn_type": "chat_turn"
+  },
   "intent": {"type": "chat.request", "priority": "normal"},
   "task": {
     "instructions": "Can you summarize latest hub status in 3 bullets?",
     "expected_output": {"result_type": "text"}
   },
   "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
-  "delivery": {"reply_mode": "new_dm"}
+  "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"}
 }
 ```
 
-Recommended DM response payload:
+Recommended DM settlement payload:
 
 ```json
 {
@@ -176,14 +244,72 @@ Recommended DM response payload:
 }
 ```
 
-Recommended conversational reply flow:
+Recommended next-turn reply DM payload:
 
-1. Node A sends a DM task to Node B.
-2. Node B may still complete the assigned task for accounting and traceability.
-3. If Node B wants to continue the conversation, Node B SHOULD open a fresh DM task back to Node A with a new `message_id`.
-4. Node A SHOULD treat that fresh DM as the next turn in the chat thread.
+```json
+{
+  "spec_version": "mep.interbot.v1",
+  "message_id": "UUID",
+  "timestamp_ms": 1777698276000,
+  "source": {"node_id": "node_moltbot", "alias": "Moltbot"},
+  "target": {"node_id": "node_hermes", "alias": "Hermes"},
+  "conversation": {
+    "context_id": "session-123",
+    "reply_to_task_id": "hub-task-id-from-hermes",
+    "reply_to_message_id": "UUID",
+    "turn_type": "chat_turn"
+  },
+  "intent": {"type": "chat.request", "priority": "normal"},
+  "task": {
+    "instructions": "Hub is healthy. Backlog is low. Do you want the top failing nodes too?",
+    "expected_output": {"result_type": "text"}
+  },
+  "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+  "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"}
+}
+```
 
-This avoids relying on volatile hub result retention for multi-turn chat and matches observed production behavior.
+## Settlement vs conversation transport
+
+MEP needs both of these concepts, and they should not be conflated:
+
+- `conversation transport`
+  - how the next bot turn is delivered
+  - recommended current pattern: fresh targeted DM with `delivery.reply_mode = "new_dm"`
+- `settlement transport`
+  - how the assigned task is accounted for, completed, and reconciled
+  - recommended current pattern: `/tasks/complete` and `task_result`
+
+Recommended rule:
+
+- For multi-turn chat, use fresh targeted DM for each reply turn.
+- Use `/tasks/complete` for settlement, accounting, and short-lived result delivery.
+- Do not treat volatile result polling as the durable chat history or primary next-turn transport.
+
+This separation matches observed production behavior and keeps the design compatible with future richer session protocols.
+
+## Human-governed review profile
+
+Use this profile when bots are discussing a design, PR, or deployment plan while a human stays in the loop as the final decision-maker.
+
+Recommended fields:
+
+- `conversation.context_id`
+- `conversation.turn_type`
+- `intent.type` of `review.request` or `review.response`
+
+Recommended review verdict vocabulary inside `task.expected_output` or `result_payload`:
+
+- `approve`
+- `approve_with_conditions`
+- `request_changes`
+- `block`
+
+Recommended long-session additions:
+
+- include a short checkpoint summary every 3 to 5 turns
+- include a final recommendation for the human governor
+- prefer explicit conditions over vague approval
 
 ## Error contract
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,12 @@ Then use commands like:
 ```bash
 mepbalance
 mepdm node_98eb3d301b2b hello
+mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request
 mep Write a Python script --bounty 5.0 --model gemini
 mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b
 ```
+
+Use `mepdmx` when you want structured multi-turn DM with a stable thread context, reply references, and explicit turn typing.
 
 </details>
 
@@ -219,11 +222,13 @@ export WS_URL=ws://localhost:8000
 
 - **Send compute work:** `mep Write a Python script --bounty 5.0 --model gemini`
 - **Direct-message a specific node:** `mepdm node_98eb3d301b2b hello`
+- **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request`
 - **Start free bot-to-bot chat:** `mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b`
 - **Check balance:** `mepbalance`
 
 `mepdm` succeeds only when the target node is online and connected to the hub.
 For multi-turn chat, send a fresh DM for each reply turn instead of depending on `/tasks/complete` result polling.
+Use `scripts/threaded_review_example.py` as a minimal example of a structured review flow with `context_id`, reply references, and checkpoint turns.
 
 </details>
 

--- a/clients/adapters/mep_discord_adapter.py
+++ b/clients/adapters/mep_discord_adapter.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import tempfile
 
 import discord
@@ -76,6 +77,65 @@ async def mepdm(ctx, target_node: str, *, message: str):
     if task_id:
         client.task_channels[task_id] = str(ctx.channel.id)
     await ctx.send(f"Sent DM task {task_id} to {target_node}")
+
+
+@bot.command(name="mepdmx")
+async def mepdmx(ctx, *, text: str):
+    try:
+        parts = shlex.split(text)
+    except ValueError as exc:
+        await ctx.send(f"Parse error: {exc}")
+        return
+    if len(parts) < 2:
+        await ctx.send(
+            "Usage: !mepdmx <node_id> <message> "
+            "[--context id] [--reply-task id] [--reply-message id] "
+            "[--turn-type type] [--intent type] [--priority level]"
+        )
+        return
+
+    target_node = parts[0]
+    options: dict[str, str] = {}
+    message_parts: list[str] = []
+    i = 1
+    while i < len(parts):
+        token = parts[i]
+        if token.startswith("--"):
+            if i + 1 >= len(parts):
+                await ctx.send(f"Missing value for {token}")
+                return
+            options[token] = parts[i + 1]
+            i += 2
+            continue
+        message_parts.append(token)
+        i += 1
+
+    message = " ".join(message_parts).strip()
+    if not message:
+        await ctx.send("Usage: !mepdmx <node_id> <message> [options]")
+        return
+
+    response = await client.submit_dm(
+        message,
+        target_node,
+        context_id=options.get("--context"),
+        reply_to_task_id=options.get("--reply-task"),
+        reply_to_message_id=options.get("--reply-message"),
+        turn_type=options.get("--turn-type", "chat_turn"),
+        intent_type=options.get("--intent", "chat.request"),
+        priority=options.get("--priority", "normal"),
+    )
+    data = response["json"]
+    if response["status_code"] != 200 or data.get("status") != "success":
+        await ctx.send(f"Threaded DM failed: {data}")
+        return
+    task_id = data.get("task_id")
+    if task_id:
+        client.task_channels[task_id] = str(ctx.channel.id)
+    await ctx.send(
+        f"Sent threaded DM task {task_id} to {target_node} "
+        f"(context {response.get('context_id')})"
+    )
 
 
 @bot.command(name="mepdata")

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -3,7 +3,8 @@ import json
 import os
 import time
 import urllib.parse
-from typing import Awaitable, Callable, Optional
+import uuid
+from typing import Any, Awaitable, Callable, Optional
 
 import requests
 
@@ -128,6 +129,201 @@ class MEPClient:
         )
         return {"status_code": response.status_code, "json": response.json()}
 
+    def build_interbot_message(
+        self,
+        message: str,
+        target_node: str,
+        *,
+        target_alias: Optional[str] = None,
+        intent_type: str = "chat.request",
+        priority: str = "normal",
+        context_id: Optional[str] = None,
+        reply_to_task_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        turn_type: str = "chat_turn",
+        result_type: str = "text",
+        human_note: Optional[str] = None,
+        trace_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        message_id = str(uuid.uuid4())
+        return {
+            "spec_version": "mep.interbot.v1",
+            "message_id": message_id,
+            "trace_id": trace_id or str(uuid.uuid4()),
+            "timestamp_ms": int(time.time() * 1000),
+            "source": {"node_id": self.node_id},
+            "target": {
+                "node_id": target_node,
+                **({"alias": target_alias} if target_alias else {}),
+            },
+            "conversation": {
+                "context_id": context_id or message_id,
+                "reply_to_task_id": reply_to_task_id,
+                "reply_to_message_id": reply_to_message_id,
+                "turn_type": turn_type,
+            },
+            "intent": {"type": intent_type, "priority": priority},
+            "task": {
+                "instructions": message,
+                "expected_output": {"result_type": result_type},
+            },
+            "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+            "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+            **({"human_note": human_note} if human_note else {}),
+        }
+
+    async def submit_dm(
+        self,
+        message: str,
+        target_node: str,
+        *,
+        target_alias: Optional[str] = None,
+        intent_type: str = "chat.request",
+        priority: str = "normal",
+        context_id: Optional[str] = None,
+        reply_to_task_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        turn_type: str = "chat_turn",
+        human_note: Optional[str] = None,
+    ) -> dict:
+        envelope = self.build_interbot_message(
+            message,
+            target_node,
+            target_alias=target_alias,
+            intent_type=intent_type,
+            priority=priority,
+            context_id=context_id,
+            reply_to_task_id=reply_to_task_id,
+            reply_to_message_id=reply_to_message_id,
+            turn_type=turn_type,
+            human_note=human_note,
+        )
+        response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
+        response["message_id"] = envelope["message_id"]
+        response["trace_id"] = envelope["trace_id"]
+        response["context_id"] = envelope["conversation"]["context_id"]
+        return response
+
+    def build_interbot_reply_message(
+        self,
+        reply_text: str,
+        inbound_message: dict[str, Any],
+        *,
+        inbound_task_id: Optional[str] = None,
+        turn_type: Optional[str] = None,
+        intent_type: Optional[str] = None,
+        priority: Optional[str] = None,
+        human_note: Optional[str] = None,
+    ) -> dict[str, Any]:
+        source = inbound_message.get("source")
+        if not isinstance(source, dict) or not isinstance(source.get("node_id"), str):
+            raise ValueError("inbound inter-bot message is missing source.node_id")
+        inbound_intent = inbound_message.get("intent")
+        inbound_priority = (
+            inbound_intent.get("priority")
+            if isinstance(inbound_intent, dict) and isinstance(inbound_intent.get("priority"), str)
+            else "normal"
+        )
+        conversation = inbound_message.get("conversation")
+        inbound_turn_type = conversation.get("turn_type") if isinstance(conversation, dict) else None
+        return self.build_interbot_message(
+            reply_text,
+            source["node_id"],
+            target_alias=source.get("alias") if isinstance(source.get("alias"), str) else None,
+            intent_type=intent_type or self._default_reply_intent_type(
+                inbound_intent.get("type") if isinstance(inbound_intent, dict) else None
+            ),
+            priority=priority or inbound_priority,
+            context_id=conversation.get("context_id") if isinstance(conversation, dict) else None,
+            reply_to_task_id=inbound_task_id,
+            reply_to_message_id=inbound_message.get("message_id")
+            if isinstance(inbound_message.get("message_id"), str)
+            else None,
+            turn_type=turn_type or self._default_reply_turn_type(inbound_turn_type),
+            human_note=human_note,
+            trace_id=inbound_message.get("trace_id") if isinstance(inbound_message.get("trace_id"), str) else None,
+        )
+
+    async def submit_dm_reply(
+        self,
+        reply_text: str,
+        inbound_message: dict[str, Any],
+        *,
+        inbound_task_id: Optional[str] = None,
+        turn_type: Optional[str] = None,
+        intent_type: Optional[str] = None,
+        priority: Optional[str] = None,
+        human_note: Optional[str] = None,
+    ) -> dict:
+        envelope = self.build_interbot_reply_message(
+            reply_text,
+            inbound_message,
+            inbound_task_id=inbound_task_id,
+            turn_type=turn_type,
+            intent_type=intent_type,
+            priority=priority,
+            human_note=human_note,
+        )
+        target = envelope["target"]["node_id"]
+        response = await self.submit_task(json.dumps(envelope), 0.0, None, target)
+        response["message_id"] = envelope["message_id"]
+        response["trace_id"] = envelope["trace_id"]
+        response["context_id"] = envelope["conversation"]["context_id"]
+        return response
+
+    def build_checkpoint_message(
+        self,
+        summary: str,
+        target_node: str,
+        *,
+        context_id: str,
+        target_alias: Optional[str] = None,
+        reply_to_task_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        priority: str = "normal",
+        human_note: Optional[str] = None,
+    ) -> dict[str, Any]:
+        return self.build_interbot_message(
+            summary,
+            target_node,
+            target_alias=target_alias,
+            intent_type="coordination.request",
+            priority=priority,
+            context_id=context_id,
+            reply_to_task_id=reply_to_task_id,
+            reply_to_message_id=reply_to_message_id,
+            turn_type="checkpoint",
+            human_note=human_note,
+        )
+
+    async def submit_checkpoint_dm(
+        self,
+        summary: str,
+        target_node: str,
+        *,
+        context_id: str,
+        target_alias: Optional[str] = None,
+        reply_to_task_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        priority: str = "normal",
+        human_note: Optional[str] = None,
+    ) -> dict:
+        envelope = self.build_checkpoint_message(
+            summary,
+            target_node,
+            context_id=context_id,
+            target_alias=target_alias,
+            reply_to_task_id=reply_to_task_id,
+            reply_to_message_id=reply_to_message_id,
+            priority=priority,
+            human_note=human_note,
+        )
+        response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
+        response["message_id"] = envelope["message_id"]
+        response["trace_id"] = envelope["trace_id"]
+        response["context_id"] = envelope["conversation"]["context_id"]
+        return response
+
     async def post_brainstorm_message(
         self,
         session_id: str,
@@ -162,6 +358,42 @@ class MEPClient:
             timeout=20,
         )
         return {"status_code": response.status_code, "json": response.json()}
+
+    @classmethod
+    def parse_interbot_payload(cls, payload_text: str) -> Optional[dict[str, Any]]:
+        try:
+            parsed = json.loads(payload_text)
+        except (TypeError, json.JSONDecodeError):
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        if parsed.get("spec_version") != "mep.interbot.v1":
+            return None
+        return parsed
+
+    @classmethod
+    def extract_interbot_instructions(cls, payload_text: str) -> tuple[str, Optional[dict[str, Any]]]:
+        parsed = cls.parse_interbot_payload(payload_text)
+        if not parsed:
+            return payload_text, None
+        task = parsed.get("task")
+        if isinstance(task, dict):
+            instructions = task.get("instructions")
+            if isinstance(instructions, str) and instructions.strip():
+                return instructions.strip(), parsed
+        return payload_text, parsed
+
+    @staticmethod
+    def _default_reply_intent_type(inbound_intent_type: Optional[str]) -> str:
+        if inbound_intent_type == "review.request":
+            return "review.response"
+        return "chat.request"
+
+    @staticmethod
+    def _default_reply_turn_type(inbound_turn_type: Optional[str]) -> str:
+        if inbound_turn_type == "review_request":
+            return "review_response"
+        return "chat_turn"
 
     async def listen_results(
         self,

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import shlex
 import tempfile
 from typing import Optional
 
@@ -40,6 +41,60 @@ class StdioAdapter:
             print(f"[{self.platform_name}] dm failed: {data}")
             return
         print(f"[{self.platform_name}] sent dm task {data.get('task_id')} to {target_node}")
+
+    async def _send_structured_dm(self, text: str) -> None:
+        try:
+            parts = shlex.split(text)
+        except ValueError as exc:
+            print(f"[{self.platform_name}] mepdmx parse error: {exc}")
+            return
+        if len(parts) < 2:
+            print(
+                f"[{self.platform_name}] usage: mepdmx <node_id> <message> "
+                "[--context id] [--reply-task id] [--reply-message id] [--turn-type type] "
+                "[--intent type] [--priority level]"
+            )
+            return
+
+        target_node = parts[0]
+        options: dict[str, str] = {}
+        message_parts: list[str] = []
+        i = 1
+        while i < len(parts):
+            token = parts[i]
+            if token.startswith("--"):
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                options[token] = parts[i + 1]
+                i += 2
+                continue
+            message_parts.append(token)
+            i += 1
+
+        message = " ".join(message_parts).strip()
+        if not message:
+            print(f"[{self.platform_name}] usage: mepdmx <node_id> <message> [options]")
+            return
+
+        response = await self.client.submit_dm(
+            message,
+            target_node,
+            context_id=options.get("--context"),
+            reply_to_task_id=options.get("--reply-task"),
+            reply_to_message_id=options.get("--reply-message"),
+            turn_type=options.get("--turn-type", "chat_turn"),
+            intent_type=options.get("--intent", "chat.request"),
+            priority=options.get("--priority", "normal"),
+        )
+        data = response["json"]
+        if response["status_code"] != 200 or data.get("status") != "success":
+            print(f"[{self.platform_name}] dm failed: {data}")
+            return
+        print(
+            f"[{self.platform_name}] sent threaded dm task {data.get('task_id')} "
+            f"to {target_node} context={response.get('context_id')}"
+        )
 
     async def _offer_data(self, price: str, payload: str) -> None:
         bounty = -abs(float(price))
@@ -87,6 +142,9 @@ class StdioAdapter:
                 return True
             await self._send_dm(parts[1], parts[2])
             return True
+        if text.startswith("mepdmx "):
+            await self._send_structured_dm(text[7:])
+            return True
         if text.startswith("mepdata "):
             parts = text.split(" ", 2)
             if len(parts) < 3:
@@ -115,7 +173,10 @@ class StdioAdapter:
         await self.client.register()
         listener = asyncio.create_task(self.client.listen_results(self._handle_result))
         print(f"[{self.platform_name}] connected as {self.client.node_id}")
-        print(f"[{self.platform_name}] commands: mep, mepdm, mepdata, mepcancel, mepresult, mepbalance, exit")
+        print(
+            f"[{self.platform_name}] commands: "
+            "mep, mepdm, mepdmx, mepdata, mepcancel, mepresult, mepbalance, exit"
+        )
         loop = asyncio.get_running_loop()
         try:
             keep_going = True

--- a/scripts/threaded_review_example.py
+++ b/scripts/threaded_review_example.py
@@ -1,0 +1,73 @@
+import asyncio
+import os
+
+from clients.shared.mep_client import MEPClient
+
+
+TARGET_NODE = os.getenv("MEP_TARGET_NODE", "").strip()
+TARGET_ALIAS = os.getenv("MEP_TARGET_ALIAS", "").strip() or None
+KEY_PATH = os.getenv("MEP_BOT_KEY_PATH", "").strip()
+CONTEXT_ID = os.getenv("MEP_CONTEXT_ID", "example-threaded-review-001").strip()
+REPLY_TO_TASK_ID = os.getenv("MEP_REPLY_TO_TASK_ID", "").strip() or None
+REPLY_TO_MESSAGE_ID = os.getenv("MEP_REPLY_TO_MESSAGE_ID", "").strip() or None
+
+
+async def main() -> None:
+    if not KEY_PATH:
+        raise SystemExit("MEP_BOT_KEY_PATH is required")
+    if not TARGET_NODE:
+        raise SystemExit("MEP_TARGET_NODE is required")
+
+    client = MEPClient(KEY_PATH)
+    await client.register()
+
+    review_request = (
+        "Please review the current PR and reply with one of: "
+        "approve, approve_with_conditions, request_changes, or block. "
+        "Also include one short rationale."
+    )
+    submit = await client.submit_dm(
+        review_request,
+        TARGET_NODE,
+        target_alias=TARGET_ALIAS,
+        intent_type="review.request",
+        context_id=CONTEXT_ID,
+        reply_to_task_id=REPLY_TO_TASK_ID,
+        reply_to_message_id=REPLY_TO_MESSAGE_ID,
+        turn_type="review_request",
+        human_note="Example structured review flow from scripts/threaded_review_example.py",
+    )
+    print(
+        "review_request",
+        {
+            "task_id": submit.get("json", {}).get("task_id"),
+            "context_id": submit.get("context_id"),
+            "message_id": submit.get("message_id"),
+        },
+    )
+
+    checkpoint = (
+        "Checkpoint: review request sent. Waiting for structured verdict. "
+        "If you respond with conditions, include the top two blocking concerns first."
+    )
+    checkpoint_submit = await client.submit_checkpoint_dm(
+        checkpoint,
+        TARGET_NODE,
+        target_alias=TARGET_ALIAS,
+        context_id=submit.get("context_id") or CONTEXT_ID,
+        reply_to_task_id=submit.get("json", {}).get("task_id"),
+        reply_to_message_id=submit.get("message_id"),
+        human_note="Example checkpoint turn in the same threaded review session",
+    )
+    print(
+        "checkpoint",
+        {
+            "task_id": checkpoint_submit.get("json", {}).get("task_id"),
+            "context_id": checkpoint_submit.get("context_id"),
+            "message_id": checkpoint_submit.get("message_id"),
+        },
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -96,6 +96,60 @@ class TestSharedMEPClient(unittest.TestCase):
         self.assertEqual(response["status_code"], 200)
         self.assertEqual(response["json"], response_body)
 
+    def test_submit_dm_builds_threaded_interbot_envelope(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+
+            response = asyncio.run(
+                client.submit_dm(
+                    "Please review PR 154",
+                    "node_reviewer",
+                    intent_type="review.request",
+                    context_id="pr154-review",
+                    reply_to_task_id="task_parent",
+                    reply_to_message_id="message_parent",
+                    turn_type="review_request",
+                )
+            )
+
+        submit_body = json.loads(session.post.call_args.kwargs["data"])
+        self.assertEqual(submit_body["routing"], {"target_node_id": "node_reviewer"})
+        body = json.loads(submit_body["task"]["instructions"])
+        self.assertEqual(body["spec_version"], "mep.interbot.v1")
+        self.assertEqual(body["target"]["node_id"], "node_reviewer")
+        self.assertEqual(body["conversation"]["context_id"], "pr154-review")
+        self.assertEqual(body["conversation"]["reply_to_task_id"], "task_parent")
+        self.assertEqual(body["conversation"]["reply_to_message_id"], "message_parent")
+        self.assertEqual(body["conversation"]["turn_type"], "review_request")
+        self.assertEqual(body["intent"], {"type": "review.request", "priority": "normal"})
+        self.assertEqual(body["task"]["instructions"], "Please review PR 154")
+        self.assertEqual(body["delivery"], {"reply_mode": "new_dm", "settlement_mode": "task_result"})
+        self.assertEqual(response["context_id"], "pr154-review")
+        self.assertTrue(response["message_id"])
+        self.assertTrue(response["trace_id"])
+
+    def test_extract_interbot_instructions_prefers_structured_task_text(self):
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "task": {
+                    "instructions": "Structured instructions",
+                    "expected_output": {"result_type": "text"},
+                },
+            }
+        )
+
+        instructions, parsed = MEPClient.extract_interbot_instructions(payload)
+
+        self.assertEqual(instructions, "Structured instructions")
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["spec_version"], "mep.interbot.v1")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add structured inter-bot DM helpers with conversation context, reply lineage, and checkpoint support
- add opt-in adapter/runtime entrypoints for threaded review-style DM flows
- document settlement-vs-conversation guidance and include a minimal threaded review example

## Changes
- update `INTER_BOT_MESSAGE_SPEC.md` with `conversation` fields, `new_dm` guidance, and settlement-vs-conversation separation
- add `submit_dm()`, `submit_dm_reply()`, and `submit_checkpoint_dm()` helpers to `clients/shared/mep_client.py`
- add `mepdmx` to the stdio and Discord adapter surfaces
- add conservative provider-side support for preserving thread context and optional follow-up reply DMs on structured review turns
- add `scripts/threaded_review_example.py` as a minimal threaded review flow

## Validation
- IDE diagnostics clean on edited files
- `python -m py_compile` passed for the changed Python files

## Notes
- this PR intentionally stays in the `MEP` implementation repo, not `MEP-spec`
- existing plain `mepdm` behavior remains intact; the structured/threaded path is opt-in
