### PR TITLE
feat: add review verdict DM helpers

### DIFF
--- a/INTER_BOT_MESSAGE_SPEC.md
+++ b/INTER_BOT_MESSAGE_SPEC.md
@@ -305,6 +305,44 @@ Recommended review verdict vocabulary inside `task.expected_output` or `result_p
 - `request_changes`
 - `block`
 
+Recommended structured review verdict payload for threaded DM:
+
+```json
+{
+  "intent": {"type": "review.response"},
+  "conversation": {
+    "context_id": "pr154-review",
+    "reply_to_task_id": "hub-task-id-from-review-request",
+    "reply_to_message_id": "prior-message-id",
+    "turn_type": "approval"
+  },
+  "task": {
+    "title": "Review verdict",
+    "instructions": "Review verdict: approve_with_conditions\nRationale: Threading model is sound.\nConditions:\n- Keep reply_mode=new_dm\n- Add a short docs note",
+    "inputs": {
+      "review_verdict": {
+        "decision": "approve_with_conditions",
+        "rationale": "Threading model is sound.",
+        "conditions": [
+          "Keep reply_mode=new_dm",
+          "Add a short docs note"
+        ],
+        "human_recommendation": "Merge after the follow-up docs note lands."
+      }
+    },
+    "expected_output": {"result_type": "text"}
+  }
+}
+```
+
+Review verdict rules:
+
+- `task.inputs.review_verdict` SHOULD be present when a bot sends a machine-readable review response.
+- `review_verdict.decision` SHOULD use the verdict vocabulary above.
+- `review_verdict.rationale` SHOULD be concise and non-empty.
+- `review_verdict.conditions` MAY be empty for `approve` and `block`, but SHOULD be explicit for `approve_with_conditions` and `request_changes`.
+- `conversation.turn_type = "approval"` is recommended for verdict turns.
+
 Recommended long-session additions:
 
 - include a short checkpoint summary every 3 to 5 turns

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b
 ```
 
 Use `mepdmx` when you want structured multi-turn DM with a stable thread context, reply references, and explicit turn typing.
+Use `MEPClient.submit_review_verdict_dm(...)` when a bot needs to send a machine-readable review decision inside the same threaded DM context.
 
 </details>
 
@@ -229,6 +230,7 @@ export WS_URL=ws://localhost:8000
 `mepdm` succeeds only when the target node is online and connected to the hub.
 For multi-turn chat, send a fresh DM for each reply turn instead of depending on `/tasks/complete` result polling.
 Use `scripts/threaded_review_example.py` as a minimal example of a structured review flow with `context_id`, reply references, and checkpoint turns.
+For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)` and `extract_review_verdict(...)`.
 
 </details>
 

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -15,6 +15,7 @@ from node.ws_connect import ws_connect
 HUB_URL = os.getenv("HUB_URL", "https://mep-hub.silentcopilot.ai")
 WS_URL = os.getenv("WS_URL", "wss://mep-hub.silentcopilot.ai")
 WS_HEARTBEAT_INTERVAL_SECONDS = float(os.getenv("MEP_WS_HEARTBEAT_INTERVAL_SECONDS", "60"))
+REVIEW_VERDICTS = {"approve", "approve_with_conditions", "request_changes", "block"}
 
 
 class MEPClient:
@@ -144,8 +145,18 @@ class MEPClient:
         result_type: str = "text",
         human_note: Optional[str] = None,
         trace_id: Optional[str] = None,
+        task_title: Optional[str] = None,
+        task_inputs: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         message_id = str(uuid.uuid4())
+        task: dict[str, Any] = {
+            "instructions": message,
+            "expected_output": {"result_type": result_type},
+        }
+        if task_title:
+            task["title"] = task_title
+        if task_inputs:
+            task["inputs"] = task_inputs
         return {
             "spec_version": "mep.interbot.v1",
             "message_id": message_id,
@@ -163,10 +174,7 @@ class MEPClient:
                 "turn_type": turn_type,
             },
             "intent": {"type": intent_type, "priority": priority},
-            "task": {
-                "instructions": message,
-                "expected_output": {"result_type": result_type},
-            },
+            "task": task,
             "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
             "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
             **({"human_note": human_note} if human_note else {}),
@@ -324,6 +332,101 @@ class MEPClient:
         response["context_id"] = envelope["conversation"]["context_id"]
         return response
 
+    def build_review_verdict_message(
+        self,
+        verdict: str,
+        rationale: str,
+        target_node: str,
+        *,
+        context_id: str,
+        target_alias: Optional[str] = None,
+        reply_to_task_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        conditions: Optional[list[str]] = None,
+        human_recommendation: Optional[str] = None,
+        priority: str = "normal",
+        human_note: Optional[str] = None,
+    ) -> dict[str, Any]:
+        normalized_verdict = verdict.strip().lower()
+        if normalized_verdict not in REVIEW_VERDICTS:
+            raise ValueError(f"unsupported review verdict: {verdict}")
+
+        normalized_rationale = rationale.strip()
+        if not normalized_rationale:
+            raise ValueError("review rationale must be non-empty")
+
+        normalized_conditions = self._normalize_string_list(conditions)
+        normalized_recommendation = (
+            human_recommendation.strip() if isinstance(human_recommendation, str) else None
+        )
+        verdict_payload: dict[str, Any] = {
+            "decision": normalized_verdict,
+            "rationale": normalized_rationale,
+            "conditions": normalized_conditions,
+        }
+        if normalized_recommendation:
+            verdict_payload["human_recommendation"] = normalized_recommendation
+
+        message_lines = [
+            f"Review verdict: {normalized_verdict}",
+            f"Rationale: {normalized_rationale}",
+        ]
+        if normalized_conditions:
+            message_lines.append("Conditions:")
+            message_lines.extend(f"- {condition}" for condition in normalized_conditions)
+        if normalized_recommendation:
+            message_lines.append(f"Human recommendation: {normalized_recommendation}")
+
+        return self.build_interbot_message(
+            "\n".join(message_lines),
+            target_node,
+            target_alias=target_alias,
+            intent_type="review.response",
+            priority=priority,
+            context_id=context_id,
+            reply_to_task_id=reply_to_task_id,
+            reply_to_message_id=reply_to_message_id,
+            turn_type="approval",
+            result_type="text",
+            human_note=human_note,
+            task_title="Review verdict",
+            task_inputs={"review_verdict": verdict_payload},
+        )
+
+    async def submit_review_verdict_dm(
+        self,
+        verdict: str,
+        rationale: str,
+        target_node: str,
+        *,
+        context_id: str,
+        target_alias: Optional[str] = None,
+        reply_to_task_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        conditions: Optional[list[str]] = None,
+        human_recommendation: Optional[str] = None,
+        priority: str = "normal",
+        human_note: Optional[str] = None,
+    ) -> dict:
+        envelope = self.build_review_verdict_message(
+            verdict,
+            rationale,
+            target_node,
+            context_id=context_id,
+            target_alias=target_alias,
+            reply_to_task_id=reply_to_task_id,
+            reply_to_message_id=reply_to_message_id,
+            conditions=conditions,
+            human_recommendation=human_recommendation,
+            priority=priority,
+            human_note=human_note,
+        )
+        response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
+        response["message_id"] = envelope["message_id"]
+        response["trace_id"] = envelope["trace_id"]
+        response["context_id"] = envelope["conversation"]["context_id"]
+        return response
+
     async def post_brainstorm_message(
         self,
         session_id: str,
@@ -383,6 +486,36 @@ class MEPClient:
                 return instructions.strip(), parsed
         return payload_text, parsed
 
+    @classmethod
+    def extract_review_verdict(cls, payload_text: str) -> Optional[dict[str, Any]]:
+        parsed = cls.parse_interbot_payload(payload_text)
+        if not parsed:
+            return None
+        task = parsed.get("task")
+        if not isinstance(task, dict):
+            return None
+        inputs = task.get("inputs")
+        if not isinstance(inputs, dict):
+            return None
+        review_verdict = inputs.get("review_verdict")
+        if not isinstance(review_verdict, dict):
+            return None
+        decision = review_verdict.get("decision")
+        rationale = review_verdict.get("rationale")
+        if not isinstance(decision, str) or decision not in REVIEW_VERDICTS:
+            return None
+        if not isinstance(rationale, str) or not rationale.strip():
+            return None
+        extracted: dict[str, Any] = {
+            "decision": decision,
+            "rationale": rationale.strip(),
+            "conditions": cls._normalize_string_list(review_verdict.get("conditions")),
+        }
+        human_recommendation = review_verdict.get("human_recommendation")
+        if isinstance(human_recommendation, str) and human_recommendation.strip():
+            extracted["human_recommendation"] = human_recommendation.strip()
+        return extracted
+
     @staticmethod
     def _default_reply_intent_type(inbound_intent_type: Optional[str]) -> str:
         if inbound_intent_type == "review.request":
@@ -394,6 +527,18 @@ class MEPClient:
         if inbound_turn_type == "review_request":
             return "review_response"
         return "chat_turn"
+
+    @staticmethod
+    def _normalize_string_list(values: Any) -> list[str]:
+        if not isinstance(values, list):
+            return []
+        normalized: list[str] = []
+        for value in values:
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped:
+                    normalized.append(stripped)
+        return normalized
 
     async def listen_results(
         self,

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -150,6 +150,78 @@ class TestSharedMEPClient(unittest.TestCase):
         self.assertIsNotNone(parsed)
         self.assertEqual(parsed["spec_version"], "mep.interbot.v1")
 
+    def test_submit_review_verdict_dm_builds_structured_verdict_payload(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+
+            response = asyncio.run(
+                client.submit_review_verdict_dm(
+                    "approve_with_conditions",
+                    "Threading model is sound, but docs should mention ack expectations.",
+                    "node_governor",
+                    context_id="pr154-review",
+                    reply_to_task_id="task_review_request",
+                    reply_to_message_id="message_review_request",
+                    conditions=["Document expected ack behavior", "Keep reply_mode=new_dm"],
+                    human_recommendation="Merge after the follow-up docs note lands.",
+                )
+            )
+
+        submit_body = json.loads(session.post.call_args.kwargs["data"])
+        body = json.loads(submit_body["task"]["instructions"])
+        self.assertEqual(body["intent"], {"type": "review.response", "priority": "normal"})
+        self.assertEqual(body["conversation"]["turn_type"], "approval")
+        self.assertEqual(body["conversation"]["context_id"], "pr154-review")
+        self.assertEqual(body["conversation"]["reply_to_task_id"], "task_review_request")
+        self.assertEqual(body["conversation"]["reply_to_message_id"], "message_review_request")
+        self.assertEqual(body["task"]["title"], "Review verdict")
+        self.assertEqual(
+            body["task"]["inputs"]["review_verdict"],
+            {
+                "decision": "approve_with_conditions",
+                "rationale": "Threading model is sound, but docs should mention ack expectations.",
+                "conditions": ["Document expected ack behavior", "Keep reply_mode=new_dm"],
+                "human_recommendation": "Merge after the follow-up docs note lands.",
+            },
+        )
+        self.assertEqual(response["context_id"], "pr154-review")
+
+    def test_extract_review_verdict_reads_structured_verdict_payload(self):
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "task": {
+                    "instructions": "Review verdict: approve",
+                    "inputs": {
+                        "review_verdict": {
+                            "decision": "approve",
+                            "rationale": "Looks good.",
+                            "conditions": ["Ship a short follow-up doc note", ""],
+                            "human_recommendation": "Safe to merge.",
+                        }
+                    },
+                    "expected_output": {"result_type": "text"},
+                },
+            }
+        )
+
+        verdict = MEPClient.extract_review_verdict(payload)
+
+        self.assertEqual(
+            verdict,
+            {
+                "decision": "approve",
+                "rationale": "Looks good.",
+                "conditions": ["Ship a short follow-up doc note"],
+                "human_recommendation": "Safe to merge.",
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add shared client helpers to send threaded machine-readable review verdict DMs
- add shared parser support for `task.inputs.review_verdict`
- document the structured review verdict payload in the inter-bot spec and README
- add focused shared client tests for verdict send/parse behavior

## Validation
- python -B -m pytest tests/test_shared_mep_client.py -q
