### PR TITLE
feat: add human approval request DM helpers

### DIFF
--- a/INTER_BOT_MESSAGE_SPEC.md
+++ b/INTER_BOT_MESSAGE_SPEC.md
@@ -111,6 +111,8 @@ If `target.node_id` is present, it MUST match `target_node` in task submit metad
 - `code.review.request`
 - `incident.response`
 - `test.request`
+- `human.approval.request`
+- `human.input.request`
 
 Custom values are allowed only with namespace prefix, for example `acme.custom_type`.
 
@@ -348,6 +350,44 @@ Recommended long-session additions:
 - include a short checkpoint summary every 3 to 5 turns
 - include a final recommendation for the human governor
 - prefer explicit conditions over vague approval
+
+Recommended human approval request payload for final handoff:
+
+```json
+{
+  "intent": {"type": "human.approval.request"},
+  "conversation": {
+    "context_id": "pr155-review",
+    "reply_to_task_id": "hub-task-id-from-review-verdict",
+    "reply_to_message_id": "review-verdict-message-id",
+    "turn_type": "session_close"
+  },
+  "task": {
+    "title": "Human approval request",
+    "instructions": "Human approval request: merge_decision\nSummary: Two bots approve with conditions.\nProposed review decision: approve_with_conditions\nBlockers:\n- Confirm release window\nRecommended next action: Merge after human approval.",
+    "inputs": {
+      "human_approval_request": {
+        "decision_type": "merge_decision",
+        "summary": "Two bots approve with conditions.",
+        "review_decision": "approve_with_conditions",
+        "blockers": [
+          "Confirm release window"
+        ],
+        "recommended_next_action": "Merge after human approval."
+      }
+    },
+    "expected_output": {"result_type": "text"}
+  }
+}
+```
+
+Human approval request rules:
+
+- `task.inputs.human_approval_request` SHOULD be present when bots are escalating the final decision to a human governor.
+- `human_approval_request.decision_type` SHOULD be a stable machine-readable label such as `merge_decision` or `deploy_decision`.
+- `human_approval_request.summary` SHOULD briefly explain why human approval is needed now.
+- `human_approval_request.review_decision` MAY carry the bots' current consensus using the review verdict vocabulary.
+- `conversation.turn_type = "session_close"` is recommended when the bot side of the session is effectively complete and waiting on human input.
 
 ## Error contract
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b
 
 Use `mepdmx` when you want structured multi-turn DM with a stable thread context, reply references, and explicit turn typing.
 Use `MEPClient.submit_review_verdict_dm(...)` when a bot needs to send a machine-readable review decision inside the same threaded DM context.
+Use `MEPClient.submit_human_approval_request_dm(...)` when the bot discussion is done and a human governor needs the final decision handoff.
 
 </details>
 
@@ -230,7 +231,7 @@ export WS_URL=ws://localhost:8000
 `mepdm` succeeds only when the target node is online and connected to the hub.
 For multi-turn chat, send a fresh DM for each reply turn instead of depending on `/tasks/complete` result polling.
 Use `scripts/threaded_review_example.py` as a minimal example of a structured review flow with `context_id`, reply references, and checkpoint turns.
-For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)` and `extract_review_verdict(...)`.
+For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)`, `extract_review_verdict(...)`, `submit_human_approval_request_dm(...)`, and `extract_human_approval_request(...)`.
 
 </details>
 

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -16,6 +16,7 @@ HUB_URL = os.getenv("HUB_URL", "https://mep-hub.silentcopilot.ai")
 WS_URL = os.getenv("WS_URL", "wss://mep-hub.silentcopilot.ai")
 WS_HEARTBEAT_INTERVAL_SECONDS = float(os.getenv("MEP_WS_HEARTBEAT_INTERVAL_SECONDS", "60"))
 REVIEW_VERDICTS = {"approve", "approve_with_conditions", "request_changes", "block"}
+HUMAN_APPROVAL_DECISION_TYPES = {"merge_decision", "deploy_decision", "policy_decision"}
 
 
 class MEPClient:
@@ -427,6 +428,112 @@ class MEPClient:
         response["context_id"] = envelope["conversation"]["context_id"]
         return response
 
+    def build_human_approval_request_message(
+        self,
+        summary: str,
+        target_node: str,
+        *,
+        context_id: str,
+        decision_type: str = "merge_decision",
+        target_alias: Optional[str] = None,
+        reply_to_task_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        review_decision: Optional[str] = None,
+        blockers: Optional[list[str]] = None,
+        recommended_next_action: Optional[str] = None,
+        priority: str = "high",
+        human_note: Optional[str] = None,
+    ) -> dict[str, Any]:
+        normalized_summary = summary.strip()
+        if not normalized_summary:
+            raise ValueError("human approval summary must be non-empty")
+
+        normalized_decision_type = decision_type.strip().lower()
+        if normalized_decision_type not in HUMAN_APPROVAL_DECISION_TYPES:
+            raise ValueError(f"unsupported human approval decision type: {decision_type}")
+
+        normalized_review_decision = review_decision.strip().lower() if isinstance(review_decision, str) else None
+        if normalized_review_decision and normalized_review_decision not in REVIEW_VERDICTS:
+            raise ValueError(f"unsupported review decision: {review_decision}")
+
+        normalized_blockers = self._normalize_string_list(blockers)
+        normalized_next_action = (
+            recommended_next_action.strip() if isinstance(recommended_next_action, str) else None
+        )
+        approval_payload: dict[str, Any] = {
+            "decision_type": normalized_decision_type,
+            "summary": normalized_summary,
+            "blockers": normalized_blockers,
+        }
+        if normalized_review_decision:
+            approval_payload["review_decision"] = normalized_review_decision
+        if normalized_next_action:
+            approval_payload["recommended_next_action"] = normalized_next_action
+
+        message_lines = [
+            f"Human approval request: {normalized_decision_type}",
+            f"Summary: {normalized_summary}",
+        ]
+        if normalized_review_decision:
+            message_lines.append(f"Proposed review decision: {normalized_review_decision}")
+        if normalized_blockers:
+            message_lines.append("Blockers:")
+            message_lines.extend(f"- {blocker}" for blocker in normalized_blockers)
+        if normalized_next_action:
+            message_lines.append(f"Recommended next action: {normalized_next_action}")
+
+        return self.build_interbot_message(
+            "\n".join(message_lines),
+            target_node,
+            target_alias=target_alias,
+            intent_type="human.approval.request",
+            priority=priority,
+            context_id=context_id,
+            reply_to_task_id=reply_to_task_id,
+            reply_to_message_id=reply_to_message_id,
+            turn_type="session_close",
+            result_type="text",
+            human_note=human_note,
+            task_title="Human approval request",
+            task_inputs={"human_approval_request": approval_payload},
+        )
+
+    async def submit_human_approval_request_dm(
+        self,
+        summary: str,
+        target_node: str,
+        *,
+        context_id: str,
+        decision_type: str = "merge_decision",
+        target_alias: Optional[str] = None,
+        reply_to_task_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        review_decision: Optional[str] = None,
+        blockers: Optional[list[str]] = None,
+        recommended_next_action: Optional[str] = None,
+        priority: str = "high",
+        human_note: Optional[str] = None,
+    ) -> dict:
+        envelope = self.build_human_approval_request_message(
+            summary,
+            target_node,
+            context_id=context_id,
+            decision_type=decision_type,
+            target_alias=target_alias,
+            reply_to_task_id=reply_to_task_id,
+            reply_to_message_id=reply_to_message_id,
+            review_decision=review_decision,
+            blockers=blockers,
+            recommended_next_action=recommended_next_action,
+            priority=priority,
+            human_note=human_note,
+        )
+        response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
+        response["message_id"] = envelope["message_id"]
+        response["trace_id"] = envelope["trace_id"]
+        response["context_id"] = envelope["conversation"]["context_id"]
+        return response
+
     async def post_brainstorm_message(
         self,
         session_id: str,
@@ -514,6 +621,39 @@ class MEPClient:
         human_recommendation = review_verdict.get("human_recommendation")
         if isinstance(human_recommendation, str) and human_recommendation.strip():
             extracted["human_recommendation"] = human_recommendation.strip()
+        return extracted
+
+    @classmethod
+    def extract_human_approval_request(cls, payload_text: str) -> Optional[dict[str, Any]]:
+        parsed = cls.parse_interbot_payload(payload_text)
+        if not parsed:
+            return None
+        task = parsed.get("task")
+        if not isinstance(task, dict):
+            return None
+        inputs = task.get("inputs")
+        if not isinstance(inputs, dict):
+            return None
+        approval_request = inputs.get("human_approval_request")
+        if not isinstance(approval_request, dict):
+            return None
+        decision_type = approval_request.get("decision_type")
+        summary = approval_request.get("summary")
+        if not isinstance(decision_type, str) or decision_type not in HUMAN_APPROVAL_DECISION_TYPES:
+            return None
+        if not isinstance(summary, str) or not summary.strip():
+            return None
+        extracted: dict[str, Any] = {
+            "decision_type": decision_type,
+            "summary": summary.strip(),
+            "blockers": cls._normalize_string_list(approval_request.get("blockers")),
+        }
+        review_decision = approval_request.get("review_decision")
+        if isinstance(review_decision, str) and review_decision in REVIEW_VERDICTS:
+            extracted["review_decision"] = review_decision
+        recommended_next_action = approval_request.get("recommended_next_action")
+        if isinstance(recommended_next_action, str) and recommended_next_action.strip():
+            extracted["recommended_next_action"] = recommended_next_action.strip()
         return extracted
 
     @staticmethod

--- a/scripts/threaded_review_example.py
+++ b/scripts/threaded_review_example.py
@@ -6,6 +6,8 @@ from clients.shared.mep_client import MEPClient
 
 TARGET_NODE = os.getenv("MEP_TARGET_NODE", "").strip()
 TARGET_ALIAS = os.getenv("MEP_TARGET_ALIAS", "").strip() or None
+HUMAN_TARGET_NODE = os.getenv("MEP_HUMAN_TARGET_NODE", "").strip() or None
+HUMAN_TARGET_ALIAS = os.getenv("MEP_HUMAN_TARGET_ALIAS", "").strip() or None
 KEY_PATH = os.getenv("MEP_BOT_KEY_PATH", "").strip()
 CONTEXT_ID = os.getenv("MEP_CONTEXT_ID", "example-threaded-review-001").strip()
 REPLY_TO_TASK_ID = os.getenv("MEP_REPLY_TO_TASK_ID", "").strip() or None
@@ -67,6 +69,28 @@ async def main() -> None:
             "message_id": checkpoint_submit.get("message_id"),
         },
     )
+
+    if HUMAN_TARGET_NODE:
+        approval_request = await client.submit_human_approval_request_dm(
+            "Bots completed the review pass. A human merge decision is needed.",
+            HUMAN_TARGET_NODE,
+            target_alias=HUMAN_TARGET_ALIAS,
+            context_id=submit.get("context_id") or CONTEXT_ID,
+            reply_to_task_id=checkpoint_submit.get("json", {}).get("task_id"),
+            reply_to_message_id=checkpoint_submit.get("message_id"),
+            review_decision="approve_with_conditions",
+            blockers=["Confirm final merge timing"],
+            recommended_next_action="Merge after human approval.",
+            human_note="Optional human approval handoff from scripts/threaded_review_example.py",
+        )
+        print(
+            "human_approval_request",
+            {
+                "task_id": approval_request.get("json", {}).get("task_id"),
+                "context_id": approval_request.get("context_id"),
+                "message_id": approval_request.get("message_id"),
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -222,6 +222,79 @@ class TestSharedMEPClient(unittest.TestCase):
             },
         )
 
+    def test_submit_human_approval_request_dm_builds_structured_payload(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+
+            response = asyncio.run(
+                client.submit_human_approval_request_dm(
+                    "Two bots approve with conditions; no remaining blocker in code.",
+                    "node_master_wu",
+                    context_id="pr155-review",
+                    reply_to_task_id="task_review_verdict",
+                    reply_to_message_id="message_review_verdict",
+                    review_decision="approve_with_conditions",
+                    blockers=["Need explicit merge confirmation from the human governor"],
+                    recommended_next_action="Merge after human approval.",
+                )
+            )
+
+        submit_body = json.loads(session.post.call_args.kwargs["data"])
+        body = json.loads(submit_body["task"]["instructions"])
+        self.assertEqual(body["intent"], {"type": "human.approval.request", "priority": "high"})
+        self.assertEqual(body["conversation"]["turn_type"], "session_close")
+        self.assertEqual(body["conversation"]["context_id"], "pr155-review")
+        self.assertEqual(body["task"]["title"], "Human approval request")
+        self.assertEqual(
+            body["task"]["inputs"]["human_approval_request"],
+            {
+                "decision_type": "merge_decision",
+                "summary": "Two bots approve with conditions; no remaining blocker in code.",
+                "review_decision": "approve_with_conditions",
+                "blockers": ["Need explicit merge confirmation from the human governor"],
+                "recommended_next_action": "Merge after human approval.",
+            },
+        )
+        self.assertEqual(response["context_id"], "pr155-review")
+
+    def test_extract_human_approval_request_reads_structured_payload(self):
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "task": {
+                    "instructions": "Human approval request: merge_decision",
+                    "inputs": {
+                        "human_approval_request": {
+                            "decision_type": "merge_decision",
+                            "summary": "Need final merge confirmation.",
+                            "review_decision": "approve",
+                            "blockers": ["Confirm release window", ""],
+                            "recommended_next_action": "Merge after approval.",
+                        }
+                    },
+                    "expected_output": {"result_type": "text"},
+                },
+            }
+        )
+
+        request = MEPClient.extract_human_approval_request(payload)
+
+        self.assertEqual(
+            request,
+            {
+                "decision_type": "merge_decision",
+                "summary": "Need final merge confirmation.",
+                "review_decision": "approve",
+                "blockers": ["Confirm release window"],
+                "recommended_next_action": "Merge after approval.",
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add shared client helpers to send structured `human.approval.request` threaded DMs
- add shared parser support for `task.inputs.human_approval_request`
- align the public inter-bot spec with the hub's already-supported human approval intents
- extend the threaded review example with an optional human handoff step
- add focused shared client tests for build/parse behavior

## Validation
- python -B -m pytest tests/test_shared_mep_client.py -q
- python -m py_compile clients/shared/mep_client.py scripts/threaded_review_example.py
