### PR TITLE
chore: add repo line ending policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+
+# Windows command scripts keep CRLF for native execution.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf


### PR DESCRIPTION
## Summary
Add a repository-level `.gitattributes` file to make line-ending handling explicit across platforms.

## Changes
- set tracked text files to `LF` by default with `* text=auto eol=lf`
- keep Windows-native script files on `CRLF`:
  - `*.bat`
  - `*.cmd`
  - `*.ps1`

## Why
This reduces false-dirty working tree noise on Windows and makes line-ending behavior consistent for all contributors instead of relying on local Git config.

## Validation
- verified branch is clean after the change
- ran focused tests:
  - `py -m pytest tests/test_shared_mep_client.py -q`
  - `9 passed`
