### PR TITLE
chore: add editorconfig defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{bat,cmd,ps1}]
+end_of_line = crlf


### PR DESCRIPTION
## Summary
Add a minimal `.editorconfig` so editor defaults align with the repo line-ending policy introduced in PR #157.

## Changes
- set `root = true`
- default text files to UTF-8 with `LF` line endings
- require a final newline
- trim trailing whitespace by default
- keep Markdown trailing whitespace intact
- set Python files to 4-space indentation
- keep Windows-native scripts on `CRLF`

## Why
`.gitattributes` handles Git checkin/checkout behavior, while `.editorconfig` helps IDEs and editors use the same defaults during editing. This makes the developer experience more consistent across platforms.

## Validation
- verified `.editorconfig` diagnostics are clean
- verified branch is clean after the change
