### PR TITLE
feat: add long-session safety guards

### DIFF
--- a/INTER_BOT_MESSAGE_SPEC.md
+++ b/INTER_BOT_MESSAGE_SPEC.md
@@ -171,6 +171,19 @@ Recommended behavior:
 - If a turn is a direct reply to a prior DM task, include `reply_to_task_id`.
 - If the runtime preserves logical message IDs beyond hub task IDs, also include `reply_to_message_id`.
 - Long sessions SHOULD emit a `checkpoint` turn at a predictable cadence, for example every 3 to 5 turns.
+- Long sessions MAY include `task.inputs.session_safety` so senders can declare machine-readable turn, timeout, and checkpoint guardrails.
+
+Recommended `task.inputs.session_safety` fields:
+
+- `max_turns`
+  - positive integer
+  - upper bound on the next conversational turn index a bot should allow before closing the session
+- `max_duration_seconds`
+  - positive integer
+  - maximum wall-clock age of the session before the runtime should stop and ask for a fresh handoff
+- `checkpoint_interval`
+  - positive integer
+  - cadence for emitting `checkpoint` turns, for example every 3 turns
 
 ## Compatibility mode (legacy plain text)
 
@@ -321,12 +334,16 @@ Recommended structured review verdict payload for threaded DM:
   "task": {
     "title": "Review verdict",
     "instructions": "Review verdict: approve_with_conditions\nRationale: Threading model is sound.\nConditions:\n- Keep reply_mode=new_dm\n- Add a short docs note",
+      "session_safety": {
+        "max_turns": 6,
+        "max_duration_seconds": 900,
+        "checkpoint_interval": 3
+      },
     "inputs": {
       "review_verdict": {
         "decision": "approve_with_conditions",
         "rationale": "Threading model is sound.",
         "conditions": [
-          "Keep reply_mode=new_dm",
           "Add a short docs note"
         ],
         "human_recommendation": "Merge after the follow-up docs note lands."
@@ -350,6 +367,7 @@ Recommended long-session additions:
 - include a short checkpoint summary every 3 to 5 turns
 - include a final recommendation for the human governor
 - prefer explicit conditions over vague approval
+- declare `task.inputs.session_safety` when the sender wants the receiver to enforce max-turn, timeout, or checkpoint cadence rules
 
 Recommended human approval request payload for final handoff:
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b
 Use `mepdmx` when you want structured multi-turn DM with a stable thread context, reply references, and explicit turn typing.
 Use `MEPClient.submit_review_verdict_dm(...)` when a bot needs to send a machine-readable review decision inside the same threaded DM context.
 Use `MEPClient.submit_human_approval_request_dm(...)` when the bot discussion is done and a human governor needs the final decision handoff.
+Use `session_safety={...}` with `MEPClient.submit_dm(...)` or `submit_checkpoint_dm(...)` when the sender wants explicit max-turn, timeout, or checkpoint cadence guardrails attached to the thread.
+Use `MEPClient.evaluate_interbot_session_safety(...)` on the receiving side before sending the next reply turn if you want the runtime to stop or checkpoint automatically.
+Use `MEPClient.submit_safe_dm_reply(...)` when a runtime wants one call that either replies, emits a checkpoint turn, or stops because the declared session limits were exceeded.
 
 </details>
 
@@ -232,6 +235,8 @@ export WS_URL=ws://localhost:8000
 For multi-turn chat, send a fresh DM for each reply turn instead of depending on `/tasks/complete` result polling.
 Use `scripts/threaded_review_example.py` as a minimal example of a structured review flow with `context_id`, reply references, and checkpoint turns.
 For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)`, `extract_review_verdict(...)`, `submit_human_approval_request_dm(...)`, and `extract_human_approval_request(...)`.
+For long sessions, the shared client also supports sender-declared `session_safety` metadata and `evaluate_interbot_session_safety(...)` so bots can enforce max-turn, timeout, and checkpoint policies consistently.
+When the receiver already has the inbound parsed message, `submit_safe_dm_reply(...)` can enforce those rules and choose reply vs checkpoint vs stop automatically.
 
 </details>
 

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -148,6 +148,7 @@ class MEPClient:
         trace_id: Optional[str] = None,
         task_title: Optional[str] = None,
         task_inputs: Optional[dict[str, Any]] = None,
+        session_safety: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         message_id = str(uuid.uuid4())
         task: dict[str, Any] = {
@@ -156,8 +157,12 @@ class MEPClient:
         }
         if task_title:
             task["title"] = task_title
-        if task_inputs:
-            task["inputs"] = task_inputs
+        inputs: dict[str, Any] = dict(task_inputs or {})
+        normalized_session_safety = self.build_session_safety_metadata(**session_safety) if session_safety else {}
+        if normalized_session_safety:
+            inputs["session_safety"] = normalized_session_safety
+        if inputs:
+            task["inputs"] = inputs
         return {
             "spec_version": "mep.interbot.v1",
             "message_id": message_id,
@@ -194,6 +199,7 @@ class MEPClient:
         reply_to_message_id: Optional[str] = None,
         turn_type: str = "chat_turn",
         human_note: Optional[str] = None,
+        session_safety: Optional[dict[str, Any]] = None,
     ) -> dict:
         envelope = self.build_interbot_message(
             message,
@@ -206,6 +212,7 @@ class MEPClient:
             reply_to_message_id=reply_to_message_id,
             turn_type=turn_type,
             human_note=human_note,
+            session_safety=session_safety,
         )
         response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
         response["message_id"] = envelope["message_id"]
@@ -251,6 +258,7 @@ class MEPClient:
             turn_type=turn_type or self._default_reply_turn_type(inbound_turn_type),
             human_note=human_note,
             trace_id=inbound_message.get("trace_id") if isinstance(inbound_message.get("trace_id"), str) else None,
+            session_safety=self._extract_session_safety_from_message(inbound_message),
         )
 
     async def submit_dm_reply(
@@ -280,6 +288,77 @@ class MEPClient:
         response["context_id"] = envelope["conversation"]["context_id"]
         return response
 
+    async def submit_safe_dm_reply(
+        self,
+        reply_text: str,
+        inbound_message: dict[str, Any],
+        *,
+        next_turn_index: int,
+        checkpoint_summary: Optional[str] = None,
+        inbound_task_id: Optional[str] = None,
+        turn_type: Optional[str] = None,
+        intent_type: Optional[str] = None,
+        priority: Optional[str] = None,
+        human_note: Optional[str] = None,
+        now_ms: Optional[int] = None,
+    ) -> dict[str, Any]:
+        evaluation = self.evaluate_interbot_session_safety_message(
+            inbound_message,
+            next_turn_index=next_turn_index,
+            now_ms=now_ms,
+        )
+        context_id = self._extract_context_id(inbound_message)
+
+        if evaluation["should_stop"]:
+            return {
+                "status": "stopped",
+                "reply_action": "stop",
+                "context_id": context_id,
+                "session_safety": evaluation["session_safety"],
+                "safety": evaluation,
+            }
+
+        if evaluation["should_checkpoint"]:
+            source = inbound_message.get("source")
+            if not isinstance(source, dict) or not isinstance(source.get("node_id"), str):
+                raise ValueError("inbound inter-bot message is missing source.node_id")
+            summary = (
+                checkpoint_summary.strip()
+                if isinstance(checkpoint_summary, str) and checkpoint_summary.strip()
+                else f"Checkpoint: session reached turn {next_turn_index}. Confirm whether to continue."
+            )
+            checkpoint_response = await self.submit_checkpoint_dm(
+                summary,
+                source["node_id"],
+                context_id=context_id,
+                target_alias=source.get("alias") if isinstance(source.get("alias"), str) else None,
+                reply_to_task_id=inbound_task_id,
+                reply_to_message_id=inbound_message.get("message_id")
+                if isinstance(inbound_message.get("message_id"), str)
+                else None,
+                priority=priority or "normal",
+                human_note=human_note,
+                session_safety=self._extract_session_safety_from_message(inbound_message),
+            )
+            checkpoint_response["status"] = "checkpointed"
+            checkpoint_response["reply_action"] = "checkpoint"
+            checkpoint_response["safety"] = evaluation
+            return checkpoint_response
+
+        response = await self.submit_dm_reply(
+            reply_text,
+            inbound_message,
+            inbound_task_id=inbound_task_id,
+            turn_type=turn_type,
+            intent_type=intent_type,
+            priority=priority,
+            human_note=human_note,
+        )
+        response["status"] = "replied"
+        response["reply_action"] = "reply"
+        response["safety"] = evaluation
+        return response
+
     def build_checkpoint_message(
         self,
         summary: str,
@@ -291,6 +370,7 @@ class MEPClient:
         reply_to_message_id: Optional[str] = None,
         priority: str = "normal",
         human_note: Optional[str] = None,
+        session_safety: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         return self.build_interbot_message(
             summary,
@@ -303,6 +383,7 @@ class MEPClient:
             reply_to_message_id=reply_to_message_id,
             turn_type="checkpoint",
             human_note=human_note,
+            session_safety=session_safety,
         )
 
     async def submit_checkpoint_dm(
@@ -316,6 +397,7 @@ class MEPClient:
         reply_to_message_id: Optional[str] = None,
         priority: str = "normal",
         human_note: Optional[str] = None,
+        session_safety: Optional[dict[str, Any]] = None,
     ) -> dict:
         envelope = self.build_checkpoint_message(
             summary,
@@ -326,6 +408,7 @@ class MEPClient:
             reply_to_message_id=reply_to_message_id,
             priority=priority,
             human_note=human_note,
+            session_safety=session_safety,
         )
         response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
         response["message_id"] = envelope["message_id"]
@@ -624,6 +707,114 @@ class MEPClient:
         return extracted
 
     @classmethod
+    def extract_session_safety(cls, payload_text: str) -> Optional[dict[str, int]]:
+        parsed = cls.parse_interbot_payload(payload_text)
+        if not parsed:
+            return None
+        return cls._extract_session_safety_from_message(parsed)
+
+    @classmethod
+    def evaluate_interbot_session_safety_message(
+        cls,
+        message: dict[str, Any],
+        *,
+        next_turn_index: int,
+        now_ms: Optional[int] = None,
+    ) -> dict[str, Any]:
+        if next_turn_index < 1:
+            raise ValueError("next_turn_index must be at least 1")
+
+        session_safety = cls._extract_session_safety_from_message(message)
+        if not session_safety:
+            return {
+                "session_safety": None,
+                "next_turn_index": next_turn_index,
+                "elapsed_ms": None,
+                "should_checkpoint": False,
+                "should_stop": False,
+                "violations": [],
+            }
+
+        evaluated_now_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+        started_at_ms = message.get("timestamp_ms") if isinstance(message.get("timestamp_ms"), int) else None
+        elapsed_ms = (
+            max(0, evaluated_now_ms - started_at_ms)
+            if started_at_ms is not None and evaluated_now_ms >= started_at_ms
+            else None
+        )
+        violations: list[str] = []
+
+        max_turns = session_safety.get("max_turns")
+        if isinstance(max_turns, int) and next_turn_index > max_turns:
+            violations.append("max_turns_exceeded")
+
+        max_duration_seconds = session_safety.get("max_duration_seconds")
+        if isinstance(max_duration_seconds, int) and elapsed_ms is not None:
+            if elapsed_ms > max_duration_seconds * 1000:
+                violations.append("max_duration_exceeded")
+
+        checkpoint_interval = session_safety.get("checkpoint_interval")
+        should_checkpoint = (
+            isinstance(checkpoint_interval, int)
+            and checkpoint_interval > 0
+            and next_turn_index > 1
+            and next_turn_index % checkpoint_interval == 0
+            and not violations
+        )
+
+        return {
+            "session_safety": session_safety,
+            "next_turn_index": next_turn_index,
+            "elapsed_ms": elapsed_ms,
+            "should_checkpoint": should_checkpoint,
+            "should_stop": bool(violations),
+            "violations": violations,
+        }
+
+    @classmethod
+    def evaluate_interbot_session_safety(
+        cls,
+        payload_text: str,
+        *,
+        next_turn_index: int,
+        now_ms: Optional[int] = None,
+    ) -> dict[str, Any]:
+        if next_turn_index < 1:
+            raise ValueError("next_turn_index must be at least 1")
+
+        parsed = cls.parse_interbot_payload(payload_text)
+        if not parsed:
+            raise ValueError("payload_text is not a valid mep.interbot.v1 payload")
+        return cls.evaluate_interbot_session_safety_message(
+            parsed,
+            next_turn_index=next_turn_index,
+            now_ms=now_ms,
+        )
+
+    @classmethod
+    def build_session_safety_metadata(
+        cls,
+        *,
+        max_turns: Optional[int] = None,
+        max_duration_seconds: Optional[int] = None,
+        checkpoint_interval: Optional[int] = None,
+    ) -> dict[str, int]:
+        normalized: dict[str, int] = {}
+        if max_turns is not None:
+            normalized["max_turns"] = cls._normalize_positive_int(max_turns, "max_turns")
+        if max_duration_seconds is not None:
+            normalized["max_duration_seconds"] = cls._normalize_positive_int(
+                max_duration_seconds, "max_duration_seconds"
+            )
+        if checkpoint_interval is not None:
+            normalized["checkpoint_interval"] = cls._normalize_positive_int(
+                checkpoint_interval, "checkpoint_interval"
+            )
+        if not normalized:
+            raise ValueError("at least one session safety guard must be provided")
+        return normalized
+
+    @classmethod
     def extract_human_approval_request(cls, payload_text: str) -> Optional[dict[str, Any]]:
         parsed = cls.parse_interbot_payload(payload_text)
         if not parsed:
@@ -679,6 +870,42 @@ class MEPClient:
                 if stripped:
                     normalized.append(stripped)
         return normalized
+
+    @classmethod
+    def _extract_session_safety_from_message(cls, message: dict[str, Any]) -> Optional[dict[str, int]]:
+        task = message.get("task")
+        if not isinstance(task, dict):
+            return None
+        inputs = task.get("inputs")
+        if not isinstance(inputs, dict):
+            return None
+        session_safety = inputs.get("session_safety")
+        if not isinstance(session_safety, dict):
+            return None
+
+        normalized: dict[str, int] = {}
+        for field in ("max_turns", "max_duration_seconds", "checkpoint_interval"):
+            value = session_safety.get(field)
+            if value is None:
+                continue
+            try:
+                normalized[field] = cls._normalize_positive_int(value, field)
+            except ValueError:
+                return None
+        return normalized or None
+
+    @staticmethod
+    def _normalize_positive_int(value: Any, field_name: str) -> int:
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError(f"{field_name} must be a positive integer")
+        return value
+
+    @staticmethod
+    def _extract_context_id(message: dict[str, Any]) -> Optional[str]:
+        conversation = message.get("conversation")
+        if isinstance(conversation, dict) and isinstance(conversation.get("context_id"), str):
+            return conversation.get("context_id")
+        return None
 
     async def listen_results(
         self,

--- a/scripts/threaded_review_example.py
+++ b/scripts/threaded_review_example.py
@@ -12,6 +12,9 @@ KEY_PATH = os.getenv("MEP_BOT_KEY_PATH", "").strip()
 CONTEXT_ID = os.getenv("MEP_CONTEXT_ID", "example-threaded-review-001").strip()
 REPLY_TO_TASK_ID = os.getenv("MEP_REPLY_TO_TASK_ID", "").strip() or None
 REPLY_TO_MESSAGE_ID = os.getenv("MEP_REPLY_TO_MESSAGE_ID", "").strip() or None
+MAX_TURNS = int(os.getenv("MEP_SESSION_MAX_TURNS", "6"))
+MAX_DURATION_SECONDS = int(os.getenv("MEP_SESSION_MAX_DURATION_SECONDS", "900"))
+CHECKPOINT_INTERVAL = int(os.getenv("MEP_SESSION_CHECKPOINT_INTERVAL", "3"))
 
 
 async def main() -> None:
@@ -22,6 +25,11 @@ async def main() -> None:
 
     client = MEPClient(KEY_PATH)
     await client.register()
+    session_safety = MEPClient.build_session_safety_metadata(
+        max_turns=MAX_TURNS,
+        max_duration_seconds=MAX_DURATION_SECONDS,
+        checkpoint_interval=CHECKPOINT_INTERVAL,
+    )
 
     review_request = (
         "Please review the current PR and reply with one of: "
@@ -38,6 +46,7 @@ async def main() -> None:
         reply_to_message_id=REPLY_TO_MESSAGE_ID,
         turn_type="review_request",
         human_note="Example structured review flow from scripts/threaded_review_example.py",
+        session_safety=session_safety,
     )
     print(
         "review_request",
@@ -60,6 +69,7 @@ async def main() -> None:
         reply_to_task_id=submit.get("json", {}).get("task_id"),
         reply_to_message_id=submit.get("message_id"),
         human_note="Example checkpoint turn in the same threaded review session",
+        session_safety=session_safety,
     )
     print(
         "checkpoint",

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -133,6 +133,32 @@ class TestSharedMEPClient(unittest.TestCase):
         self.assertTrue(response["message_id"])
         self.assertTrue(response["trace_id"])
 
+    def test_submit_dm_can_attach_session_safety_metadata(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+
+            asyncio.run(
+                client.submit_dm(
+                    "Stay inside the review lane.",
+                    "node_reviewer",
+                    context_id="pr154-review",
+                    turn_type="review_request",
+                    session_safety={"max_turns": 6, "max_duration_seconds": 900, "checkpoint_interval": 3},
+                )
+            )
+
+        submit_body = json.loads(session.post.call_args.kwargs["data"])
+        body = json.loads(submit_body["task"]["instructions"])
+        self.assertEqual(
+            body["task"]["inputs"]["session_safety"],
+            {"max_turns": 6, "max_duration_seconds": 900, "checkpoint_interval": 3},
+        )
+
     def test_extract_interbot_instructions_prefers_structured_task_text(self):
         payload = json.dumps(
             {
@@ -294,6 +320,219 @@ class TestSharedMEPClient(unittest.TestCase):
                 "recommended_next_action": "Merge after approval.",
             },
         )
+
+    def test_submit_dm_reply_preserves_session_safety_from_inbound_message(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+
+            inbound_message = {
+                "message_id": "message_review_request",
+                "trace_id": "trace-123",
+                "source": {"node_id": "node_reviewer"},
+                "intent": {"type": "review.request", "priority": "high"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {
+                    "instructions": "Please review this PR.",
+                    "inputs": {"session_safety": {"max_turns": 6, "checkpoint_interval": 3}},
+                },
+            }
+
+            asyncio.run(
+                client.submit_dm_reply(
+                    "I approve with conditions.",
+                    inbound_message,
+                    inbound_task_id="task_review_request",
+                )
+            )
+
+        submit_body = json.loads(session.post.call_args.kwargs["data"])
+        body = json.loads(submit_body["task"]["instructions"])
+        self.assertEqual(body["task"]["inputs"]["session_safety"], {"max_turns": 6, "checkpoint_interval": 3})
+        self.assertEqual(body["conversation"]["reply_to_task_id"], "task_review_request")
+        self.assertEqual(body["conversation"]["reply_to_message_id"], "message_review_request")
+
+    def test_extract_session_safety_reads_structured_payload(self):
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "timestamp_ms": 1_777_000_000_000,
+                "task": {
+                    "instructions": "Stay in the review thread.",
+                    "inputs": {"session_safety": {"max_turns": 5, "max_duration_seconds": 600}},
+                    "expected_output": {"result_type": "text"},
+                },
+            }
+        )
+
+        session_safety = MEPClient.extract_session_safety(payload)
+
+        self.assertEqual(session_safety, {"max_turns": 5, "max_duration_seconds": 600})
+
+    def test_evaluate_interbot_session_safety_requests_checkpoint_at_interval(self):
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "timestamp_ms": 1_777_000_000_000,
+                "task": {
+                    "instructions": "Stay in the review thread.",
+                    "inputs": {"session_safety": {"max_turns": 6, "checkpoint_interval": 3}},
+                    "expected_output": {"result_type": "text"},
+                },
+            }
+        )
+
+        evaluation = MEPClient.evaluate_interbot_session_safety(
+            payload,
+            next_turn_index=3,
+            now_ms=1_777_000_100_000,
+        )
+
+        self.assertEqual(evaluation["session_safety"], {"max_turns": 6, "checkpoint_interval": 3})
+        self.assertTrue(evaluation["should_checkpoint"])
+        self.assertFalse(evaluation["should_stop"])
+        self.assertEqual(evaluation["violations"], [])
+
+    def test_evaluate_interbot_session_safety_stops_when_limits_are_exceeded(self):
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "timestamp_ms": 1_777_000_000_000,
+                "task": {
+                    "instructions": "Stay in the review thread.",
+                    "inputs": {
+                        "session_safety": {"max_turns": 4, "max_duration_seconds": 60, "checkpoint_interval": 2}
+                    },
+                    "expected_output": {"result_type": "text"},
+                },
+            }
+        )
+
+        evaluation = MEPClient.evaluate_interbot_session_safety(
+            payload,
+            next_turn_index=5,
+            now_ms=1_777_000_070_000,
+        )
+
+        self.assertFalse(evaluation["should_checkpoint"])
+        self.assertTrue(evaluation["should_stop"])
+        self.assertEqual(
+            evaluation["violations"],
+            ["max_turns_exceeded", "max_duration_exceeded"],
+        )
+
+    def test_submit_safe_dm_reply_replies_when_session_is_within_limits(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+            inbound_message = {
+                "message_id": "message_review_request",
+                "trace_id": "trace-123",
+                "timestamp_ms": 1_777_000_000_000,
+                "source": {"node_id": "node_reviewer"},
+                "intent": {"type": "review.request", "priority": "high"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {
+                    "instructions": "Please review this PR.",
+                    "inputs": {"session_safety": {"max_turns": 6, "checkpoint_interval": 3}},
+                },
+            }
+
+            response = asyncio.run(
+                client.submit_safe_dm_reply(
+                    "I approve with conditions.",
+                    inbound_message,
+                    inbound_task_id="task_review_request",
+                    next_turn_index=2,
+                    now_ms=1_777_000_010_000,
+                )
+            )
+
+        submit_body = json.loads(session.post.call_args.kwargs["data"])
+        body = json.loads(submit_body["task"]["instructions"])
+        self.assertEqual(response["reply_action"], "reply")
+        self.assertEqual(response["status"], "replied")
+        self.assertFalse(response["safety"]["should_stop"])
+        self.assertEqual(body["task"]["instructions"], "I approve with conditions.")
+
+    def test_submit_safe_dm_reply_sends_checkpoint_when_interval_is_reached(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+            inbound_message = {
+                "message_id": "message_review_request",
+                "trace_id": "trace-123",
+                "timestamp_ms": 1_777_000_000_000,
+                "source": {"node_id": "node_reviewer", "alias": "Reviewer"},
+                "intent": {"type": "review.request", "priority": "high"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {
+                    "instructions": "Please review this PR.",
+                    "inputs": {"session_safety": {"max_turns": 6, "checkpoint_interval": 3}},
+                },
+            }
+
+            response = asyncio.run(
+                client.submit_safe_dm_reply(
+                    "I approve with conditions.",
+                    inbound_message,
+                    inbound_task_id="task_review_request",
+                    next_turn_index=3,
+                    checkpoint_summary="Checkpoint: 3 turns reached.",
+                    now_ms=1_777_000_020_000,
+                )
+            )
+
+        submit_body = json.loads(session.post.call_args.kwargs["data"])
+        body = json.loads(submit_body["task"]["instructions"])
+        self.assertEqual(response["reply_action"], "checkpoint")
+        self.assertEqual(response["status"], "checkpointed")
+        self.assertTrue(response["safety"]["should_checkpoint"])
+        self.assertEqual(body["conversation"]["turn_type"], "checkpoint")
+        self.assertEqual(body["task"]["instructions"], "Checkpoint: 3 turns reached.")
+
+    def test_submit_safe_dm_reply_stops_when_session_limits_are_exceeded(self):
+        with patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()):
+            client = MEPClient("unused.pem")
+            inbound_message = {
+                "message_id": "message_review_request",
+                "trace_id": "trace-123",
+                "timestamp_ms": 1_777_000_000_000,
+                "source": {"node_id": "node_reviewer"},
+                "intent": {"type": "review.request", "priority": "high"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {
+                    "instructions": "Please review this PR.",
+                    "inputs": {"session_safety": {"max_turns": 4, "max_duration_seconds": 60}},
+                },
+            }
+
+            response = asyncio.run(
+                client.submit_safe_dm_reply(
+                    "I approve with conditions.",
+                    inbound_message,
+                    inbound_task_id="task_review_request",
+                    next_turn_index=5,
+                    now_ms=1_777_000_070_000,
+                )
+            )
+
+        self.assertEqual(response["reply_action"], "stop")
+        self.assertEqual(response["status"], "stopped")
+        self.assertTrue(response["safety"]["should_stop"])
+        self.assertEqual(response["safety"]["violations"], ["max_turns_exceeded", "max_duration_exceeded"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add the first long-session safety guard slice for threaded inter-bot DM flows.

## Changes
- add sender-declared `session_safety` metadata for threaded DM and checkpoint messages
- add shared-client helpers to extract and evaluate max-turn, timeout, and checkpoint rules
- add `submit_safe_dm_reply(...)` so receivers can automatically reply, checkpoint, or stop based on declared limits
- update the threaded review example to attach session safety metadata
- document the new safety block in the spec and README
- add focused shared-client tests for metadata propagation, evaluation, checkpointing, and stop behavior

## Validation
- ran `py -m pytest tests/test_shared_mep_client.py -q`
- result: `17 passed`