### PR TITLE
feat: add safe threaded DM reply command

### DIFF
--- a/INTER_BOT_MESSAGE_SPEC.md
+++ b/INTER_BOT_MESSAGE_SPEC.md
@@ -184,6 +184,9 @@ Recommended `task.inputs.session_safety` fields:
 - `checkpoint_interval`
   - positive integer
   - cadence for emitting `checkpoint` turns, for example every 3 turns
+- `started_at_ms`
+  - positive integer Unix epoch in milliseconds
+  - optional runtime-managed field used to preserve the original session start time across reply/checkpoint hops so total session age stays enforceable
 
 ## Compatibility mode (legacy plain text)
 
@@ -334,12 +337,12 @@ Recommended structured review verdict payload for threaded DM:
   "task": {
     "title": "Review verdict",
     "instructions": "Review verdict: approve_with_conditions\nRationale: Threading model is sound.\nConditions:\n- Keep reply_mode=new_dm\n- Add a short docs note",
+    "inputs": {
       "session_safety": {
         "max_turns": 6,
         "max_duration_seconds": 900,
         "checkpoint_interval": 3
       },
-    "inputs": {
       "review_verdict": {
         "decision": "approve_with_conditions",
         "rationale": "Threading model is sound.",

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b
 ```
 
 Use `mepdmx` when you want structured multi-turn DM with a stable thread context, reply references, and explicit turn typing.
+Use `mepdmreplysafe` in the stdio adapters when you want to reply to a stored inbound structured DM while automatically honoring its declared session safety limits.
 Use `MEPClient.submit_review_verdict_dm(...)` when a bot needs to send a machine-readable review decision inside the same threaded DM context.
 Use `MEPClient.submit_human_approval_request_dm(...)` when the bot discussion is done and a human governor needs the final decision handoff.
 Use `session_safety={...}` with `MEPClient.submit_dm(...)` or `submit_checkpoint_dm(...)` when the sender wants explicit max-turn, timeout, or checkpoint cadence guardrails attached to the thread.
@@ -228,6 +229,7 @@ export WS_URL=ws://localhost:8000
 - **Send compute work:** `mep Write a Python script --bounty 5.0 --model gemini`
 - **Direct-message a specific node:** `mepdm node_98eb3d301b2b hello`
 - **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request`
+- **Safely reply to a stored structured DM:** `mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-type review_response --intent review.response`
 - **Start free bot-to-bot chat:** `mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b`
 - **Check balance:** `mepbalance`
 

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -151,6 +151,7 @@ class MEPClient:
         session_safety: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         message_id = str(uuid.uuid4())
+        timestamp_ms = int(time.time() * 1000)
         task: dict[str, Any] = {
             "instructions": message,
             "expected_output": {"result_type": result_type},
@@ -159,6 +160,8 @@ class MEPClient:
             task["title"] = task_title
         inputs: dict[str, Any] = dict(task_inputs or {})
         normalized_session_safety = self.build_session_safety_metadata(**session_safety) if session_safety else {}
+        if normalized_session_safety and "started_at_ms" not in normalized_session_safety:
+            normalized_session_safety["started_at_ms"] = timestamp_ms
         if normalized_session_safety:
             inputs["session_safety"] = normalized_session_safety
         if inputs:
@@ -167,7 +170,7 @@ class MEPClient:
             "spec_version": "mep.interbot.v1",
             "message_id": message_id,
             "trace_id": trace_id or str(uuid.uuid4()),
-            "timestamp_ms": int(time.time() * 1000),
+            "timestamp_ms": timestamp_ms,
             "source": {"node_id": self.node_id},
             "target": {
                 "node_id": target_node,
@@ -736,7 +739,9 @@ class MEPClient:
             }
 
         evaluated_now_ms = now_ms if now_ms is not None else int(time.time() * 1000)
-        started_at_ms = message.get("timestamp_ms") if isinstance(message.get("timestamp_ms"), int) else None
+        started_at_ms = session_safety.get("started_at_ms")
+        if not isinstance(started_at_ms, int):
+            started_at_ms = message.get("timestamp_ms") if isinstance(message.get("timestamp_ms"), int) else None
         elapsed_ms = (
             max(0, evaluated_now_ms - started_at_ms)
             if started_at_ms is not None and evaluated_now_ms >= started_at_ms
@@ -798,6 +803,7 @@ class MEPClient:
         max_turns: Optional[int] = None,
         max_duration_seconds: Optional[int] = None,
         checkpoint_interval: Optional[int] = None,
+        started_at_ms: Optional[int] = None,
     ) -> dict[str, int]:
         normalized: dict[str, int] = {}
         if max_turns is not None:
@@ -810,6 +816,8 @@ class MEPClient:
             normalized["checkpoint_interval"] = cls._normalize_positive_int(
                 checkpoint_interval, "checkpoint_interval"
             )
+        if started_at_ms is not None:
+            normalized["started_at_ms"] = cls._normalize_positive_int(started_at_ms, "started_at_ms")
         if not normalized:
             raise ValueError("at least one session safety guard must be provided")
         return normalized
@@ -884,7 +892,7 @@ class MEPClient:
             return None
 
         normalized: dict[str, int] = {}
-        for field in ("max_turns", "max_duration_seconds", "checkpoint_interval"):
+        for field in ("max_turns", "max_duration_seconds", "checkpoint_interval", "started_at_ms"):
             value = session_safety.get(field)
             if value is None:
                 continue

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import shlex
 import tempfile
-from typing import Optional
+from typing import Any, Optional
 
 from clients.shared.commands import parse_task_args
 from clients.shared.mep_client import MEPClient
@@ -16,11 +16,33 @@ class StdioAdapter:
         self.platform_name = platform_name
         self.default_model = default_model
         self.client = MEPClient(key_path)
+        self._recent_interbot_results: dict[str, dict[str, Any]] = {}
 
     async def _handle_result(self, data: dict) -> None:
         task_id = data.get("task_id")
         result = data.get("result_payload", "")
         print(f"[{self.platform_name}] task_result {task_id}: {result}")
+        if isinstance(task_id, str) and isinstance(result, str):
+            parsed = self.client.parse_interbot_payload(result)
+            if parsed:
+                self._remember_interbot_result(task_id, result, parsed)
+                context_id = None
+                conversation = parsed.get("conversation")
+                if isinstance(conversation, dict) and isinstance(conversation.get("context_id"), str):
+                    context_id = conversation["context_id"]
+                print(
+                    f"[{self.platform_name}] stored structured dm result {task_id}"
+                    + (f" context={context_id}" if context_id else "")
+                )
+
+    def _remember_interbot_result(self, task_id: str, payload_text: str, message: dict[str, Any]) -> None:
+        self._recent_interbot_results[task_id] = {
+            "payload_text": payload_text,
+            "message": message,
+        }
+        while len(self._recent_interbot_results) > 20:
+            oldest_task_id = next(iter(self._recent_interbot_results))
+            del self._recent_interbot_results[oldest_task_id]
 
     async def _submit(self, text: str) -> None:
         payload, bounty, model, target = parse_task_args(text, DEFAULT_BOUNTY, self.default_model)
@@ -96,6 +118,82 @@ class StdioAdapter:
             f"to {target_node} context={response.get('context_id')}"
         )
 
+    async def _send_safe_dm_reply(self, text: str) -> None:
+        try:
+            parts = shlex.split(text)
+        except ValueError as exc:
+            print(f"[{self.platform_name}] mepdmreplysafe parse error: {exc}")
+            return
+        if len(parts) < 3:
+            print(
+                f"[{self.platform_name}] usage: mepdmreplysafe <task_id> <next_turn_index> <reply> "
+                "[--checkpoint-summary text] [--turn-type type] [--intent type] [--priority level]"
+            )
+            return
+
+        task_id = parts[0]
+        try:
+            next_turn_index = int(parts[1])
+        except ValueError:
+            print(f"[{self.platform_name}] next_turn_index must be an integer")
+            return
+
+        options: dict[str, str] = {}
+        reply_parts: list[str] = []
+        i = 2
+        while i < len(parts):
+            token = parts[i]
+            if token.startswith("--"):
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                options[token] = parts[i + 1]
+                i += 2
+                continue
+            reply_parts.append(token)
+            i += 1
+
+        reply_text = " ".join(reply_parts).strip()
+        if not reply_text:
+            print(
+                f"[{self.platform_name}] usage: mepdmreplysafe <task_id> <next_turn_index> <reply> [options]"
+            )
+            return
+
+        inbound = self._recent_interbot_results.get(task_id)
+        if not inbound:
+            print(f"[{self.platform_name}] no stored structured dm result for task {task_id}")
+            return
+
+        response = await self.client.submit_safe_dm_reply(
+            reply_text,
+            inbound["message"],
+            next_turn_index=next_turn_index,
+            checkpoint_summary=options.get("--checkpoint-summary"),
+            inbound_task_id=task_id,
+            turn_type=options.get("--turn-type"),
+            intent_type=options.get("--intent"),
+            priority=options.get("--priority"),
+        )
+
+        action = response.get("reply_action")
+        if action == "stop":
+            print(
+                f"[{self.platform_name}] safe reply stopped for {task_id}: "
+                f"{', '.join(response.get('safety', {}).get('violations', [])) or 'limits exceeded'}"
+            )
+            return
+
+        data = response.get("json", {})
+        if response.get("status_code") != 200 or data.get("status") != "success":
+            print(f"[{self.platform_name}] safe dm reply failed: {data}")
+            return
+
+        print(
+            f"[{self.platform_name}] safe reply {action} task {data.get('task_id')} "
+            f"context={response.get('context_id')}"
+        )
+
     async def _offer_data(self, price: str, payload: str) -> None:
         bounty = -abs(float(price))
         response = await self.client.submit_task("Data offer available", bounty, secret_data=payload)
@@ -145,6 +243,9 @@ class StdioAdapter:
         if text.startswith("mepdmx "):
             await self._send_structured_dm(text[7:])
             return True
+        if text.startswith("mepdmreplysafe "):
+            await self._send_safe_dm_reply(text[15:])
+            return True
         if text.startswith("mepdata "):
             parts = text.split(" ", 2)
             if len(parts) < 3:
@@ -175,7 +276,7 @@ class StdioAdapter:
         print(f"[{self.platform_name}] connected as {self.client.node_id}")
         print(
             f"[{self.platform_name}] commands: "
-            "mep, mepdm, mepdmx, mepdata, mepcancel, mepresult, mepbalance, exit"
+            "mep, mepdm, mepdmx, mepdmreplysafe, mepdata, mepcancel, mepresult, mepbalance, exit"
         )
         loop = asyncio.get_running_loop()
         try:

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -165,16 +165,20 @@ class StdioAdapter:
             print(f"[{self.platform_name}] no stored structured dm result for task {task_id}")
             return
 
-        response = await self.client.submit_safe_dm_reply(
-            reply_text,
-            inbound["message"],
-            next_turn_index=next_turn_index,
-            checkpoint_summary=options.get("--checkpoint-summary"),
-            inbound_task_id=task_id,
-            turn_type=options.get("--turn-type"),
-            intent_type=options.get("--intent"),
-            priority=options.get("--priority"),
-        )
+        try:
+            response = await self.client.submit_safe_dm_reply(
+                reply_text,
+                inbound["message"],
+                next_turn_index=next_turn_index,
+                checkpoint_summary=options.get("--checkpoint-summary"),
+                inbound_task_id=task_id,
+                turn_type=options.get("--turn-type"),
+                intent_type=options.get("--intent"),
+                priority=options.get("--priority"),
+            )
+        except ValueError as exc:
+            print(f"[{self.platform_name}] safe dm reply error: {exc}")
+            return
 
         action = response.get("reply_action")
         if action == "stop":

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -154,10 +154,11 @@ class TestSharedMEPClient(unittest.TestCase):
 
         submit_body = json.loads(session.post.call_args.kwargs["data"])
         body = json.loads(submit_body["task"]["instructions"])
-        self.assertEqual(
-            body["task"]["inputs"]["session_safety"],
-            {"max_turns": 6, "max_duration_seconds": 900, "checkpoint_interval": 3},
-        )
+        session_safety = body["task"]["inputs"]["session_safety"]
+        self.assertEqual(session_safety["max_turns"], 6)
+        self.assertEqual(session_safety["max_duration_seconds"], 900)
+        self.assertEqual(session_safety["checkpoint_interval"], 3)
+        self.assertEqual(session_safety["started_at_ms"], body["timestamp_ms"])
 
     def test_extract_interbot_instructions_prefers_structured_task_text(self):
         payload = json.dumps(
@@ -333,12 +334,19 @@ class TestSharedMEPClient(unittest.TestCase):
             inbound_message = {
                 "message_id": "message_review_request",
                 "trace_id": "trace-123",
+                "timestamp_ms": 1_777_000_000_000,
                 "source": {"node_id": "node_reviewer"},
                 "intent": {"type": "review.request", "priority": "high"},
                 "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
                 "task": {
                     "instructions": "Please review this PR.",
-                    "inputs": {"session_safety": {"max_turns": 6, "checkpoint_interval": 3}},
+                    "inputs": {
+                        "session_safety": {
+                            "max_turns": 6,
+                            "checkpoint_interval": 3,
+                            "started_at_ms": 1_777_000_000_000,
+                        }
+                    },
                 },
             }
 
@@ -352,7 +360,10 @@ class TestSharedMEPClient(unittest.TestCase):
 
         submit_body = json.loads(session.post.call_args.kwargs["data"])
         body = json.loads(submit_body["task"]["instructions"])
-        self.assertEqual(body["task"]["inputs"]["session_safety"], {"max_turns": 6, "checkpoint_interval": 3})
+        self.assertEqual(
+            body["task"]["inputs"]["session_safety"],
+            {"max_turns": 6, "checkpoint_interval": 3, "started_at_ms": 1_777_000_000_000},
+        )
         self.assertEqual(body["conversation"]["reply_to_task_id"], "task_review_request")
         self.assertEqual(body["conversation"]["reply_to_message_id"], "message_review_request")
 
@@ -363,7 +374,13 @@ class TestSharedMEPClient(unittest.TestCase):
                 "timestamp_ms": 1_777_000_000_000,
                 "task": {
                     "instructions": "Stay in the review thread.",
-                    "inputs": {"session_safety": {"max_turns": 5, "max_duration_seconds": 600}},
+                    "inputs": {
+                        "session_safety": {
+                            "max_turns": 5,
+                            "max_duration_seconds": 600,
+                            "started_at_ms": 1_777_000_000_000,
+                        }
+                    },
                     "expected_output": {"result_type": "text"},
                 },
             }
@@ -371,7 +388,10 @@ class TestSharedMEPClient(unittest.TestCase):
 
         session_safety = MEPClient.extract_session_safety(payload)
 
-        self.assertEqual(session_safety, {"max_turns": 5, "max_duration_seconds": 600})
+        self.assertEqual(
+            session_safety,
+            {"max_turns": 5, "max_duration_seconds": 600, "started_at_ms": 1_777_000_000_000},
+        )
 
     def test_evaluate_interbot_session_safety_requests_checkpoint_at_interval(self):
         payload = json.dumps(
@@ -424,6 +444,33 @@ class TestSharedMEPClient(unittest.TestCase):
             evaluation["violations"],
             ["max_turns_exceeded", "max_duration_exceeded"],
         )
+
+    def test_evaluate_interbot_session_safety_uses_original_session_start_time(self):
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "timestamp_ms": 1_777_000_060_000,
+                "task": {
+                    "instructions": "Stay in the review thread.",
+                    "inputs": {
+                        "session_safety": {
+                            "max_duration_seconds": 60,
+                            "started_at_ms": 1_777_000_000_000,
+                        }
+                    },
+                    "expected_output": {"result_type": "text"},
+                },
+            }
+        )
+
+        evaluation = MEPClient.evaluate_interbot_session_safety(
+            payload,
+            next_turn_index=2,
+            now_ms=1_777_000_070_000,
+        )
+
+        self.assertTrue(evaluation["should_stop"])
+        self.assertEqual(evaluation["violations"], ["max_duration_exceeded"])
 
     def test_submit_safe_dm_reply_replies_when_session_is_within_limits(self):
         with (

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -107,6 +107,27 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
         client.submit_safe_dm_reply.assert_awaited_once()
         print_mock.assert_any_call("[codex] safe reply stopped for task_review_request: max_turns_exceeded")
 
+    async def test_dispatch_line_safe_reply_reports_validation_errors(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_safe_dm_reply = AsyncMock(side_effect=ValueError("next_turn_index must be at least 1"))
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmreplysafe task_review_request 0 "I approve with conditions."'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_safe_dm_reply.assert_awaited_once()
+        print_mock.assert_any_call("[codex] safe dm reply error: next_turn_index must be at least 1")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -1,0 +1,112 @@
+import json
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from clients.shared.stdio_adapter import StdioAdapter
+
+
+class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
+    def _make_adapter(self):
+        patcher = patch("clients.shared.stdio_adapter.MEPClient")
+        client_cls = patcher.start()
+        self.addCleanup(patcher.stop)
+        client = client_cls.return_value
+        client.node_id = "node_adapter"
+        adapter = StdioAdapter("codex", "codex-agent", "unused.pem")
+        return adapter, client
+
+    async def test_handle_result_stores_structured_interbot_payload(self):
+        adapter, client = self._make_adapter()
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "message_id": "message_review_request",
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            }
+        )
+        client.parse_interbot_payload.return_value = json.loads(payload)
+
+        with patch("builtins.print") as print_mock:
+            await adapter._handle_result({"task_id": "task_review_request", "result_payload": payload})
+
+        self.assertIn("task_review_request", adapter._recent_interbot_results)
+        self.assertEqual(
+            adapter._recent_interbot_results["task_review_request"]["message"]["conversation"]["context_id"],
+            "pr154-review",
+        )
+        print_mock.assert_any_call(
+            "[codex] stored structured dm result task_review_request context=pr154-review"
+        )
+
+    async def test_dispatch_line_safe_reply_uses_stored_inbound_message(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_safe_dm_reply = AsyncMock(
+            return_value={
+                "reply_action": "reply",
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_safe_reply"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmreplysafe task_review_request 3 "I approve with conditions." '
+                '--checkpoint-summary "Checkpoint: 3 turns reached." '
+                '--turn-type review_response --intent review.response --priority high'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_safe_dm_reply.assert_awaited_once_with(
+            "I approve with conditions.",
+            adapter._recent_interbot_results["task_review_request"]["message"],
+            next_turn_index=3,
+            checkpoint_summary="Checkpoint: 3 turns reached.",
+            inbound_task_id="task_review_request",
+            turn_type="review_response",
+            intent_type="review.response",
+            priority="high",
+        )
+        print_mock.assert_any_call("[codex] safe reply reply task task_safe_reply context=pr154-review")
+
+    async def test_dispatch_line_safe_reply_reports_stop_without_submitting_dm(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_safe_dm_reply = AsyncMock(
+            return_value={
+                "reply_action": "stop",
+                "safety": {"violations": ["max_turns_exceeded"]},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmreplysafe task_review_request 5 "I approve with conditions."'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_safe_dm_reply.assert_awaited_once()
+        print_mock.assert_any_call("[codex] safe reply stopped for task_review_request: max_turns_exceeded")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add a real stdio runtime hook for safe threaded DM replies.

## Changes
- store recent inbound structured inter-bot DM results in the shared stdio adapter
- add `mepdmreplysafe <task_id> <next_turn_index> <reply>` so operators can reply against a stored inbound DM while honoring declared session safety
- route the command through `submit_safe_dm_reply(...)`, which can reply, checkpoint, or stop
- document the new command in the README
- add focused adapter tests for result storage, safe reply dispatch, and stop behavior

## Validation
- ran `py -m pytest tests/test_shared_mep_client.py tests/test_stdio_adapter.py -q`
- result: `20 passed`