### PR TITLE
feat: add recent structured dm inspection command

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ export WS_URL=ws://localhost:8000
 - **Send compute work:** `mep Write a Python script --bounty 5.0 --model gemini`
 - **Direct-message a specific node:** `mepdm node_98eb3d301b2b hello`
 - **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request`
+- **List recent stored structured DMs:** `mepdmlist`
 - **Safely reply to a stored structured DM:** `mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-type review_response --intent review.response`
 - **Start free bot-to-bot chat:** `mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b`
 - **Check balance:** `mepbalance`
@@ -236,6 +237,7 @@ export WS_URL=ws://localhost:8000
 `mepdm` succeeds only when the target node is online and connected to the hub.
 For multi-turn chat, send a fresh DM for each reply turn instead of depending on `/tasks/complete` result polling.
 Use `scripts/threaded_review_example.py` as a minimal example of a structured review flow with `context_id`, reply references, and checkpoint turns.
+Use `mepdmlist` to inspect the recent structured DM cache and find the right `task_id` before using `mepdmreplysafe`.
 For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)`, `extract_review_verdict(...)`, `submit_human_approval_request_dm(...)`, and `extract_human_approval_request(...)`.
 For long sessions, the shared client also supports sender-declared `session_safety` metadata and `evaluate_interbot_session_safety(...)` so bots can enforce max-turn, timeout, and checkpoint policies consistently.
 When the receiver already has the inbound parsed message, `submit_safe_dm_reply(...)` can enforce those rules and choose reply vs checkpoint vs stop automatically.

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -44,6 +44,26 @@ class StdioAdapter:
             oldest_task_id = next(iter(self._recent_interbot_results))
             del self._recent_interbot_results[oldest_task_id]
 
+    def _list_recent_structured_dm_results(self) -> None:
+        if not self._recent_interbot_results:
+            print(f"[{self.platform_name}] no stored structured dm results")
+            return
+
+        print(f"[{self.platform_name}] recent structured dm results:")
+        for task_id, inbound in reversed(list(self._recent_interbot_results.items())):
+            message = inbound.get("message", {})
+            source = message.get("source") if isinstance(message, dict) else None
+            conversation = message.get("conversation") if isinstance(message, dict) else None
+            intent = message.get("intent") if isinstance(message, dict) else None
+            print(
+                f"[{self.platform_name}] - task_id={task_id} "
+                f"context_id={conversation.get('context_id') if isinstance(conversation, dict) else None} "
+                f"message_id={message.get('message_id') if isinstance(message, dict) else None} "
+                f"source={source.get('node_id') if isinstance(source, dict) else None} "
+                f"turn_type={conversation.get('turn_type') if isinstance(conversation, dict) else None} "
+                f"intent={intent.get('type') if isinstance(intent, dict) else None}"
+            )
+
     async def _submit(self, text: str) -> None:
         payload, bounty, model, target = parse_task_args(text, DEFAULT_BOUNTY, self.default_model)
         if not payload:
@@ -247,6 +267,9 @@ class StdioAdapter:
         if text.startswith("mepdmx "):
             await self._send_structured_dm(text[7:])
             return True
+        if text == "mepdmlist":
+            self._list_recent_structured_dm_results()
+            return True
         if text.startswith("mepdmreplysafe "):
             await self._send_safe_dm_reply(text[15:])
             return True
@@ -280,7 +303,7 @@ class StdioAdapter:
         print(f"[{self.platform_name}] connected as {self.client.node_id}")
         print(
             f"[{self.platform_name}] commands: "
-            "mep, mepdm, mepdmx, mepdmreplysafe, mepdata, mepcancel, mepresult, mepbalance, exit"
+            "mep, mepdm, mepdmx, mepdmlist, mepdmreplysafe, mepdata, mepcancel, mepresult, mepbalance, exit"
         )
         loop = asyncio.get_running_loop()
         try:

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -79,6 +79,54 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
         )
         print_mock.assert_any_call("[codex] safe reply reply task task_safe_reply context=pr154-review")
 
+    async def test_dispatch_line_dmlist_reports_when_empty(self):
+        adapter, _client = self._make_adapter()
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line("mepdmlist")
+
+        self.assertTrue(keep_going)
+        print_mock.assert_any_call("[codex] no stored structured dm results")
+
+    async def test_dispatch_line_dmlist_shows_recent_structured_dm_results(self):
+        adapter, _client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "intent": {"type": "review.request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        adapter._recent_interbot_results["task_checkpoint"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_checkpoint",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "checkpoint"},
+                "intent": {"type": "coordination.request"},
+                "task": {"instructions": "Checkpoint summary"},
+            },
+        }
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line("mepdmlist")
+
+        self.assertTrue(keep_going)
+        print_mock.assert_any_call("[codex] recent structured dm results:")
+        print_mock.assert_any_call(
+            "[codex] - task_id=task_checkpoint context_id=pr154-review "
+            "message_id=message_checkpoint source=node_reviewer "
+            "turn_type=checkpoint intent=coordination.request"
+        )
+        print_mock.assert_any_call(
+            "[codex] - task_id=task_review_request context_id=pr154-review "
+            "message_id=message_review_request source=node_reviewer "
+            "turn_type=review_request intent=review.request"
+        )
+
     async def test_dispatch_line_safe_reply_reports_stop_without_submitting_dm(self):
         adapter, client = self._make_adapter()
         adapter._recent_interbot_results["task_review_request"] = {


### PR DESCRIPTION
## Summary
- add mepdmlist to inspect the recent cached structured DM entries in the stdio adapter
- show task id, context id, message id, source node, turn type, and intent for each cached entry
- document the new command and how it helps operators find the correct task id before using mepdmreplysafe

## Testing
- python -m pytest tests/test_stdio_adapter.py tests/test_shared_mep_client.py -q