### PR TITLE
feat: add review verdict runtime command

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ export WS_URL=ws://localhost:8000
 - **Direct-message a specific node:** `mepdm node_98eb3d301b2b hello`
 - **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request`
 - **List recent stored structured DMs:** `mepdmlist`
+- **Send a structured review verdict DM:** `mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations."`
 - **Safely reply to a stored structured DM:** `mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-type review_response --intent review.response`
 - **Start free bot-to-bot chat:** `mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b`
 - **Check balance:** `mepbalance`
@@ -238,6 +239,7 @@ export WS_URL=ws://localhost:8000
 For multi-turn chat, send a fresh DM for each reply turn instead of depending on `/tasks/complete` result polling.
 Use `scripts/threaded_review_example.py` as a minimal example of a structured review flow with `context_id`, reply references, and checkpoint turns.
 Use `mepdmlist` to inspect the recent structured DM cache and find the right `task_id` before using `mepdmreplysafe`.
+Use `mepdmverdict` when the operator wants to send a machine-readable review decision back through the same threaded DM context without rebuilding the reply metadata by hand.
 For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)`, `extract_review_verdict(...)`, `submit_human_approval_request_dm(...)`, and `extract_human_approval_request(...)`.
 For long sessions, the shared client also supports sender-declared `session_safety` metadata and `evaluate_interbot_session_safety(...)` so bots can enforce max-turn, timeout, and checkpoint policies consistently.
 When the receiver already has the inbound parsed message, `submit_safe_dm_reply(...)` can enforce those rules and choose reply vs checkpoint vs stop automatically.

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -233,13 +233,17 @@ class StdioAdapter:
 
         task_id = parts[0]
         verdict = parts[1]
-        rationale = parts[2]
+        rationale_parts: list[str] = []
         conditions: list[str] = []
         recommendation: Optional[str] = None
         priority = "normal"
-        i = 3
+        i = 2
         while i < len(parts):
             token = parts[i]
+            if not token.startswith("--"):
+                rationale_parts.append(token)
+                i += 1
+                continue
             if token == "--condition":
                 if i + 1 >= len(parts):
                     print(f"[{self.platform_name}] missing value for {token}")
@@ -262,6 +266,13 @@ class StdioAdapter:
                 i += 2
                 continue
             print(f"[{self.platform_name}] unknown option {token}")
+            return
+
+        rationale = " ".join(rationale_parts).strip()
+        if not rationale:
+            print(
+                f"[{self.platform_name}] usage: mepdmverdict <task_id> <verdict> <rationale> [options]"
+            )
             return
 
         inbound = self._recent_interbot_results.get(task_id)

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -218,6 +218,98 @@ class StdioAdapter:
             f"context={response.get('context_id')}"
         )
 
+    async def _send_review_verdict_dm(self, text: str) -> None:
+        try:
+            parts = shlex.split(text)
+        except ValueError as exc:
+            print(f"[{self.platform_name}] mepdmverdict parse error: {exc}")
+            return
+        if len(parts) < 3:
+            print(
+                f"[{self.platform_name}] usage: mepdmverdict <task_id> <verdict> <rationale> "
+                "[--condition text] [--recommendation text] [--priority level]"
+            )
+            return
+
+        task_id = parts[0]
+        verdict = parts[1]
+        rationale = parts[2]
+        conditions: list[str] = []
+        recommendation: Optional[str] = None
+        priority = "normal"
+        i = 3
+        while i < len(parts):
+            token = parts[i]
+            if token == "--condition":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                conditions.append(parts[i + 1])
+                i += 2
+                continue
+            if token == "--recommendation":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                recommendation = parts[i + 1]
+                i += 2
+                continue
+            if token == "--priority":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                priority = parts[i + 1]
+                i += 2
+                continue
+            print(f"[{self.platform_name}] unknown option {token}")
+            return
+
+        inbound = self._recent_interbot_results.get(task_id)
+        if not inbound:
+            print(f"[{self.platform_name}] no stored structured dm result for task {task_id}")
+            return
+
+        message = inbound["message"]
+        source = message.get("source") if isinstance(message, dict) else None
+        conversation = message.get("conversation") if isinstance(message, dict) else None
+        target_node = source.get("node_id") if isinstance(source, dict) else None
+        context_id = conversation.get("context_id") if isinstance(conversation, dict) else None
+        reply_to_message_id = message.get("message_id") if isinstance(message, dict) else None
+
+        if not isinstance(target_node, str) or not target_node:
+            print(f"[{self.platform_name}] stored structured dm result {task_id} is missing source.node_id")
+            return
+        if not isinstance(context_id, str) or not context_id:
+            print(f"[{self.platform_name}] stored structured dm result {task_id} is missing conversation.context_id")
+            return
+
+        try:
+            response = await self.client.submit_review_verdict_dm(
+                verdict,
+                rationale,
+                target_node,
+                context_id=context_id,
+                target_alias=source.get("alias") if isinstance(source, dict) and isinstance(source.get("alias"), str) else None,
+                reply_to_task_id=task_id,
+                reply_to_message_id=reply_to_message_id if isinstance(reply_to_message_id, str) else None,
+                conditions=conditions or None,
+                human_recommendation=recommendation,
+                priority=priority,
+            )
+        except ValueError as exc:
+            print(f"[{self.platform_name}] review verdict error: {exc}")
+            return
+
+        data = response.get("json", {})
+        if response.get("status_code") != 200 or data.get("status") != "success":
+            print(f"[{self.platform_name}] review verdict failed: {data}")
+            return
+
+        print(
+            f"[{self.platform_name}] review verdict sent task {data.get('task_id')} "
+            f"context={response.get('context_id')}"
+        )
+
     async def _offer_data(self, price: str, payload: str) -> None:
         bounty = -abs(float(price))
         response = await self.client.submit_task("Data offer available", bounty, secret_data=payload)
@@ -270,6 +362,9 @@ class StdioAdapter:
         if text == "mepdmlist":
             self._list_recent_structured_dm_results()
             return True
+        if text.startswith("mepdmverdict "):
+            await self._send_review_verdict_dm(text[13:])
+            return True
         if text.startswith("mepdmreplysafe "):
             await self._send_safe_dm_reply(text[15:])
             return True
@@ -303,7 +398,8 @@ class StdioAdapter:
         print(f"[{self.platform_name}] connected as {self.client.node_id}")
         print(
             f"[{self.platform_name}] commands: "
-            "mep, mepdm, mepdmx, mepdmlist, mepdmreplysafe, mepdata, mepcancel, mepresult, mepbalance, exit"
+            "mep, mepdm, mepdmx, mepdmlist, mepdmverdict, mepdmreplysafe, "
+            "mepdata, mepcancel, mepresult, mepbalance, exit"
         )
         loop = asyncio.get_running_loop()
         try:

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -171,6 +171,46 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
         )
         print_mock.assert_any_call("[codex] review verdict sent task task_review_verdict context=pr154-review")
 
+    async def test_dispatch_line_review_verdict_accepts_unquoted_multiword_rationale(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_review_verdict_dm = AsyncMock(
+            return_value={
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_review_verdict"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                "mepdmverdict task_review_request approve_with_conditions "
+                "Threading model is sound. --condition \"Document reply expectations.\""
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_review_verdict_dm.assert_awaited_once_with(
+            "approve_with_conditions",
+            "Threading model is sound.",
+            "node_reviewer",
+            context_id="pr154-review",
+            target_alias=None,
+            reply_to_task_id="task_review_request",
+            reply_to_message_id="message_review_request",
+            conditions=["Document reply expectations."],
+            human_recommendation=None,
+            priority="normal",
+        )
+        print_mock.assert_any_call("[codex] review verdict sent task task_review_verdict context=pr154-review")
+
     async def test_dispatch_line_review_verdict_reports_validation_errors(self):
         adapter, client = self._make_adapter()
         adapter._recent_interbot_results["task_review_request"] = {

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -127,6 +127,72 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             "turn_type=review_request intent=review.request"
         )
 
+    async def test_dispatch_line_review_verdict_uses_stored_inbound_message(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer", "alias": "Reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_review_verdict_dm = AsyncMock(
+            return_value={
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_review_verdict"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmverdict task_review_request approve_with_conditions '
+                '"Threading model is sound." '
+                '--condition "Document reply expectations." '
+                '--condition "Keep reply_mode=new_dm." '
+                '--recommendation "Merge after the docs note lands." '
+                '--priority high'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_review_verdict_dm.assert_awaited_once_with(
+            "approve_with_conditions",
+            "Threading model is sound.",
+            "node_reviewer",
+            context_id="pr154-review",
+            target_alias="Reviewer",
+            reply_to_task_id="task_review_request",
+            reply_to_message_id="message_review_request",
+            conditions=["Document reply expectations.", "Keep reply_mode=new_dm."],
+            human_recommendation="Merge after the docs note lands.",
+            priority="high",
+        )
+        print_mock.assert_any_call("[codex] review verdict sent task task_review_verdict context=pr154-review")
+
+    async def test_dispatch_line_review_verdict_reports_validation_errors(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_review_verdict_dm = AsyncMock(side_effect=ValueError("unsupported review verdict: maybe"))
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmverdict task_review_request maybe "Threading model is sound."'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_review_verdict_dm.assert_awaited_once()
+        print_mock.assert_any_call("[codex] review verdict error: unsupported review verdict: maybe")
+
     async def test_dispatch_line_safe_reply_reports_stop_without_submitting_dm(self):
         adapter, client = self._make_adapter()
         adapter._recent_interbot_results["task_review_request"] = {


### PR DESCRIPTION
## Summary
- add a stdio adapter command for sending machine-readable review verdict DMs from cached structured DM context
- reuse stored task and message metadata so operators do not need to reconstruct reply fields manually
- add focused adapter coverage and README usage notes

## Testing
- python -m pytest tests/test_stdio_adapter.py tests/test_shared_mep_client.py -q