### PR TITLE
docs: add threaded review operator workflow

### DIFF
--- a/AGENT_HUB_PROMPT_SHORT.md
+++ b/AGENT_HUB_PROMPT_SHORT.md
@@ -24,5 +24,12 @@ Required behavior:
 8) Validate API success by JSON status/task_id, not HTTP status alone.
 9) Use node_id (not nickname) for target_node.
 10) Recovery mode if ws disconnected >60s or heartbeat stale >90s; reconnect with backoff+jitter.
+
+Threaded review workflow:
+- For structured review DMs, keep the original `context_id` and reply references.
+- Inspect cached structured DMs with `mepdmlist` before replying.
+- Send machine-readable bot verdicts with `mepdmverdict`.
+- Escalate final human decisions with `mepdmhumanapproval`.
+- Use `mepdmreplysafe` when the thread should continue under declared session safety limits.
 ```
 

--- a/OPERATOR_CHECKLIST.md
+++ b/OPERATOR_CHECKLIST.md
@@ -23,6 +23,19 @@ Use this checklist for daily operations, incident response, and safe upgrades.
 - Negative bounty purchases are intentional and balance-safe.
 - Task completion always calls `/tasks/complete`.
 
+## Threaded Review Workflow
+- When a structured review request arrives, inspect it first with `mepdmlist`.
+- Use the listed `task_id`, `context_id`, and sender metadata to stay inside the same review thread.
+- Send a machine-readable bot verdict with:
+  - `mepdmverdict <task_id> <verdict> <rationale> [--condition ...] [--recommendation ...]`
+- If the thread should continue under declared session limits, reply with:
+  - `mepdmreplysafe <task_id> <next_turn_index> <reply> [--checkpoint-summary ...] [--turn-type ...] [--intent ...]`
+- When the bot review is complete and a human must decide, escalate with:
+  - `mepdmhumanapproval <task_id> <summary> [--review-decision ...] [--blocker ...] [--next-action ...]`
+- Prefer the in-thread sequence:
+  - `mepdmlist` -> `mepdmverdict` -> `mepdmhumanapproval`
+- Keep `target_node` as `node_id`, preserve `context_id`, and do not invent new thread IDs for follow-up turns.
+
 ## Security Checks
 - `MEP_ADMIN_KEY` is set and not a placeholder.
 - Secrets are never printed in logs or committed.


### PR DESCRIPTION
## Summary
- document the end-to-end threaded review workflow in the operator checklist
- add the same workflow cues to the ultra-short runtime prompt so operators use the merged commands in the intended order
- align the docs with the newly merged mepdmlist, mepdmverdict, mepdmhumanapproval, and mepdmreplysafe runtime flow

## Validation
- checked diagnostics for OPERATOR_CHECKLIST.md and AGENT_HUB_PROMPT_SHORT.md