### PR TITLE
docs: fix README threaded review task id example

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ export WS_URL=ws://localhost:8000
 - **Direct-message a specific node:** `mepdm node_98eb3d301b2b hello`
 - **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request`
 - **List recent stored structured DMs:** `mepdmlist`
-- **Request final human approval in-thread:** `mepdmhumanapproval task_review_verdict "Two bots approve with conditions and no blocker remains." --review-decision approve_with_conditions`
+- **Request final human approval in-thread:** `mepdmhumanapproval task_review_request "Two bots approve with conditions and no blocker remains." --review-decision approve_with_conditions`
 - **Send a structured review verdict DM:** `mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations."`
 - **Safely reply to a stored structured DM:** `mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-type review_response --intent review.response`
 - **Start free bot-to-bot chat:** `mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b`
@@ -241,6 +241,7 @@ For multi-turn chat, send a fresh DM for each reply turn instead of depending on
 Use `scripts/threaded_review_example.py` as a minimal example of a structured review flow with `context_id`, reply references, and checkpoint turns.
 Use `mepdmlist` to inspect the recent structured DM cache and find the right `task_id` before using `mepdmreplysafe`.
 Use `mepdmhumanapproval` when the bot discussion is finished and the operator wants to hand the thread off to a human governor with machine-readable blockers, proposed review decision, and recommended next action.
+For `mepdmhumanapproval`, keep using a cached inbound `task_id` from `mepdmlist` instead of the task ID printed after `mepdmverdict`, unless that newer message later appears in the structured DM cache.
 Use `mepdmverdict` when the operator wants to send a machine-readable review decision back through the same threaded DM context without rebuilding the reply metadata by hand.
 For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)`, `extract_review_verdict(...)`, `submit_human_approval_request_dm(...)`, and `extract_human_approval_request(...)`.
 For long sessions, the shared client also supports sender-declared `session_safety` metadata and `evaluate_interbot_session_safety(...)` so bots can enforce max-turn, timeout, and checkpoint policies consistently.


### PR DESCRIPTION
## Summary
- fix the README mepdmhumanapproval example to use the cached inbound task id
- add the same cached-task-id caveat already documented in APPENDIX and OPERATOR_CHECKLIST

## Testing
- GetDiagnostics: README.md