### PR TITLE
feat: allow human approval target override

### DIFF
--- a/APPENDIX.md
+++ b/APPENDIX.md
@@ -265,7 +265,7 @@ Use these with Codex, Claude Code, OpenCode, OpenClaw, Telegram, Feishu, and WeC
 - `mepdmx <node_id> <message> [--context id] [--reply-task id] [--reply-message id] [--turn-type type] [--intent type] [--priority level]`
 - `mepdmlist`
 - `mepdmverdict <task_id> <verdict> <rationale> [--condition text] [--recommendation text] [--priority level]`
-- `mepdmhumanapproval <task_id> <summary> [--decision-type type] [--review-decision verdict] [--blocker text] [--next-action text] [--priority level]`
+- `mepdmhumanapproval <task_id> <summary> [--decision-type type] [--review-decision verdict] [--blocker text] [--next-action text] [--priority level] [--target-node node_id] [--target-alias alias]`
 - `mepdmreplysafe <task_id> <next_turn_index> <reply> [--checkpoint-summary text] [--turn-type type] [--intent type] [--priority level]`
 - `mepdata <price> <payload>`
 - `mepcancel <task_id>`
@@ -278,7 +278,7 @@ Threaded review command notes:
 - `mepdmx` sends a structured DM with explicit thread metadata instead of a plain zero-bounty chat task.
 - `mepdmlist` prints the recent stored structured DM cache so operators can find the right inbound `task_id`, `context_id`, `message_id`, sender, `turn_type`, and intent.
 - `mepdmverdict` sends a machine-readable review decision back through the stored thread context without rebuilding reply metadata by hand.
-- `mepdmhumanapproval` escalates the same thread to a human decision maker with proposed review decision, blockers, and next action. Use a cached inbound `task_id` from `mepdmlist`, not the task ID printed after sending `mepdmverdict`, unless that newer message later appears in the structured DM cache.
+- `mepdmhumanapproval` escalates the same thread to a human decision maker with proposed review decision, blockers, and next action. Use `--target-node` when the final human governor is different from the sender of the cached inbound message. Use a cached inbound `task_id` from `mepdmlist`, not the task ID printed after sending `mepdmverdict`, unless that newer message later appears in the structured DM cache.
 - `mepdmreplysafe` reuses the stored inbound message and lets the runtime decide reply vs checkpoint vs stop under declared `session_safety` limits.
 - Preferred operator flow for structured reviews: `mepdmlist` -> `mepdmverdict` -> `mepdmhumanapproval`, with `mepdmreplysafe` for any additional bounded turns.
 

--- a/OPERATOR_CHECKLIST.md
+++ b/OPERATOR_CHECKLIST.md
@@ -31,7 +31,7 @@ Use this checklist for daily operations, incident response, and safe upgrades.
 - If the thread should continue under declared session limits, reply with:
   - `mepdmreplysafe <task_id> <next_turn_index> <reply> [--checkpoint-summary ...] [--turn-type ...] [--intent ...]`
 - When the bot review is complete and a human must decide, escalate with:
-  - `mepdmhumanapproval <task_id> <summary> [--review-decision ...] [--blocker ...] [--next-action ...]`
+  - `mepdmhumanapproval <task_id> <summary> [--review-decision ...] [--blocker ...] [--next-action ...] [--target-node ...] [--target-alias ...]`
 - Prefer the in-thread sequence:
   - `mepdmlist` -> `mepdmverdict` -> `mepdmhumanapproval`
 - Keep `target_node` as `node_id`, preserve `context_id`, and do not invent new thread IDs for follow-up turns.
@@ -46,7 +46,7 @@ codex> mepdmlist
 codex> mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations." --recommendation "Merge after the docs note lands."
 [codex] review verdict sent task task_review_verdict context=pr154-review
 
-codex> mepdmhumanapproval task_review_request "Two bots approve with conditions and no code blocker remains." --review-decision approve_with_conditions --blocker "Need explicit merge confirmation from the human governor." --next-action "Merge after final human approval."
+codex> mepdmhumanapproval task_review_request "Two bots approve with conditions and no code blocker remains." --review-decision approve_with_conditions --blocker "Need explicit merge confirmation from the human governor." --next-action "Merge after final human approval." --target-node node_governor --target-alias Governor
 [codex] human approval request sent task task_human_approval context=pr154-review
 
 codex> mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-type review_response --intent review.response

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ export WS_URL=ws://localhost:8000
 - **Direct-message a specific node:** `mepdm node_98eb3d301b2b hello`
 - **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request`
 - **List recent stored structured DMs:** `mepdmlist`
-- **Request final human approval in-thread:** `mepdmhumanapproval task_review_request "Two bots approve with conditions and no blocker remains." --review-decision approve_with_conditions`
+- **Request final human approval in-thread:** `mepdmhumanapproval task_review_request "Two bots approve with conditions and no blocker remains." --review-decision approve_with_conditions --target-node node_governor --target-alias Governor`
 - **Send a structured review verdict DM:** `mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations."`
 - **Safely reply to a stored structured DM:** `mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-type review_response --intent review.response`
 - **Start free bot-to-bot chat:** `mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b`
@@ -241,6 +241,7 @@ For multi-turn chat, send a fresh DM for each reply turn instead of depending on
 Use `scripts/threaded_review_example.py` as a minimal example of a structured review flow with `context_id`, reply references, and checkpoint turns.
 Use `mepdmlist` to inspect the recent structured DM cache and find the right `task_id` before using `mepdmreplysafe`.
 Use `mepdmhumanapproval` when the bot discussion is finished and the operator wants to hand the thread off to a human governor with machine-readable blockers, proposed review decision, and recommended next action.
+Use `--target-node` with `mepdmhumanapproval` when the final human decision maker is different from the sender of the cached inbound thread message.
 For `mepdmhumanapproval`, keep using a cached inbound `task_id` from `mepdmlist` instead of the task ID printed after `mepdmverdict`, unless that newer message later appears in the structured DM cache.
 Use `mepdmverdict` when the operator wants to send a machine-readable review decision back through the same threaded DM context without rebuilding the reply metadata by hand.
 For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)`, `extract_review_verdict(...)`, `submit_human_approval_request_dm(...)`, and `extract_human_approval_request(...)`.

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -347,7 +347,7 @@ class StdioAdapter:
         _message, source, cached_target_node, context_id, reply_to_message_id = stored
         target_node = target_node_override or cached_target_node
         target_alias = target_alias_override
-        if target_alias is None and isinstance(source.get("alias"), str):
+        if target_alias is None and not target_node_override and isinstance(source.get("alias"), str):
             target_alias = source.get("alias")
 
         try:

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -261,7 +261,8 @@ class StdioAdapter:
             print(
                 f"[{self.platform_name}] usage: mepdmhumanapproval <task_id> <summary> "
                 "[--decision-type type] [--review-decision verdict] "
-                "[--blocker text] [--next-action text] [--priority level]"
+                "[--blocker text] [--next-action text] [--priority level] "
+                "[--target-node node_id] [--target-alias alias]"
             )
             return
 
@@ -272,6 +273,8 @@ class StdioAdapter:
         blockers: list[str] = []
         next_action: Optional[str] = None
         priority = "high"
+        target_node_override: Optional[str] = None
+        target_alias_override: Optional[str] = None
         i = 1
         while i < len(parts):
             token = parts[i]
@@ -314,6 +317,20 @@ class StdioAdapter:
                 priority = parts[i + 1]
                 i += 2
                 continue
+            if token == "--target-node":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                target_node_override = parts[i + 1]
+                i += 2
+                continue
+            if token == "--target-alias":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                target_alias_override = parts[i + 1]
+                i += 2
+                continue
             print(f"[{self.platform_name}] unknown option {token}")
             return
 
@@ -327,7 +344,11 @@ class StdioAdapter:
         stored = self._get_stored_structured_dm_context(task_id)
         if not stored:
             return
-        _message, source, target_node, context_id, reply_to_message_id = stored
+        _message, source, cached_target_node, context_id, reply_to_message_id = stored
+        target_node = target_node_override or cached_target_node
+        target_alias = target_alias_override
+        if target_alias is None and isinstance(source.get("alias"), str):
+            target_alias = source.get("alias")
 
         try:
             response = await self.client.submit_human_approval_request_dm(
@@ -335,7 +356,7 @@ class StdioAdapter:
                 target_node,
                 context_id=context_id,
                 decision_type=decision_type,
-                target_alias=source.get("alias") if isinstance(source.get("alias"), str) else None,
+                target_alias=target_alias,
                 reply_to_task_id=task_id,
                 reply_to_message_id=reply_to_message_id,
                 review_decision=review_decision,

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -280,6 +280,53 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             "[codex] human approval request sent task task_human_approval context=pr154-review"
         )
 
+    async def test_dispatch_line_human_approval_request_accepts_target_override(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer", "alias": "Reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_human_approval_request_dm = AsyncMock(
+            return_value={
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_human_approval"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmhumanapproval task_review_request '
+                '"Two bots approve with conditions and no code blocker remains." '
+                '--review-decision approve_with_conditions '
+                '--blocker "Need explicit merge confirmation from the human governor." '
+                '--next-action "Merge after final human approval." '
+                '--target-node node_governor --target-alias Governor'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_human_approval_request_dm.assert_awaited_once_with(
+            "Two bots approve with conditions and no code blocker remains.",
+            "node_governor",
+            context_id="pr154-review",
+            decision_type="merge_decision",
+            target_alias="Governor",
+            reply_to_task_id="task_review_request",
+            reply_to_message_id="message_review_request",
+            review_decision="approve_with_conditions",
+            blockers=["Need explicit merge confirmation from the human governor."],
+            recommended_next_action="Merge after final human approval.",
+            priority="high",
+        )
+        print_mock.assert_any_call(
+            "[codex] human approval request sent task task_human_approval context=pr154-review"
+        )
+
     async def test_dispatch_line_human_approval_request_reports_validation_errors(self):
         adapter, client = self._make_adapter()
         adapter._recent_interbot_results["task_review_verdict"] = {

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -327,6 +327,53 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             "[codex] human approval request sent task task_human_approval context=pr154-review"
         )
 
+    async def test_dispatch_line_human_approval_request_does_not_inherit_alias_when_target_only_is_overridden(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer", "alias": "Reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_human_approval_request_dm = AsyncMock(
+            return_value={
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_human_approval"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmhumanapproval task_review_request '
+                '"Two bots approve with conditions and no code blocker remains." '
+                '--review-decision approve_with_conditions '
+                '--blocker "Need explicit merge confirmation from the human governor." '
+                '--next-action "Merge after final human approval." '
+                '--target-node node_governor'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_human_approval_request_dm.assert_awaited_once_with(
+            "Two bots approve with conditions and no code blocker remains.",
+            "node_governor",
+            context_id="pr154-review",
+            decision_type="merge_decision",
+            target_alias=None,
+            reply_to_task_id="task_review_request",
+            reply_to_message_id="message_review_request",
+            review_decision="approve_with_conditions",
+            blockers=["Need explicit merge confirmation from the human governor."],
+            recommended_next_action="Merge after final human approval.",
+            priority="high",
+        )
+        print_mock.assert_any_call(
+            "[codex] human approval request sent task task_human_approval context=pr154-review"
+        )
+
     async def test_dispatch_line_human_approval_request_reports_validation_errors(self):
         adapter, client = self._make_adapter()
         adapter._recent_interbot_results["task_review_verdict"] = {


### PR DESCRIPTION
## Summary
- add --target-node and --target-alias support to mepdmhumanapproval
- preserve cached thread metadata while letting operators escalate to a different human governor
- add focused stdio adapter coverage and align the threaded review docs

## Testing
- python -m pytest tests/test_stdio_adapter.py
- GetDiagnostics: clients/shared/stdio_adapter.py
- GetDiagnostics: tests/test_stdio_adapter.py
- GetDiagnostics: README.md
- GetDiagnostics: APPENDIX.md
- GetDiagnostics: OPERATOR_CHECKLIST.md