### PR TITLE
fix: validate safe reply options

### DIFF
--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -193,10 +193,19 @@ class StdioAdapter:
 
         options: dict[str, str] = {}
         reply_parts: list[str] = []
+        allowed_options = {
+            "--checkpoint-summary",
+            "--turn-type",
+            "--intent",
+            "--priority",
+        }
         i = 2
         while i < len(parts):
             token = parts[i]
             if token.startswith("--"):
+                if token not in allowed_options:
+                    print(f"[{self.platform_name}] unknown option {token}")
+                    return
                 if i + 1 >= len(parts):
                     print(f"[{self.platform_name}] missing value for {token}")
                     return

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -79,6 +79,28 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
         )
         print_mock.assert_any_call("[codex] safe reply reply task task_safe_reply context=pr154-review")
 
+    async def test_dispatch_line_safe_reply_rejects_unknown_option(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_safe_dm_reply = AsyncMock()
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmreplysafe task_review_request 3 "I approve with conditions." --bogus nope'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_safe_dm_reply.assert_not_awaited()
+        print_mock.assert_any_call("[codex] unknown option --bogus")
+
     async def test_dispatch_line_dmlist_reports_when_empty(self):
         adapter, _client = self._make_adapter()
 


### PR DESCRIPTION
## Summary
- reject unknown mepdmreplysafe flags instead of silently accepting them
- keep the stdio adapter behavior aligned with the documented supported flag set
- add focused regression coverage for the unknown-option path

## Testing
- python -m pytest tests/test_stdio_adapter.py
- GetDiagnostics on clients/shared/stdio_adapter.py
- GetDiagnostics on tests/test_stdio_adapter.py