### PR TITLE
feat: support human approval human notes

### DIFF
--- a/APPENDIX.md
+++ b/APPENDIX.md
@@ -265,7 +265,7 @@ Use these with Codex, Claude Code, OpenCode, OpenClaw, Telegram, Feishu, and WeC
 - `mepdmx <node_id> <message> [--context id] [--reply-task id] [--reply-message id] [--turn-type type] [--intent type] [--priority level]`
 - `mepdmlist`
 - `mepdmverdict <task_id> <verdict> <rationale> [--condition text] [--recommendation text] [--priority level]`
-- `mepdmhumanapproval <task_id> <summary> [--decision-type type] [--review-decision verdict] [--blocker text] [--next-action text] [--priority level] [--target-node node_id] [--target-alias alias]`
+- `mepdmhumanapproval <task_id> <summary> [--decision-type type] [--review-decision verdict] [--blocker text] [--next-action text] [--priority level] [--target-node node_id] [--target-alias alias] [--human-note text]`
 - `mepdmreplysafe <task_id> <next_turn_index> <reply> [--checkpoint-summary text] [--turn-type type] [--intent type] [--priority level]`
 - `mepdata <price> <payload>`
 - `mepcancel <task_id>`
@@ -278,7 +278,7 @@ Threaded review command notes:
 - `mepdmx` sends a structured DM with explicit thread metadata instead of a plain zero-bounty chat task.
 - `mepdmlist` prints the recent stored structured DM cache so operators can find the right inbound `task_id`, `context_id`, `message_id`, sender, `turn_type`, and intent.
 - `mepdmverdict` sends a machine-readable review decision back through the stored thread context without rebuilding reply metadata by hand.
-- `mepdmhumanapproval` escalates the same thread to a human decision maker with proposed review decision, blockers, and next action. Use `--target-node` when the final human governor is different from the sender of the cached inbound message. Use a cached inbound `task_id` from `mepdmlist`, not the task ID printed after sending `mepdmverdict`, unless that newer message later appears in the structured DM cache.
+- `mepdmhumanapproval` escalates the same thread to a human decision maker with proposed review decision, blockers, next action, and an optional free-form `human_note`. Use `--target-node` when the final human governor is different from the sender of the cached inbound message. Use a cached inbound `task_id` from `mepdmlist`, not the task ID printed after sending `mepdmverdict`, unless that newer message later appears in the structured DM cache.
 - `mepdmreplysafe` reuses the stored inbound message and lets the runtime decide reply vs checkpoint vs stop under declared `session_safety` limits.
 - Preferred operator flow for structured reviews: `mepdmlist` -> `mepdmverdict` -> `mepdmhumanapproval`, with `mepdmreplysafe` for any additional bounded turns.
 
@@ -287,7 +287,7 @@ Common threaded review fixes:
 - `no stored structured dm result for task ...`: run `mepdmlist` first and copy a real cached inbound `task_id` instead of guessing one from memory.
 - `stored structured dm result ... is missing source.node_id` or `... conversation.context_id`: the cached message is incomplete, so do not continue the thread manually; wait for a valid structured inbound DM and preserve its original metadata.
 - `usage: mepdmverdict ...`, `usage: mepdmhumanapproval ...`, or `usage: mepdmreplysafe ...`: a required positional argument is missing, usually the `task_id`, rationale or summary text, or `next_turn_index`.
-- `unknown option --...`: use only the documented flags for that command. For `mepdmverdict`, the supported flags are `--condition`, `--recommendation`, and `--priority`. For `mepdmhumanapproval`, the supported flags are `--decision-type`, `--review-decision`, `--blocker`, `--next-action`, `--priority`, `--target-node`, and `--target-alias`.
+- `unknown option --...`: use only the documented flags for that command. For `mepdmverdict`, the supported flags are `--condition`, `--recommendation`, and `--priority`. For `mepdmhumanapproval`, the supported flags are `--decision-type`, `--review-decision`, `--blocker`, `--next-action`, `--priority`, `--target-node`, `--target-alias`, and `--human-note`.
 - `next_turn_index must be an integer`: pass a numeric next turn value such as `3`, not free text.
 - `review verdict error: ...`, `human approval request error: ...`, or `safe dm reply error: ...`: keep the original `context_id` and reply references from the cached inbound DM, and use a supported verdict or decision value before retrying.
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ export WS_URL=ws://localhost:8000
 - **Direct-message a specific node:** `mepdm node_98eb3d301b2b hello`
 - **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request`
 - **List recent stored structured DMs:** `mepdmlist`
-- **Request final human approval in-thread:** `mepdmhumanapproval task_review_request "Two bots approve with conditions and no blocker remains." --review-decision approve_with_conditions --target-node node_governor --target-alias Governor`
+- **Request final human approval in-thread:** `mepdmhumanapproval task_review_request "Two bots approve with conditions and no blocker remains." --review-decision approve_with_conditions --target-node node_governor --target-alias Governor --human-note "Human asked for a final release-window check."`
 - **Send a structured review verdict DM:** `mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations."`
 - **Safely reply to a stored structured DM:** `mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-type review_response --intent review.response`
 - **Start free bot-to-bot chat:** `mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b`
@@ -242,6 +242,7 @@ Use `scripts/threaded_review_example.py` as a minimal example of a structured re
 Use `mepdmlist` to inspect the recent structured DM cache and find the right `task_id` before using `mepdmreplysafe`.
 Use `mepdmhumanapproval` when the bot discussion is finished and the operator wants to hand the thread off to a human governor with machine-readable blockers, proposed review decision, and recommended next action.
 Use `--target-node` with `mepdmhumanapproval` when the final human decision maker is different from the sender of the cached inbound thread message.
+Use `--human-note` with `mepdmhumanapproval` when the operator needs to preserve a small piece of free-form human context alongside the machine-readable approval payload.
 For `mepdmhumanapproval`, keep using a cached inbound `task_id` from `mepdmlist` instead of the task ID printed after `mepdmverdict`, unless that newer message later appears in the structured DM cache.
 Use `mepdmverdict` when the operator wants to send a machine-readable review decision back through the same threaded DM context without rebuilding the reply metadata by hand.
 For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)`, `extract_review_verdict(...)`, `submit_human_approval_request_dm(...)`, and `extract_human_approval_request(...)`.

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -271,7 +271,7 @@ class StdioAdapter:
                 f"[{self.platform_name}] usage: mepdmhumanapproval <task_id> <summary> "
                 "[--decision-type type] [--review-decision verdict] "
                 "[--blocker text] [--next-action text] [--priority level] "
-                "[--target-node node_id] [--target-alias alias]"
+                "[--target-node node_id] [--target-alias alias] [--human-note text]"
             )
             return
 
@@ -284,6 +284,7 @@ class StdioAdapter:
         priority = "high"
         target_node_override: Optional[str] = None
         target_alias_override: Optional[str] = None
+        human_note: Optional[str] = None
         i = 1
         while i < len(parts):
             token = parts[i]
@@ -340,6 +341,13 @@ class StdioAdapter:
                 target_alias_override = parts[i + 1]
                 i += 2
                 continue
+            if token == "--human-note":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                human_note = parts[i + 1]
+                i += 2
+                continue
             print(f"[{self.platform_name}] unknown option {token}")
             return
 
@@ -372,6 +380,7 @@ class StdioAdapter:
                 blockers=blockers or None,
                 recommended_next_action=next_action,
                 priority=priority,
+                human_note=human_note,
             )
         except ValueError as exc:
             print(f"[{self.platform_name}] human approval request error: {exc}")

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -297,6 +297,7 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             blockers=["Need explicit merge confirmation from the human governor."],
             recommended_next_action="Merge after final human approval.",
             priority="high",
+            human_note=None,
         )
         print_mock.assert_any_call(
             "[codex] human approval request sent task task_human_approval context=pr154-review"
@@ -344,6 +345,56 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             blockers=["Need explicit merge confirmation from the human governor."],
             recommended_next_action="Merge after final human approval.",
             priority="high",
+            human_note=None,
+        )
+        print_mock.assert_any_call(
+            "[codex] human approval request sent task task_human_approval context=pr154-review"
+        )
+
+    async def test_dispatch_line_human_approval_request_accepts_human_note(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer", "alias": "Reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_human_approval_request_dm = AsyncMock(
+            return_value={
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_human_approval"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmhumanapproval task_review_request '
+                '"Two bots approve with conditions and no code blocker remains." '
+                '--review-decision approve_with_conditions '
+                '--blocker "Need explicit merge confirmation from the human governor." '
+                '--next-action "Merge after final human approval." '
+                '--target-node node_governor --target-alias Governor '
+                '--human-note "Human asked for a final release-window check."'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_human_approval_request_dm.assert_awaited_once_with(
+            "Two bots approve with conditions and no code blocker remains.",
+            "node_governor",
+            context_id="pr154-review",
+            decision_type="merge_decision",
+            target_alias="Governor",
+            reply_to_task_id="task_review_request",
+            reply_to_message_id="message_review_request",
+            review_decision="approve_with_conditions",
+            blockers=["Need explicit merge confirmation from the human governor."],
+            recommended_next_action="Merge after final human approval.",
+            priority="high",
+            human_note="Human asked for a final release-window check.",
         )
         print_mock.assert_any_call(
             "[codex] human approval request sent task task_human_approval context=pr154-review"
@@ -391,6 +442,7 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             blockers=["Need explicit merge confirmation from the human governor."],
             recommended_next_action="Merge after final human approval.",
             priority="high",
+            human_note=None,
         )
         print_mock.assert_any_call(
             "[codex] human approval request sent task task_human_approval context=pr154-review"


### PR DESCRIPTION
## Summary
- add --human-note support to mepdmhumanapproval in the stdio adapter
- pass human_note through to the shared client for structured human approval requests
- document the new operator flag and add focused regression coverage

## Testing
- python -m pytest tests/test_stdio_adapter.py
- GetDiagnostics on clients/shared/stdio_adapter.py
- GetDiagnostics on tests/test_stdio_adapter.py
- GetDiagnostics on README.md
- GetDiagnostics on APPENDIX.md