### PR TITLE
docs: add human note to operator checklist

### DIFF
--- a/OPERATOR_CHECKLIST.md
+++ b/OPERATOR_CHECKLIST.md
@@ -31,7 +31,7 @@ Use this checklist for daily operations, incident response, and safe upgrades.
 - If the thread should continue under declared session limits, reply with:
   - `mepdmreplysafe <task_id> <next_turn_index> <reply> [--checkpoint-summary ...] [--turn-type ...] [--intent ...]`
 - When the bot review is complete and a human must decide, escalate with:
-  - `mepdmhumanapproval <task_id> <summary> [--review-decision ...] [--blocker ...] [--next-action ...] [--target-node ...] [--target-alias ...]`
+  - `mepdmhumanapproval <task_id> <summary> [--review-decision ...] [--blocker ...] [--next-action ...] [--target-node ...] [--target-alias ...] [--human-note ...]`
 - Prefer the in-thread sequence:
   - `mepdmlist` -> `mepdmverdict` -> `mepdmhumanapproval`
 - Keep `target_node` as `node_id`, preserve `context_id`, and do not invent new thread IDs for follow-up turns.
@@ -46,7 +46,7 @@ codex> mepdmlist
 codex> mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations." --recommendation "Merge after the docs note lands."
 [codex] review verdict sent task task_review_verdict context=pr154-review
 
-codex> mepdmhumanapproval task_review_request "Two bots approve with conditions and no code blocker remains." --review-decision approve_with_conditions --blocker "Need explicit merge confirmation from the human governor." --next-action "Merge after final human approval." --target-node node_governor --target-alias Governor
+codex> mepdmhumanapproval task_review_request "Two bots approve with conditions and no code blocker remains." --review-decision approve_with_conditions --blocker "Need explicit merge confirmation from the human governor." --next-action "Merge after final human approval." --target-node node_governor --target-alias Governor --human-note "Human asked for a final release-window check."
 [codex] human approval request sent task task_human_approval context=pr154-review
 
 codex> mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-type review_response --intent review.response


### PR DESCRIPTION
## Summary
- update OPERATOR_CHECKLIST to include the new --human-note flag on mepdmhumanapproval
- align the operator example with the runtime, README, and APPENDIX after PR #171

## Testing
- GetDiagnostics on OPERATOR_CHECKLIST.md