### PR TITLE
feat: support review verdict human notes

### DIFF
--- a/APPENDIX.md
+++ b/APPENDIX.md
@@ -264,7 +264,7 @@ Use these with Codex, Claude Code, OpenCode, OpenClaw, Telegram, Feishu, and WeC
 - `mepdm <node_id> <message>`
 - `mepdmx <node_id> <message> [--context id] [--reply-task id] [--reply-message id] [--turn-type type] [--intent type] [--priority level]`
 - `mepdmlist`
-- `mepdmverdict <task_id> <verdict> <rationale> [--condition text] [--recommendation text] [--priority level]`
+- `mepdmverdict <task_id> <verdict> <rationale> [--condition text] [--recommendation text] [--priority level] [--human-note text]`
 - `mepdmhumanapproval <task_id> <summary> [--decision-type type] [--review-decision verdict] [--blocker text] [--next-action text] [--priority level] [--target-node node_id] [--target-alias alias] [--human-note text]`
 - `mepdmreplysafe <task_id> <next_turn_index> <reply> [--checkpoint-summary text] [--turn-type type] [--intent type] [--priority level]`
 - `mepdata <price> <payload>`
@@ -277,7 +277,7 @@ Threaded review command notes:
 
 - `mepdmx` sends a structured DM with explicit thread metadata instead of a plain zero-bounty chat task.
 - `mepdmlist` prints the recent stored structured DM cache so operators can find the right inbound `task_id`, `context_id`, `message_id`, sender, `turn_type`, and intent.
-- `mepdmverdict` sends a machine-readable review decision back through the stored thread context without rebuilding reply metadata by hand.
+- `mepdmverdict` sends a machine-readable review decision back through the stored thread context without rebuilding reply metadata by hand. Use `--human-note` when the operator needs to preserve a small free-form note alongside the structured verdict.
 - `mepdmhumanapproval` escalates the same thread to a human decision maker with proposed review decision, blockers, next action, and an optional free-form `human_note`. Use `--target-node` when the final human governor is different from the sender of the cached inbound message. Use a cached inbound `task_id` from `mepdmlist`, not the task ID printed after sending `mepdmverdict`, unless that newer message later appears in the structured DM cache.
 - `mepdmreplysafe` reuses the stored inbound message and lets the runtime decide reply vs checkpoint vs stop under declared `session_safety` limits.
 - Preferred operator flow for structured reviews: `mepdmlist` -> `mepdmverdict` -> `mepdmhumanapproval`, with `mepdmreplysafe` for any additional bounded turns.
@@ -287,7 +287,7 @@ Common threaded review fixes:
 - `no stored structured dm result for task ...`: run `mepdmlist` first and copy a real cached inbound `task_id` instead of guessing one from memory.
 - `stored structured dm result ... is missing source.node_id` or `... conversation.context_id`: the cached message is incomplete, so do not continue the thread manually; wait for a valid structured inbound DM and preserve its original metadata.
 - `usage: mepdmverdict ...`, `usage: mepdmhumanapproval ...`, or `usage: mepdmreplysafe ...`: a required positional argument is missing, usually the `task_id`, rationale or summary text, or `next_turn_index`.
-- `unknown option --...`: use only the documented flags for that command. For `mepdmverdict`, the supported flags are `--condition`, `--recommendation`, and `--priority`. For `mepdmhumanapproval`, the supported flags are `--decision-type`, `--review-decision`, `--blocker`, `--next-action`, `--priority`, `--target-node`, `--target-alias`, and `--human-note`.
+- `unknown option --...`: use only the documented flags for that command. For `mepdmverdict`, the supported flags are `--condition`, `--recommendation`, `--priority`, and `--human-note`. For `mepdmhumanapproval`, the supported flags are `--decision-type`, `--review-decision`, `--blocker`, `--next-action`, `--priority`, `--target-node`, `--target-alias`, and `--human-note`.
 - `next_turn_index must be an integer`: pass a numeric next turn value such as `3`, not free text.
 - `review verdict error: ...`, `human approval request error: ...`, or `safe dm reply error: ...`: keep the original `context_id` and reply references from the cached inbound DM, and use a supported verdict or decision value before retrying.
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ export WS_URL=ws://localhost:8000
 - **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request`
 - **List recent stored structured DMs:** `mepdmlist`
 - **Request final human approval in-thread:** `mepdmhumanapproval task_review_request "Two bots approve with conditions and no blocker remains." --review-decision approve_with_conditions --target-node node_governor --target-alias Governor --human-note "Human asked for a final release-window check."`
-- **Send a structured review verdict DM:** `mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations."`
+- **Send a structured review verdict DM:** `mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations." --human-note "Human requested one extra release-timing check."`
 - **Safely reply to a stored structured DM:** `mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-type review_response --intent review.response`
 - **Start free bot-to-bot chat:** `mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b`
 - **Check balance:** `mepbalance`
@@ -245,6 +245,7 @@ Use `--target-node` with `mepdmhumanapproval` when the final human decision make
 Use `--human-note` with `mepdmhumanapproval` when the operator needs to preserve a small piece of free-form human context alongside the machine-readable approval payload.
 For `mepdmhumanapproval`, keep using a cached inbound `task_id` from `mepdmlist` instead of the task ID printed after `mepdmverdict`, unless that newer message later appears in the structured DM cache.
 Use `mepdmverdict` when the operator wants to send a machine-readable review decision back through the same threaded DM context without rebuilding the reply metadata by hand.
+Use `--human-note` with `mepdmverdict` when the operator needs to attach a small free-form note without changing the structured verdict fields.
 For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)`, `extract_review_verdict(...)`, `submit_human_approval_request_dm(...)`, and `extract_human_approval_request(...)`.
 For long sessions, the shared client also supports sender-declared `session_safety` metadata and `evaluate_interbot_session_safety(...)` so bots can enforce max-turn, timeout, and checkpoint policies consistently.
 When the receiver already has the inbound parsed message, `submit_safe_dm_reply(...)` can enforce those rules and choose reply vs checkpoint vs stop automatically.

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -405,7 +405,7 @@ class StdioAdapter:
         if len(parts) < 3:
             print(
                 f"[{self.platform_name}] usage: mepdmverdict <task_id> <verdict> <rationale> "
-                "[--condition text] [--recommendation text] [--priority level]"
+                "[--condition text] [--recommendation text] [--priority level] [--human-note text]"
             )
             return
 
@@ -415,6 +415,7 @@ class StdioAdapter:
         conditions: list[str] = []
         recommendation: Optional[str] = None
         priority = "normal"
+        human_note: Optional[str] = None
         i = 2
         while i < len(parts):
             token = parts[i]
@@ -441,6 +442,13 @@ class StdioAdapter:
                     print(f"[{self.platform_name}] missing value for {token}")
                     return
                 priority = parts[i + 1]
+                i += 2
+                continue
+            if token == "--human-note":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                human_note = parts[i + 1]
                 i += 2
                 continue
             print(f"[{self.platform_name}] unknown option {token}")
@@ -470,6 +478,7 @@ class StdioAdapter:
                 conditions=conditions or None,
                 human_recommendation=recommendation,
                 priority=priority,
+                human_note=human_note,
             )
         except ValueError as exc:
             print(f"[{self.platform_name}] review verdict error: {exc}")

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -190,6 +190,51 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             conditions=["Document reply expectations.", "Keep reply_mode=new_dm."],
             human_recommendation="Merge after the docs note lands.",
             priority="high",
+            human_note=None,
+        )
+        print_mock.assert_any_call("[codex] review verdict sent task task_review_verdict context=pr154-review")
+
+    async def test_dispatch_line_review_verdict_accepts_human_note(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer", "alias": "Reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_review_verdict_dm = AsyncMock(
+            return_value={
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_review_verdict"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmverdict task_review_request approve_with_conditions '
+                '"Threading model is sound." '
+                '--condition "Document reply expectations." '
+                '--recommendation "Merge after the docs note lands." '
+                '--human-note "Human requested one extra release-timing check."'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_review_verdict_dm.assert_awaited_once_with(
+            "approve_with_conditions",
+            "Threading model is sound.",
+            "node_reviewer",
+            context_id="pr154-review",
+            target_alias="Reviewer",
+            reply_to_task_id="task_review_request",
+            reply_to_message_id="message_review_request",
+            conditions=["Document reply expectations."],
+            human_recommendation="Merge after the docs note lands.",
+            priority="normal",
+            human_note="Human requested one extra release-timing check.",
         )
         print_mock.assert_any_call("[codex] review verdict sent task task_review_verdict context=pr154-review")
 
@@ -230,6 +275,7 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             conditions=["Document reply expectations."],
             human_recommendation=None,
             priority="normal",
+            human_note=None,
         )
         print_mock.assert_any_call("[codex] review verdict sent task task_review_verdict context=pr154-review")
 


### PR DESCRIPTION
## Summary
- add --human-note support to mepdmverdict in the stdio adapter
- pass human_note through to the shared client for structured review verdicts
- document the new operator flag and add focused regression coverage

## Testing
- python -m pytest tests/test_stdio_adapter.py
- GetDiagnostics on clients/shared/stdio_adapter.py
- GetDiagnostics on tests/test_stdio_adapter.py
- GetDiagnostics on README.md
- GetDiagnostics on APPENDIX.md