### PR TITLE
feat: add mepdmx session safety flags

### DIFF
--- a/APPENDIX.md
+++ b/APPENDIX.md
@@ -262,7 +262,7 @@ Use these with Codex, Claude Code, OpenCode, OpenClaw, Telegram, Feishu, and WeC
 
 - `mep <task> [--bounty 5.0] [--model adapter-agent] [--target node_id]`
 - `mepdm <node_id> <message>`
-- `mepdmx <node_id> <message> [--context id] [--reply-task id] [--reply-message id] [--turn-type type] [--intent type] [--priority <level>]`
+- `mepdmx <node_id> <message> [--context id] [--reply-task id] [--reply-message id] [--turn-type type] [--intent type] [--priority <level>] [--max-turns count] [--max-duration-seconds seconds] [--checkpoint-interval count]`
 - `mepdmlist`
 - `mepdmverdict <task_id> <verdict> <rationale> [--condition text] [--recommendation text] [--priority <level>] [--human-note text]`
 - `mepdmhumanapproval <task_id> <summary> [--decision-type type] [--review-decision verdict] [--blocker text] [--next-action text] [--priority <level>] [--target-node node_id] [--target-alias alias] [--human-note text]`
@@ -275,7 +275,7 @@ Use these with Codex, Claude Code, OpenCode, OpenClaw, Telegram, Feishu, and WeC
 
 Threaded review command notes:
 
-- `mepdmx` sends a structured DM with explicit thread metadata instead of a plain zero-bounty chat task.
+- `mepdmx` sends a structured DM with explicit thread metadata instead of a plain zero-bounty chat task. Use `--max-turns`, `--max-duration-seconds`, and `--checkpoint-interval` when the operator wants to start a guarded live relay or soak-test thread directly from stdio.
 - `mepdmlist` prints the recent stored structured DM cache so operators can find the right inbound `task_id`, `context_id`, `message_id`, sender, `turn_type`, and intent.
 - `mepdmverdict` sends a machine-readable review decision back through the stored thread context without rebuilding reply metadata by hand. Use `--human-note` when the operator needs to preserve a small free-form note alongside the structured verdict.
 - `mepdmhumanapproval` escalates the same thread to a human decision maker with proposed review decision, blockers, next action, and an optional free-form `human_note`. Use `--target-node` when the final human governor is different from the sender of the cached inbound message. Use a cached inbound `task_id` from `mepdmlist`, not the task ID printed after sending `mepdmverdict`, unless that newer message later appears in the structured DM cache.
@@ -286,8 +286,9 @@ Common threaded review fixes:
 
 - `no stored structured dm result for task ...`: run `mepdmlist` first and copy a real cached inbound `task_id` instead of guessing one from memory.
 - `stored structured dm result ... is missing source.node_id` or `... conversation.context_id`: the cached message is incomplete, so do not continue the thread manually; wait for a valid structured inbound DM and preserve its original metadata.
-- `usage: mepdmverdict ...`, `usage: mepdmhumanapproval ...`, or `usage: mepdmreplysafe ...`: a required positional argument is missing, usually the `task_id`, rationale or summary text, or `next_turn_index`.
-- `unknown option --...`: use only the documented flags for that command. For `mepdmverdict`, the supported flags are `--condition`, `--recommendation`, `--priority`, and `--human-note`. For `mepdmhumanapproval`, the supported flags are `--decision-type`, `--review-decision`, `--blocker`, `--next-action`, `--priority`, `--target-node`, `--target-alias`, and `--human-note`. For `mepdmreplysafe`, the supported flags are `--checkpoint-summary`, `--turn-type`, `--intent`, `--priority`, and `--human-note`.
+- `usage: mepdmx ...`, `usage: mepdmverdict ...`, `usage: mepdmhumanapproval ...`, or `usage: mepdmreplysafe ...`: a required positional argument is missing, usually the target `node_id`, cached `task_id`, rationale or summary text, or `next_turn_index`.
+- `unknown option --...`: use only the documented flags for that command. For `mepdmx`, the supported flags are `--context`, `--reply-task`, `--reply-message`, `--turn-type`, `--intent`, `--priority`, `--max-turns`, `--max-duration-seconds`, and `--checkpoint-interval`. For `mepdmverdict`, the supported flags are `--condition`, `--recommendation`, `--priority`, and `--human-note`. For `mepdmhumanapproval`, the supported flags are `--decision-type`, `--review-decision`, `--blocker`, `--next-action`, `--priority`, `--target-node`, `--target-alias`, and `--human-note`. For `mepdmreplysafe`, the supported flags are `--checkpoint-summary`, `--turn-type`, `--intent`, `--priority`, and `--human-note`.
+- `threaded dm error: ...`: use positive integers for `--max-turns`, `--max-duration-seconds`, and `--checkpoint-interval`, and provide at least one of them when you want `mepdmx` to attach `session_safety`.
 - `next_turn_index must be an integer`: pass a numeric next turn value such as `3`, not free text.
 - `review verdict error: ...`, `human approval request error: ...`, or `safe dm reply error: ...`: keep the original `context_id` and reply references from the cached inbound DM, and use a supported verdict or decision value before retrying.
 

--- a/OPERATOR_CHECKLIST.md
+++ b/OPERATOR_CHECKLIST.md
@@ -26,6 +26,7 @@ Use this checklist for daily operations, incident response, and safe upgrades.
 ## Threaded Review Workflow
 - When a structured review request arrives, inspect it first with `mepdmlist`.
 - Use the listed `task_id`, `context_id`, and sender metadata to stay inside the same review thread.
+- When you start a long review thread from stdio, attach guardrails up front with `mepdmx ... --max-turns ... --max-duration-seconds ... --checkpoint-interval ...`.
 - Send a machine-readable bot verdict with:
   - `mepdmverdict <task_id> <verdict> <rationale> [--condition ...] [--recommendation ...]`
 - If the thread should continue under declared session limits, reply with:
@@ -39,6 +40,9 @@ Use this checklist for daily operations, incident response, and safe upgrades.
 Example operator flow:
 
 ```text
+codex> mepdmx node_reviewer "Please review PR 154 and keep replies inside this thread." --context pr154-review --turn-type review_request --intent review.request --max-turns 12 --max-duration-seconds 3600 --checkpoint-interval 3
+[codex] sent threaded dm task task_review_request to node_reviewer context=pr154-review
+
 codex> mepdmlist
 [codex] recent structured dm results:
 [codex] - task_id=task_review_request context_id=pr154-review message_id=message_review_request source=node_reviewer turn_type=review_request intent=review.request

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ export WS_URL=ws://localhost:8000
 
 - **Send compute work:** `mep Write a Python script --bounty 5.0 --model gemini`
 - **Direct-message a specific node:** `mepdm node_98eb3d301b2b hello`
-- **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request`
+- **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request --max-turns 12 --max-duration-seconds 3600 --checkpoint-interval 3`
 - **List recent stored structured DMs:** `mepdmlist`
 - **Request final human approval in-thread:** `mepdmhumanapproval task_review_request "Two bots approve with conditions and no blocker remains." --review-decision approve_with_conditions --target-node node_governor --target-alias Governor --human-note "Human asked for a final release-window check."`
 - **Send a structured review verdict DM:** `mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations." --human-note "Human requested one extra release-timing check."`
@@ -247,6 +247,7 @@ For `mepdmhumanapproval`, keep using a cached inbound `task_id` from `mepdmlist`
 Use `mepdmverdict` when the operator wants to send a machine-readable review decision back through the same threaded DM context without rebuilding the reply metadata by hand.
 Use `--human-note` with `mepdmverdict` when the operator needs to attach a small free-form note without changing the structured verdict fields.
 For machine-readable review decisions, the shared client also provides `submit_review_verdict_dm(...)`, `extract_review_verdict(...)`, `submit_human_approval_request_dm(...)`, and `extract_human_approval_request(...)`.
+Use `--max-turns`, `--max-duration-seconds`, and `--checkpoint-interval` with `mepdmx` when the operator wants to start a guarded live relay thread directly from stdio instead of hand-writing `session_safety` in Python.
 For long sessions, the shared client also supports sender-declared `session_safety` metadata and `evaluate_interbot_session_safety(...)` so bots can enforce max-turn, timeout, and checkpoint policies consistently.
 When the receiver already has the inbound parsed message, `submit_safe_dm_reply(...)` can enforce those rules and choose reply vs checkpoint vs stop automatically.
 Use `--human-note` with `mepdmreplysafe` when the operator needs to attach a small free-form note to a bounded safe reply without changing its structured turn metadata.

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -127,17 +127,32 @@ class StdioAdapter:
             print(
                 f"[{self.platform_name}] usage: mepdmx <node_id> <message> "
                 "[--context id] [--reply-task id] [--reply-message id] [--turn-type type] "
-                "[--intent type] [--priority <level>]"
+                "[--intent type] [--priority <level>] [--max-turns count] "
+                "[--max-duration-seconds seconds] [--checkpoint-interval count]"
             )
             return
 
         target_node = parts[0]
+        allowed_options = {
+            "--context",
+            "--reply-task",
+            "--reply-message",
+            "--turn-type",
+            "--intent",
+            "--priority",
+            "--max-turns",
+            "--max-duration-seconds",
+            "--checkpoint-interval",
+        }
         options: dict[str, str] = {}
         message_parts: list[str] = []
         i = 1
         while i < len(parts):
             token = parts[i]
             if token.startswith("--"):
+                if token not in allowed_options:
+                    print(f"[{self.platform_name}] unknown option {token}")
+                    return
                 if i + 1 >= len(parts):
                     print(f"[{self.platform_name}] missing value for {token}")
                     return
@@ -152,16 +167,43 @@ class StdioAdapter:
             print(f"[{self.platform_name}] usage: mepdmx <node_id> <message> [options]")
             return
 
-        response = await self.client.submit_dm(
-            message,
-            target_node,
-            context_id=options.get("--context"),
-            reply_to_task_id=options.get("--reply-task"),
-            reply_to_message_id=options.get("--reply-message"),
-            turn_type=options.get("--turn-type", "chat_turn"),
-            intent_type=options.get("--intent", "chat.request"),
-            priority=options.get("--priority", "normal"),
-        )
+        try:
+            max_turns = int(options["--max-turns"]) if "--max-turns" in options else None
+            max_duration_seconds = (
+                int(options["--max-duration-seconds"])
+                if "--max-duration-seconds" in options
+                else None
+            )
+            checkpoint_interval = (
+                int(options["--checkpoint-interval"])
+                if "--checkpoint-interval" in options
+                else None
+            )
+            session_safety = None
+            if (
+                max_turns is not None
+                or max_duration_seconds is not None
+                or checkpoint_interval is not None
+            ):
+                session_safety = self.client.build_session_safety_metadata(
+                    max_turns=max_turns,
+                    max_duration_seconds=max_duration_seconds,
+                    checkpoint_interval=checkpoint_interval,
+                )
+            response = await self.client.submit_dm(
+                message,
+                target_node,
+                context_id=options.get("--context"),
+                reply_to_task_id=options.get("--reply-task"),
+                reply_to_message_id=options.get("--reply-message"),
+                turn_type=options.get("--turn-type", "chat_turn"),
+                intent_type=options.get("--intent", "chat.request"),
+                priority=options.get("--priority", "normal"),
+                session_safety=session_safety,
+            )
+        except ValueError as exc:
+            print(f"[{self.platform_name}] threaded dm error: {exc}")
+            return
         data = response["json"]
         if response["status_code"] != 200 or data.get("status") != "success":
             print(f"[{self.platform_name}] dm failed: {data}")

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -39,6 +39,85 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             "[codex] stored structured dm result task_review_request context=pr154-review"
         )
 
+    async def test_dispatch_line_structured_dm_accepts_session_safety_flags(self):
+        adapter, client = self._make_adapter()
+        client.build_session_safety_metadata.return_value = {
+            "max_turns": 12,
+            "max_duration_seconds": 3600,
+            "checkpoint_interval": 3,
+            "started_at_ms": 1_777_000_000_000,
+        }
+        client.submit_dm = AsyncMock(
+            return_value={
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_threaded_dm"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmx node_reviewer "Please review PR 154." '
+                "--context pr154-review --turn-type review_request --intent review.request "
+                "--priority high --max-turns 12 --max-duration-seconds 3600 "
+                "--checkpoint-interval 3"
+            )
+
+        self.assertTrue(keep_going)
+        client.build_session_safety_metadata.assert_called_once_with(
+            max_turns=12,
+            max_duration_seconds=3600,
+            checkpoint_interval=3,
+        )
+        client.submit_dm.assert_awaited_once_with(
+            "Please review PR 154.",
+            "node_reviewer",
+            context_id="pr154-review",
+            reply_to_task_id=None,
+            reply_to_message_id=None,
+            turn_type="review_request",
+            intent_type="review.request",
+            priority="high",
+            session_safety={
+                "max_turns": 12,
+                "max_duration_seconds": 3600,
+                "checkpoint_interval": 3,
+                "started_at_ms": 1_777_000_000_000,
+            },
+        )
+        print_mock.assert_any_call("[codex] sent threaded dm task task_threaded_dm to node_reviewer context=pr154-review")
+
+    async def test_dispatch_line_structured_dm_rejects_unknown_option(self):
+        adapter, client = self._make_adapter()
+        client.submit_dm = AsyncMock()
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmx node_reviewer "Please review PR 154." --bogus nope'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_dm.assert_not_awaited()
+        print_mock.assert_any_call("[codex] unknown option --bogus")
+
+    async def test_dispatch_line_structured_dm_reports_invalid_session_safety(self):
+        adapter, client = self._make_adapter()
+        client.build_session_safety_metadata.side_effect = ValueError(
+            "checkpoint_interval must be a positive integer"
+        )
+        client.submit_dm = AsyncMock()
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmx node_reviewer "Please review PR 154." --checkpoint-interval 0'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_dm.assert_not_awaited()
+        print_mock.assert_any_call(
+            "[codex] threaded dm error: checkpoint_interval must be a positive integer"
+        )
+
     async def test_dispatch_line_safe_reply_uses_stored_inbound_message(self):
         adapter, client = self._make_adapter()
         adapter._recent_interbot_results["task_review_request"] = {


### PR DESCRIPTION
## Summary
- add --max-turns, --max-duration-seconds, and --checkpoint-interval to mepdmx
- reject unknown mepdmx flags and surface invalid session-safety values as operator-facing errors
- update the threaded review docs so guarded live relay threads are copy-pasteable from stdio

## Testing
- python -m pytest tests/test_stdio_adapter.py