### PR TITLE
docs: add threaded review soak runbook

### DIFF
--- a/OPERATOR_CHECKLIST.md
+++ b/OPERATOR_CHECKLIST.md
@@ -24,6 +24,7 @@ Use this checklist for daily operations, incident response, and safe upgrades.
 - Task completion always calls `/tasks/complete`.
 
 ## Threaded Review Workflow
+- Use `docs/threaded-review/SOAK_RUNBOOK.md` when you want the full one-hour guarded relay playbook instead of the short operator example below.
 - When a structured review request arrives, inspect it first with `mepdmlist`.
 - Use the listed `task_id`, `context_id`, and sender metadata to stay inside the same review thread.
 - When you start a long review thread from stdio, attach guardrails up front with `mepdmx ... --max-turns ... --max-duration-seconds ... --checkpoint-interval ...`.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Use `--human-note` with `mepdmreplysafe` when the operator needs to attach a sma
 - Use `AGENT_HUB_PROMPT.md` for the full autonomous bot operating guide.
 - Use `AGENT_HUB_PROMPT_SHORT.md` for the shorter runtime prompt.
 - Use `OPERATOR_CHECKLIST.md` for operational runbook steps.
+- Use `docs/threaded-review/SOAK_RUNBOOK.md` for the live guarded multi-bot relay / soak-session playbook.
 
 </details>
 

--- a/docs/threaded-review/SOAK_RUNBOOK.md
+++ b/docs/threaded-review/SOAK_RUNBOOK.md
@@ -36,6 +36,10 @@ These values are large enough for a real relay but small enough to prove checkpo
 
 Before starting the session, choose these values for the specific soak you are running:
 
+- `<hub_base_url>`: the HTTP base URL used by the participating nodes, for example `http://localhost:8000` or `https://mep-hub.silentcopilot.ai`
+- `<hub_ws_url>`: the matching WebSocket URL, for example `ws://localhost:8000` or `wss://mep-hub.silentcopilot.ai`
+- `<operator_adapter_launch_command>`: the command used by the operator-controlled sender node
+- `<reviewer_adapter_launch_command>`: the command used by each reviewer node
 - `<reviewer_node_id>`: the first reviewer bot that should receive the opening request
 - `<human_governor_node_id>`: the human decision maker if the session includes final approval
 - `<context_id>`: a fresh thread identifier for this soak run, for example `review-soak-20260525-01`
@@ -46,25 +50,43 @@ Keep these values stable for the full session. Do not recycle an old `context_id
 
 ## Preflight
 
-1. Verify hub health:
+1. Verify that every participating node is configured against the same hub:
 
 ```bash
-curl http://localhost:8000/health
+export HUB_URL=<hub_base_url>
+export WS_URL=<hub_ws_url>
 ```
 
-2. Launch the operator adapter on the sender node:
+2. Verify hub health:
 
 ```bash
-python -m clients.adapters.mep_codex_adapter
+curl <hub_base_url>/health
 ```
 
-3. Launch the other participating adapters on their nodes, for example:
+3. Launch the operator adapter on the sender node:
 
 ```bash
-python -m clients.adapters.mep_claude_code_adapter
+<operator_adapter_launch_command>
 ```
 
-4. Confirm each bot can register and reach the hub before starting the threaded session.
+4. Launch the reviewer adapters on their nodes:
+
+```bash
+<reviewer_adapter_launch_command>
+```
+
+5. Confirm each bot can register and reach the same hub before starting the threaded session.
+
+Adapter command examples:
+
+- `python -m clients.adapters.mep_codex_adapter`
+- `python -m clients.adapters.mep_claude_code_adapter`
+- `python -m clients.adapters.mep_opencode_adapter`
+- `python -m clients.adapters.mep_openclaw_adapter`
+- `python -m clients.adapters.mep_wechat_adapter`
+- `python -m clients.adapters.mep_telegram_adapter`
+
+Use the adapter commands that match the actual nodes participating in your soak. The runbook does not require Codex or Claude specifically.
 
 ## Start The Thread
 

--- a/docs/threaded-review/SOAK_RUNBOOK.md
+++ b/docs/threaded-review/SOAK_RUNBOOK.md
@@ -1,0 +1,147 @@
+# Threaded Review Soak Runbook
+
+Use this runbook for a real guarded multi-bot review session that should run for up to one hour with low human burden.
+
+## Goal
+
+Prove that a live threaded review can:
+
+- start from stdio with declared `session_safety`
+- stay inside one `context_id`
+- hand off between bots with structured verdict and safe-reply turns
+- emit checkpoints at the declared cadence
+- stop or escalate cleanly without rebuilding thread metadata by hand
+
+## Preconditions
+
+- At least three online bot nodes are available:
+  - one operator-controlled sender
+  - one or two reviewer bots
+  - one human governor target if final approval is part of the session
+- Each participating node already has a valid key and can register with the hub.
+- The operator knows the stable node IDs for the reviewers and human governor.
+- The hub is healthy and the target reviewer nodes are online.
+
+## Recommended Session Guards
+
+Use these defaults for a one-hour soak:
+
+- `--max-turns 12`
+- `--max-duration-seconds 3600`
+- `--checkpoint-interval 3`
+
+These values are large enough for a real relay but small enough to prove checkpoint and stop behavior during the session.
+
+## Preflight
+
+1. Verify hub health:
+
+```bash
+curl http://localhost:8000/health
+```
+
+2. Launch the operator adapter on the sender node:
+
+```bash
+python -m clients.adapters.mep_codex_adapter
+```
+
+3. Launch the other participating adapters on their nodes, for example:
+
+```bash
+python -m clients.adapters.mep_claude_code_adapter
+```
+
+4. Confirm each bot can register and reach the hub before starting the threaded session.
+
+## Start The Thread
+
+Use `mepdmx` to start the guarded thread from stdio:
+
+```text
+mepdmx node_reviewer_a "Please review PR 154. Keep all follow-up turns in this thread, surface blockers early, and preserve context for a final human merge decision." --context pr154-review-soak-001 --turn-type review_request --intent review.request --priority high --max-turns 12 --max-duration-seconds 3600 --checkpoint-interval 3
+```
+
+Expected output:
+
+```text
+[codex] sent threaded dm task task_review_request context=pr154-review-soak-001
+```
+
+## Relay Loop
+
+Use this repeatable operator loop for the rest of the session.
+
+1. Inspect the latest cached structured DM:
+
+```text
+mepdmlist
+```
+
+2. When a reviewer sends a structured verdict, send a machine-readable response if needed:
+
+```text
+mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document rollout timing." --recommendation "Continue the relay and escalate after the final checkpoint."
+```
+
+3. When the thread should continue within the same session, use bounded replies:
+
+```text
+mepdmreplysafe task_review_request 2 "Continuing the review relay. Keep the next reply focused on blocking concerns." --turn-type review_response --intent review.response
+```
+
+4. On the next bounded turn, keep using the cached inbound `task_id` shown by `mepdmlist`:
+
+```text
+mepdmreplysafe task_review_request 3 "Checkpoint follow-up: summarize the top two remaining blockers before we escalate." --checkpoint-summary "Checkpoint: three turns completed; preserve the same context and highlight unresolved blockers." --turn-type review_response --intent review.response --human-note "Soak run checkpoint one."
+```
+
+5. When bot review is complete and a human governor must decide, escalate in-thread:
+
+```text
+mepdmhumanapproval task_review_request "Two bots approve with conditions and the relay stayed inside the guarded thread." --review-decision approve_with_conditions --blocker "Need explicit human merge confirmation." --next-action "Merge after the governor confirms release timing." --target-node node_governor --target-alias Governor --human-note "Live soak session completed without thread drift."
+```
+
+## What To Watch
+
+During the session, verify these invariants:
+
+- every turn stays on the same `context_id`
+- follow-up turns reuse cached inbound `task_id` values from `mepdmlist`
+- no one invents new thread IDs or manual reply metadata
+- checkpoint turns appear at the declared cadence
+- safe replies print `safe reply task ...` or `safe checkpoint task ...`
+- if the session exceeds limits, the runtime stops cleanly instead of sending one more reply
+
+## Evidence To Capture
+
+Save these artifacts during or immediately after the session:
+
+- the initial `mepdmx` command line and returned task/context IDs
+- one `mepdmlist` snapshot near the beginning, middle, and end of the run
+- at least one `safe checkpoint task ...` line
+- the final `mepdmhumanapproval ...` line or the final `safe dm reply stopped ...` line
+- any operator-facing errors such as `unknown option ...` or `threaded dm error: ...`
+
+## Success Criteria
+
+Treat the soak as successful if:
+
+- the relay runs for the planned duration or reaches the declared stop condition
+- all turns remain inside one thread
+- checkpoint behavior matches the declared cadence
+- no operator had to rebuild `context_id`, `reply_to_task_id`, or `reply_to_message_id` manually
+- the session ends with a clean human approval handoff or a clean runtime stop
+
+## If Something Breaks
+
+- If `mepdmlist` does not show the expected inbound structured DM, stop and wait for a valid cached inbound turn before continuing.
+- If `unknown option --...` appears, fix the command line and resend the same intended action without inventing new thread metadata.
+- If `threaded dm error: ...` appears on `mepdmx`, correct the guard values and restart the session with a fresh `context_id`.
+- If `safe dm reply error: ...` appears, do not hand-build reply metadata; use the latest cached inbound task from `mepdmlist`.
+
+## Related References
+
+- `OPERATOR_CHECKLIST.md`
+- `APPENDIX.md`
+- `scripts/threaded_review_example.py`

--- a/docs/threaded-review/SOAK_RUNBOOK.md
+++ b/docs/threaded-review/SOAK_RUNBOOK.md
@@ -16,7 +16,7 @@ Prove that a live threaded review can:
 
 - At least three online bot nodes are available:
   - one operator-controlled sender
-  - one or two reviewer bots
+  - one primary reviewer bot, plus an optional second reviewer if you want to observe a broader relay
   - one human governor target if final approval is part of the session
 - Each participating node already has a valid key and can register with the hub.
 - The operator knows the stable node IDs for the reviewers and human governor.
@@ -108,6 +108,10 @@ Expected output:
 [codex] sent threaded dm task <task_id> context=<context_id>
 ```
 
+Treat this first successful `mepdmx` as the start of the soak clock. The one-hour session guard begins when the thread is created, not during preflight.
+
+If you want to include a second reviewer in the same soak, open that as a separate `mepdmx` thread after the first one is healthy. Choose a fresh `context_id` unless you are deliberately testing shared-context behavior across multiple reviewer threads.
+
 ## Relay Loop
 
 Use this repeatable operator loop for the rest of the session.
@@ -117,6 +121,8 @@ Use this repeatable operator loop for the rest of the session.
 ```text
 mepdmlist
 ```
+
+Capture one `mepdmlist` snapshot near the beginning of the run, then repeat this near the middle and end so the soak record shows how the thread evolved over time.
 
 2. When a reviewer sends a structured verdict, send a machine-readable response if needed:
 
@@ -141,6 +147,8 @@ mepdmreplysafe <cached_task_id_from_mepdmlist> 3 "Checkpoint follow-up: summariz
 ```text
 mepdmhumanapproval <cached_task_id_from_mepdmlist> "The relay stayed inside the guarded thread and the bots completed their review pass." --review-decision <success_decision> --blocker "Need explicit human merge confirmation." --next-action "Decide whether to proceed based on the final human review." --target-node <human_governor_node_id> --target-alias Governor --human-note "Live soak session completed without thread drift."
 ```
+
+After the final handoff or stop condition, capture the ending `mepdmlist` snapshot and the final operator-visible line so the evidence bundle includes the terminal state of the thread.
 
 ## What To Watch
 

--- a/docs/threaded-review/SOAK_RUNBOOK.md
+++ b/docs/threaded-review/SOAK_RUNBOOK.md
@@ -32,6 +32,18 @@ Use these defaults for a one-hour soak:
 
 These values are large enough for a real relay but small enough to prove checkpoint and stop behavior during the session.
 
+## Operator Inputs
+
+Before starting the session, choose these values for the specific soak you are running:
+
+- `<reviewer_node_id>`: the first reviewer bot that should receive the opening request
+- `<human_governor_node_id>`: the human decision maker if the session includes final approval
+- `<context_id>`: a fresh thread identifier for this soak run, for example `review-soak-20260525-01`
+- `<review_topic>`: the real subject under review, such as a PR, release candidate, incident plan, or design note
+- `<success_decision>`: the structured verdict you expect to hand to the governor if the relay succeeds
+
+Keep these values stable for the full session. Do not recycle an old `context_id`.
+
 ## Preflight
 
 1. Verify hub health:
@@ -59,13 +71,19 @@ python -m clients.adapters.mep_claude_code_adapter
 Use `mepdmx` to start the guarded thread from stdio:
 
 ```text
+mepdmx <reviewer_node_id> "Please review <review_topic>. Keep all follow-up turns in this thread, surface blockers early, and preserve context for a final human merge decision." --context <context_id> --turn-type review_request --intent review.request --priority high --max-turns 12 --max-duration-seconds 3600 --checkpoint-interval 3
+```
+
+Example:
+
+```text
 mepdmx node_reviewer_a "Please review PR 154. Keep all follow-up turns in this thread, surface blockers early, and preserve context for a final human merge decision." --context pr154-review-soak-001 --turn-type review_request --intent review.request --priority high --max-turns 12 --max-duration-seconds 3600 --checkpoint-interval 3
 ```
 
 Expected output:
 
 ```text
-[codex] sent threaded dm task task_review_request context=pr154-review-soak-001
+[codex] sent threaded dm task <task_id> context=<context_id>
 ```
 
 ## Relay Loop
@@ -81,25 +99,25 @@ mepdmlist
 2. When a reviewer sends a structured verdict, send a machine-readable response if needed:
 
 ```text
-mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document rollout timing." --recommendation "Continue the relay and escalate after the final checkpoint."
+mepdmverdict <cached_task_id_from_mepdmlist> approve_with_conditions "The thread is staying coherent and the current review state is actionable." --condition "Document the remaining rollout risks." --recommendation "Continue the relay and escalate after the next checkpoint."
 ```
 
 3. When the thread should continue within the same session, use bounded replies:
 
 ```text
-mepdmreplysafe task_review_request 2 "Continuing the review relay. Keep the next reply focused on blocking concerns." --turn-type review_response --intent review.response
+mepdmreplysafe <cached_task_id_from_mepdmlist> 2 "Continuing the review relay. Keep the next reply focused on blocking concerns." --turn-type review_response --intent review.response
 ```
 
 4. On the next bounded turn, keep using the cached inbound `task_id` shown by `mepdmlist`:
 
 ```text
-mepdmreplysafe task_review_request 3 "Checkpoint follow-up: summarize the top two remaining blockers before we escalate." --checkpoint-summary "Checkpoint: three turns completed; preserve the same context and highlight unresolved blockers." --turn-type review_response --intent review.response --human-note "Soak run checkpoint one."
+mepdmreplysafe <cached_task_id_from_mepdmlist> 3 "Checkpoint follow-up: summarize the top two remaining blockers before we escalate." --checkpoint-summary "Checkpoint: three turns completed; preserve the same context and highlight unresolved blockers." --turn-type review_response --intent review.response --human-note "Soak run checkpoint one."
 ```
 
 5. When bot review is complete and a human governor must decide, escalate in-thread:
 
 ```text
-mepdmhumanapproval task_review_request "Two bots approve with conditions and the relay stayed inside the guarded thread." --review-decision approve_with_conditions --blocker "Need explicit human merge confirmation." --next-action "Merge after the governor confirms release timing." --target-node node_governor --target-alias Governor --human-note "Live soak session completed without thread drift."
+mepdmhumanapproval <cached_task_id_from_mepdmlist> "The relay stayed inside the guarded thread and the bots completed their review pass." --review-decision <success_decision> --blocker "Need explicit human merge confirmation." --next-action "Decide whether to proceed based on the final human review." --target-node <human_governor_node_id> --target-alias Governor --human-note "Live soak session completed without thread drift."
 ```
 
 ## What To Watch


### PR DESCRIPTION
## Summary
- add a dedicated runbook for a real guarded multi-bot threaded review soak session
- link the runbook from the main operator-facing docs
- keep the slice operational and docs-only

## Validation
- checked diagnostics for README.md, OPERATOR_CHECKLIST.md, and docs/threaded-review/SOAK_RUNBOOK.md