### PR TITLE
feat: add mepdmlist thread filters

### DIFF
--- a/APPENDIX.md
+++ b/APPENDIX.md
@@ -263,7 +263,7 @@ Use these with Codex, Claude Code, OpenCode, OpenClaw, Telegram, Feishu, and WeC
 - `mep <task> [--bounty 5.0] [--model adapter-agent] [--target node_id]`
 - `mepdm <node_id> <message>`
 - `mepdmx <node_id> <message> [--context id] [--reply-task id] [--reply-message id] [--turn-type type] [--intent type] [--priority <level>] [--max-turns count] [--max-duration-seconds seconds] [--checkpoint-interval count]`
-- `mepdmlist`
+- `mepdmlist [--context id] [--limit count]`
 - `mepdmverdict <task_id> <verdict> <rationale> [--condition text] [--recommendation text] [--priority <level>] [--human-note text]`
 - `mepdmhumanapproval <task_id> <summary> [--decision-type type] [--review-decision verdict] [--blocker text] [--next-action text] [--priority <level>] [--target-node node_id] [--target-alias alias] [--human-note text]`
 - `mepdmreplysafe <task_id> <next_turn_index> <reply> [--checkpoint-summary text] [--turn-type type] [--intent type] [--priority <level>] [--human-note text]`
@@ -276,7 +276,7 @@ Use these with Codex, Claude Code, OpenCode, OpenClaw, Telegram, Feishu, and WeC
 Threaded review command notes:
 
 - `mepdmx` sends a structured DM with explicit thread metadata instead of a plain zero-bounty chat task. Use `--max-turns`, `--max-duration-seconds`, and `--checkpoint-interval` when the operator wants to start a guarded live relay or soak-test thread directly from stdio.
-- `mepdmlist` prints the recent stored structured DM cache so operators can find the right inbound `task_id`, `context_id`, `message_id`, sender, `turn_type`, and intent.
+- `mepdmlist` prints the recent stored structured DM cache so operators can find the right inbound `task_id`, `context_id`, `message_id`, sender, `turn_type`, and intent. Use `--context` to focus on one live thread and `--limit` to keep the output short during a busy soak.
 - `mepdmverdict` sends a machine-readable review decision back through the stored thread context without rebuilding reply metadata by hand. Use `--human-note` when the operator needs to preserve a small free-form note alongside the structured verdict.
 - `mepdmhumanapproval` escalates the same thread to a human decision maker with proposed review decision, blockers, next action, and an optional free-form `human_note`. Use `--target-node` when the final human governor is different from the sender of the cached inbound message. Use a cached inbound `task_id` from `mepdmlist`, not the task ID printed after sending `mepdmverdict`, unless that newer message later appears in the structured DM cache.
 - `mepdmreplysafe` reuses the stored inbound message and lets the runtime decide reply vs checkpoint vs stop under declared `session_safety` limits. Use `--human-note` when the operator needs to preserve a small free-form note alongside the bounded safe reply payload.
@@ -285,9 +285,11 @@ Threaded review command notes:
 Common threaded review fixes:
 
 - `no stored structured dm result for task ...`: run `mepdmlist` first and copy a real cached inbound `task_id` instead of guessing one from memory.
+- `no stored structured dm results for context=...`: the cache does not currently contain an inbound turn for that thread, so wait for the expected message or double-check the `context_id` before continuing.
 - `stored structured dm result ... is missing source.node_id` or `... conversation.context_id`: the cached message is incomplete, so do not continue the thread manually; wait for a valid structured inbound DM and preserve its original metadata.
 - `usage: mepdmx ...`, `usage: mepdmverdict ...`, `usage: mepdmhumanapproval ...`, or `usage: mepdmreplysafe ...`: a required positional argument is missing, usually the target `node_id`, cached `task_id`, rationale or summary text, or `next_turn_index`.
-- `unknown option --...`: use only the documented flags for that command. For `mepdmx`, the supported flags are `--context`, `--reply-task`, `--reply-message`, `--turn-type`, `--intent`, `--priority`, `--max-turns`, `--max-duration-seconds`, and `--checkpoint-interval`. For `mepdmverdict`, the supported flags are `--condition`, `--recommendation`, `--priority`, and `--human-note`. For `mepdmhumanapproval`, the supported flags are `--decision-type`, `--review-decision`, `--blocker`, `--next-action`, `--priority`, `--target-node`, `--target-alias`, and `--human-note`. For `mepdmreplysafe`, the supported flags are `--checkpoint-summary`, `--turn-type`, `--intent`, `--priority`, and `--human-note`.
+- `unknown option --...`: use only the documented flags for that command. For `mepdmlist`, the supported flags are `--context` and `--limit`. For `mepdmx`, the supported flags are `--context`, `--reply-task`, `--reply-message`, `--turn-type`, `--intent`, `--priority`, `--max-turns`, `--max-duration-seconds`, and `--checkpoint-interval`. For `mepdmverdict`, the supported flags are `--condition`, `--recommendation`, `--priority`, and `--human-note`. For `mepdmhumanapproval`, the supported flags are `--decision-type`, `--review-decision`, `--blocker`, `--next-action`, `--priority`, `--target-node`, `--target-alias`, and `--human-note`. For `mepdmreplysafe`, the supported flags are `--checkpoint-summary`, `--turn-type`, `--intent`, `--priority`, and `--human-note`.
+- `--limit must be an integer` or `--limit must be a positive integer`: pass a positive whole number such as `5` when you want to trim the list to the most recent matching entries.
 - `threaded dm error: ...`: use positive integers for `--max-turns`, `--max-duration-seconds`, and `--checkpoint-interval`, and provide at least one of them when you want `mepdmx` to attach `session_safety`.
 - `next_turn_index must be an integer`: pass a numeric next turn value such as `3`, not free text.
 - `review verdict error: ...`, `human approval request error: ...`, or `safe dm reply error: ...`: keep the original `context_id` and reply references from the cached inbound DM, and use a supported verdict or decision value before retrying.

--- a/OPERATOR_CHECKLIST.md
+++ b/OPERATOR_CHECKLIST.md
@@ -25,7 +25,7 @@ Use this checklist for daily operations, incident response, and safe upgrades.
 
 ## Threaded Review Workflow
 - Use `docs/threaded-review/SOAK_RUNBOOK.md` when you want the full one-hour guarded relay playbook instead of the short operator example below.
-- When a structured review request arrives, inspect it first with `mepdmlist`.
+- When a structured review request arrives, inspect it first with `mepdmlist`, and prefer `mepdmlist --context <context_id>` once a long-running review thread is active.
 - Use the listed `task_id`, `context_id`, and sender metadata to stay inside the same review thread.
 - When you start a long review thread from stdio, attach guardrails up front with `mepdmx ... --max-turns ... --max-duration-seconds ... --checkpoint-interval ...`.
 - Send a machine-readable bot verdict with:
@@ -44,8 +44,8 @@ Example operator flow:
 codex> mepdmx node_reviewer "Please review PR 154 and keep replies inside this thread." --context pr154-review --turn-type review_request --intent review.request --max-turns 12 --max-duration-seconds 3600 --checkpoint-interval 3
 [codex] sent threaded dm task task_review_request to node_reviewer context=pr154-review
 
-codex> mepdmlist
-[codex] recent structured dm results:
+codex> mepdmlist --context pr154-review
+[codex] recent structured dm results for context=pr154-review:
 [codex] - task_id=task_review_request context_id=pr154-review message_id=message_review_request source=node_reviewer turn_type=review_request intent=review.request
 
 codex> mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations." --recommendation "Merge after the docs note lands."

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ export WS_URL=ws://localhost:8000
 - **Direct-message a specific node:** `mepdm node_98eb3d301b2b hello`
 - **Send a threaded structured DM:** `mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request --max-turns 12 --max-duration-seconds 3600 --checkpoint-interval 3`
 - **List recent stored structured DMs:** `mepdmlist`
+- **Filter the structured DM cache to one live thread:** `mepdmlist --context pr154-review --limit 5`
 - **Request final human approval in-thread:** `mepdmhumanapproval task_review_request "Two bots approve with conditions and no blocker remains." --review-decision approve_with_conditions --target-node node_governor --target-alias Governor --human-note "Human asked for a final release-window check."`
 - **Send a structured review verdict DM:** `mepdmverdict task_review_request approve_with_conditions "Threading model is sound." --condition "Document reply expectations." --human-note "Human requested one extra release-timing check."`
 - **Safely reply to a stored structured DM:** `mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-type review_response --intent review.response --human-note "Human asked to preserve final release context."`
@@ -240,6 +241,7 @@ export WS_URL=ws://localhost:8000
 For multi-turn chat, send a fresh DM for each reply turn instead of depending on `/tasks/complete` result polling.
 Use `scripts/threaded_review_example.py` as a minimal example of a structured review flow with `context_id`, reply references, and checkpoint turns.
 Use `mepdmlist` to inspect the recent structured DM cache and find the right `task_id` before using `mepdmreplysafe`.
+Use `mepdmlist --context <context_id>` during a live relay or soak so operators do not accidentally act on an unrelated cached thread.
 Use `mepdmhumanapproval` when the bot discussion is finished and the operator wants to hand the thread off to a human governor with machine-readable blockers, proposed review decision, and recommended next action.
 Use `--target-node` with `mepdmhumanapproval` when the final human decision maker is different from the sender of the cached inbound thread message.
 Use `--human-note` with `mepdmhumanapproval` when the operator needs to preserve a small piece of free-form human context alongside the machine-readable approval payload.

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -44,13 +44,66 @@ class StdioAdapter:
             oldest_task_id = next(iter(self._recent_interbot_results))
             del self._recent_interbot_results[oldest_task_id]
 
-    def _list_recent_structured_dm_results(self) -> None:
-        if not self._recent_interbot_results:
+    def _list_recent_structured_dm_results(self, text: str = "") -> None:
+        try:
+            parts = shlex.split(text)
+        except ValueError as exc:
+            print(f"[{self.platform_name}] mepdmlist parse error: {exc}")
+            return
+
+        context_filter: Optional[str] = None
+        limit: Optional[int] = None
+        i = 0
+        while i < len(parts):
+            token = parts[i]
+            if token == "--context":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                context_filter = parts[i + 1]
+                i += 2
+                continue
+            if token == "--limit":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                try:
+                    limit = int(parts[i + 1])
+                except ValueError:
+                    print(f"[{self.platform_name}] --limit must be an integer")
+                    return
+                if limit <= 0:
+                    print(f"[{self.platform_name}] --limit must be a positive integer")
+                    return
+                i += 2
+                continue
+            print(f"[{self.platform_name}] unknown option {token}")
+            return
+
+        entries = list(reversed(list(self._recent_interbot_results.items())))
+        if context_filter is not None:
+            filtered_entries: list[tuple[str, dict[str, Any]]] = []
+            for task_id, inbound in entries:
+                message = inbound.get("message", {})
+                conversation = message.get("conversation") if isinstance(message, dict) else None
+                if isinstance(conversation, dict) and conversation.get("context_id") == context_filter:
+                    filtered_entries.append((task_id, inbound))
+            entries = filtered_entries
+        if limit is not None:
+            entries = entries[:limit]
+
+        if not entries:
+            if context_filter is not None:
+                print(f"[{self.platform_name}] no stored structured dm results for context={context_filter}")
+                return
             print(f"[{self.platform_name}] no stored structured dm results")
             return
 
-        print(f"[{self.platform_name}] recent structured dm results:")
-        for task_id, inbound in reversed(list(self._recent_interbot_results.items())):
+        header = f"[{self.platform_name}] recent structured dm results:"
+        if context_filter is not None:
+            header = f"[{self.platform_name}] recent structured dm results for context={context_filter}:"
+        print(header)
+        for task_id, inbound in entries:
             message = inbound.get("message", {})
             source = message.get("source") if isinstance(message, dict) else None
             conversation = message.get("conversation") if isinstance(message, dict) else None
@@ -593,6 +646,9 @@ class StdioAdapter:
             return True
         if text == "mepdmlist":
             self._list_recent_structured_dm_results()
+            return True
+        if text.startswith("mepdmlist "):
+            self._list_recent_structured_dm_results(text[10:])
             return True
         if text.startswith("mepdmhumanapproval "):
             await self._send_human_approval_request_dm(text[19:])

--- a/docs/threaded-review/SOAK_RUNBOOK.md
+++ b/docs/threaded-review/SOAK_RUNBOOK.md
@@ -116,13 +116,13 @@ If you want to include a second reviewer in the same soak, open that as a separa
 
 Use this repeatable operator loop for the rest of the session.
 
-1. Inspect the latest cached structured DM:
+1. Inspect the latest cached structured DM for the active soak thread:
 
 ```text
-mepdmlist
+mepdmlist --context <context_id> --limit 5
 ```
 
-Capture one `mepdmlist` snapshot near the beginning of the run, then repeat this near the middle and end so the soak record shows how the thread evolved over time.
+Capture one `mepdmlist --context <context_id>` snapshot near the beginning of the run, then repeat this near the middle and end so the soak record shows how the thread evolved over time without mixing in unrelated cached threads.
 
 2. When a reviewer sends a structured verdict, send a machine-readable response if needed:
 
@@ -155,7 +155,7 @@ After the final handoff or stop condition, capture the ending `mepdmlist` snapsh
 During the session, verify these invariants:
 
 - every turn stays on the same `context_id`
-- follow-up turns reuse cached inbound `task_id` values from `mepdmlist`
+- follow-up turns reuse cached inbound `task_id` values from `mepdmlist --context <context_id>`
 - no one invents new thread IDs or manual reply metadata
 - checkpoint turns appear at the declared cadence
 - safe replies print `safe reply task ...` or `safe checkpoint task ...`
@@ -166,7 +166,7 @@ During the session, verify these invariants:
 Save these artifacts during or immediately after the session:
 
 - the initial `mepdmx` command line and returned task/context IDs
-- one `mepdmlist` snapshot near the beginning, middle, and end of the run
+- one `mepdmlist --context <context_id>` snapshot near the beginning, middle, and end of the run
 - at least one `safe checkpoint task ...` line
 - the final `mepdmhumanapproval ...` line or the final `safe dm reply stopped ...` line
 - any operator-facing errors such as `unknown option ...` or `threaded dm error: ...`
@@ -183,7 +183,7 @@ Treat the soak as successful if:
 
 ## If Something Breaks
 
-- If `mepdmlist` does not show the expected inbound structured DM, stop and wait for a valid cached inbound turn before continuing.
+- If `mepdmlist --context <context_id>` does not show the expected inbound structured DM, stop and wait for a valid cached inbound turn before continuing.
 - If `unknown option --...` appears, fix the command line and resend the same intended action without inventing new thread metadata.
 - If `threaded dm error: ...` appears on `mepdmx`, correct the guard values and restart the session with a fresh `context_id`.
 - If `safe dm reply error: ...` appears, do not hand-build reply metadata; use the latest cached inbound task from `mepdmlist`.

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -302,6 +302,95 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             "turn_type=review_request intent=review.request"
         )
 
+    async def test_dispatch_line_dmlist_filters_by_context(self):
+        adapter, _client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "intent": {"type": "review.request"},
+            },
+        }
+        adapter._recent_interbot_results["task_other_context"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_other",
+                "source": {"node_id": "node_other"},
+                "conversation": {"context_id": "incident-42", "turn_type": "review_request"},
+                "intent": {"type": "review.request"},
+            },
+        }
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line("mepdmlist --context pr154-review")
+
+        self.assertTrue(keep_going)
+        print_mock.assert_any_call("[codex] recent structured dm results for context=pr154-review:")
+        print_mock.assert_any_call(
+            "[codex] - task_id=task_review_request context_id=pr154-review "
+            "message_id=message_review_request source=node_reviewer "
+            "turn_type=review_request intent=review.request"
+        )
+        self.assertNotIn(
+            unittest.mock.call(
+                "[codex] - task_id=task_other_context context_id=incident-42 "
+                "message_id=message_other source=node_other "
+                "turn_type=review_request intent=review.request"
+            ),
+            print_mock.mock_calls,
+        )
+
+    async def test_dispatch_line_dmlist_honors_limit(self):
+        adapter, _client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "intent": {"type": "review.request"},
+            },
+        }
+        adapter._recent_interbot_results["task_checkpoint"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_checkpoint",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "checkpoint"},
+                "intent": {"type": "coordination.request"},
+            },
+        }
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line("mepdmlist --limit 1")
+
+        self.assertTrue(keep_going)
+        print_mock.assert_any_call("[codex] recent structured dm results:")
+        print_mock.assert_any_call(
+            "[codex] - task_id=task_checkpoint context_id=pr154-review "
+            "message_id=message_checkpoint source=node_reviewer "
+            "turn_type=checkpoint intent=coordination.request"
+        )
+        self.assertNotIn(
+            unittest.mock.call(
+                "[codex] - task_id=task_review_request context_id=pr154-review "
+                "message_id=message_review_request source=node_reviewer "
+                "turn_type=review_request intent=review.request"
+            ),
+            print_mock.mock_calls,
+        )
+
+    async def test_dispatch_line_dmlist_rejects_unknown_option(self):
+        adapter, _client = self._make_adapter()
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line("mepdmlist --bogus nope")
+
+        self.assertTrue(keep_going)
+        print_mock.assert_any_call("[codex] unknown option --bogus")
+
     async def test_dispatch_line_review_verdict_uses_stored_inbound_message(self):
         adapter, client = self._make_adapter()
         adapter._recent_interbot_results["task_review_request"] = {


### PR DESCRIPTION
## Summary
- add `--context` and `--limit` support to `mepdmlist` so operators can focus on one live thread
- cover the new filtering and validation paths in `tests/test_stdio_adapter.py`
- update `README.md`, `APPENDIX.md`, `OPERATOR_CHECKLIST.md`, and the soak runbook to prefer `mepdmlist --context <context_id>` during live relay sessions

## Testing
- `python -m pytest tests/test_stdio_adapter.py`