### PR TITLE
ci: update workflow actions for node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
- update `actions/checkout` from `v4` to `v6`
- update `actions/setup-python` from `v5` to `v6`
- remove the Node 20 deprecation warning path from the CI workflow before GitHub flips runners to Node 24 by default

## Validation
- verified the workflow YAML is clean in the IDE diagnostics
- rely on the PR CI run to validate the updated action majors on both Ubuntu and Windows