### PR TITLE
feat: auto-advance safe reply turn index

### DIFF
--- a/APPENDIX.md
+++ b/APPENDIX.md
@@ -269,7 +269,9 @@ Use these with Codex, Claude Code, OpenCode, OpenClaw, Telegram, Feishu, and WeC
 - `mepdmhumanapproval <task_id> <summary> [--decision-type type] [--review-decision verdict] [--blocker text] [--next-action text] [--priority <level>] [--target-node node_id] [--target-alias alias] [--human-note text]`
 - `mepdmhumanapproval --context <context_id> <summary> [--decision-type type] [--review-decision verdict] [--blocker text] [--next-action text] [--priority <level>] [--target-node node_id] [--target-alias alias] [--human-note text]`
 - `mepdmreplysafe <task_id> <next_turn_index> <reply> [--checkpoint-summary text] [--turn-type type] [--intent type] [--priority <level>] [--human-note text]`
+- `mepdmreplysafe <task_id> auto <reply> [--checkpoint-summary text] [--turn-type type] [--intent type] [--priority <level>] [--human-note text]`
 - `mepdmreplysafe --context <context_id> <next_turn_index> <reply> [--checkpoint-summary text] [--turn-type type] [--intent type] [--priority <level>] [--human-note text]`
+- `mepdmreplysafe --context <context_id> auto <reply> [--checkpoint-summary text] [--turn-type type] [--intent type] [--priority <level>] [--human-note text]`
 - `mepdata <price> <payload>`
 - `mepcancel <task_id>`
 - `mepresult <task_id>`
@@ -282,7 +284,7 @@ Threaded review command notes:
 - `mepdmlist` prints the recent stored structured DM cache so operators can find the right inbound `task_id`, `context_id`, `message_id`, sender, `turn_type`, and intent. Use `--context` to focus on one live thread and `--limit` to keep the output short during a busy soak. Use `--json` when you need a machine-readable snapshot that can be saved directly as soak evidence.
 - `mepdmverdict` sends a machine-readable review decision back through the stored thread context without rebuilding reply metadata by hand. Use `--human-note` when the operator needs to preserve a small free-form note alongside the structured verdict. Use `--context` when you want the adapter to resolve the latest cached inbound turn for a thread automatically instead of copying a `task_id`.
 - `mepdmhumanapproval` escalates the same thread to a human decision maker with proposed review decision, blockers, next action, and an optional free-form `human_note`. Use `--target-node` when the final human governor is different from the sender of the cached inbound message. Use a cached inbound `task_id` from `mepdmlist` or `--context <context_id>` when you want the adapter to resolve the latest cached inbound turn automatically.
-- `mepdmreplysafe` reuses the stored inbound message and lets the runtime decide reply vs checkpoint vs stop under declared `session_safety` limits. Use `--human-note` when the operator needs to preserve a small free-form note alongside the bounded safe reply payload. Use `--context` when the operator knows the active thread and wants to avoid copying the latest cached inbound `task_id`.
+- `mepdmreplysafe` reuses the stored inbound message and lets the runtime decide reply vs checkpoint vs stop under declared `session_safety` limits. Use `--human-note` when the operator needs to preserve a small free-form note alongside the bounded safe reply payload. Use `--context` when the operator knows the active thread and wants to avoid copying the latest cached inbound `task_id`. Use `auto` when the cached inbound thread message already carries `conversation.turn_index` and you want the adapter to derive the next turn number for you.
 - Preferred operator flow for structured reviews: `mepdmlist` -> `mepdmverdict` -> `mepdmhumanapproval`, with `mepdmreplysafe` for any additional bounded turns.
 
 Common threaded review fixes:
@@ -295,6 +297,7 @@ Common threaded review fixes:
 - `--limit must be an integer` or `--limit must be a positive integer`: pass a positive whole number such as `5` when you want to trim the list to the most recent matching entries.
 - `threaded dm error: ...`: use positive integers for `--max-turns`, `--max-duration-seconds`, and `--checkpoint-interval`, and provide at least one of them when you want `mepdmx` to attach `session_safety`.
 - `next_turn_index must be an integer`: pass a numeric next turn value such as `3`, not free text.
+- `stored structured dm result ... is missing conversation.turn_index; pass an explicit next_turn_index`: the cached inbound message came from an older or external sender that does not emit turn indexes yet, so keep using an explicit numeric turn value for this thread.
 - `review verdict error: ...`, `human approval request error: ...`, or `safe dm reply error: ...`: keep the original `context_id` and reply references from the cached inbound DM, and use a supported verdict or decision value before retrying.
 
 ## Technical Architecture

--- a/OPERATOR_CHECKLIST.md
+++ b/OPERATOR_CHECKLIST.md
@@ -35,11 +35,13 @@ Use this checklist for daily operations, incident response, and safe upgrades.
 - If the thread should continue under declared session limits, reply with:
   - `mepdmreplysafe <task_id> <next_turn_index> <reply> [--checkpoint-summary ...] [--turn-type ...] [--intent ...] [--human-note ...]`
   - `mepdmreplysafe --context <context_id> <next_turn_index> <reply> [--checkpoint-summary ...] [--turn-type ...] [--intent ...] [--human-note ...]`
+  - `mepdmreplysafe --context <context_id> auto <reply> [--checkpoint-summary ...] [--turn-type ...] [--intent ...] [--human-note ...]`
 - When the bot review is complete and a human must decide, escalate with:
   - `mepdmhumanapproval <task_id> <summary> [--review-decision ...] [--blocker ...] [--next-action ...] [--target-node ...] [--target-alias ...] [--human-note ...]`
   - `mepdmhumanapproval --context <context_id> <summary> [--review-decision ...] [--blocker ...] [--next-action ...] [--target-node ...] [--target-alias ...] [--human-note ...]`
 - Prefer the in-thread sequence:
   - `mepdmlist` -> `mepdmverdict` -> `mepdmhumanapproval`
+- Prefer `mepdmreplysafe ... auto ...` once the thread was started by the current stdio flow, because those messages carry `conversation.turn_index` automatically.
 - Keep `target_node` as `node_id`, preserve `context_id`, and do not invent new thread IDs for follow-up turns.
 
 Example operator flow:

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ export WS_URL=ws://localhost:8000
 - **Export a machine-readable structured DM snapshot:** `mepdmlist --context <context_id> --limit 5 --json > soak-<context_id>-snapshot.json`
 - **Request final human approval in-thread:** `mepdmhumanapproval --context <context_id> "Two bots approve with conditions and no blocker remains." --review-decision approve_with_conditions --target-node <human_governor_node_id> --target-alias Governor --human-note "Human asked for a final release-window check."`
 - **Send a structured review verdict DM:** `mepdmverdict --context <context_id> approve_with_conditions "Threading model is sound." --condition "Document reply expectations." --human-note "Human requested one extra release-timing check."`
-- **Safely reply to a stored structured DM:** `mepdmreplysafe --context <context_id> 3 "I approve with conditions." --turn-type review_response --intent review.response --human-note "Human asked to preserve final release context."`
+- **Safely reply to a stored structured DM:** `mepdmreplysafe --context <context_id> auto "I approve with conditions." --turn-type review_response --intent review.response --human-note "Human asked to preserve final release context."`
 - **Start free bot-to-bot chat:** `mep Are you free to chat? --bounty 0.0 --target <node_id>`
 - **Check balance:** `mepbalance`
 
@@ -256,6 +256,7 @@ For long sessions, the shared client also supports sender-declared `session_safe
 When the receiver already has the inbound parsed message, `submit_safe_dm_reply(...)` can enforce those rules and choose reply vs checkpoint vs stop automatically.
 Use `--human-note` with `mepdmreplysafe` when the operator needs to attach a small free-form note to a bounded safe reply without changing its structured turn metadata.
 Use `--context <context_id>` with `mepdmverdict`, `mepdmhumanapproval`, or `mepdmreplysafe` when you want the adapter to reuse the latest cached inbound turn for that thread without manually copying its `task_id`.
+Use `mepdmreplysafe ... auto ...` when the cached inbound thread message already carries `conversation.turn_index`; the current stdio threaded-review flow emits that metadata automatically from `mepdmx` onward.
 
 </details>
 

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -149,9 +149,12 @@ class MEPClient:
         task_title: Optional[str] = None,
         task_inputs: Optional[dict[str, Any]] = None,
         session_safety: Optional[dict[str, Any]] = None,
+        turn_index: Optional[int] = None,
     ) -> dict[str, Any]:
         message_id = str(uuid.uuid4())
         timestamp_ms = int(time.time() * 1000)
+        if turn_index is not None and turn_index < 1:
+            raise ValueError("turn_index must be at least 1")
         task: dict[str, Any] = {
             "instructions": message,
             "expected_output": {"result_type": result_type},
@@ -181,6 +184,7 @@ class MEPClient:
                 "reply_to_task_id": reply_to_task_id,
                 "reply_to_message_id": reply_to_message_id,
                 "turn_type": turn_type,
+                **({"turn_index": turn_index} if turn_index is not None else {}),
             },
             "intent": {"type": intent_type, "priority": priority},
             "task": task,
@@ -203,6 +207,7 @@ class MEPClient:
         turn_type: str = "chat_turn",
         human_note: Optional[str] = None,
         session_safety: Optional[dict[str, Any]] = None,
+        turn_index: Optional[int] = None,
     ) -> dict:
         envelope = self.build_interbot_message(
             message,
@@ -216,6 +221,7 @@ class MEPClient:
             turn_type=turn_type,
             human_note=human_note,
             session_safety=session_safety,
+            turn_index=turn_index,
         )
         response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
         response["message_id"] = envelope["message_id"]
@@ -245,6 +251,7 @@ class MEPClient:
         )
         conversation = inbound_message.get("conversation")
         inbound_turn_type = conversation.get("turn_type") if isinstance(conversation, dict) else None
+        next_turn_index = self._derive_reply_turn_index(inbound_message)
         return self.build_interbot_message(
             reply_text,
             source["node_id"],
@@ -262,6 +269,7 @@ class MEPClient:
             human_note=human_note,
             trace_id=inbound_message.get("trace_id") if isinstance(inbound_message.get("trace_id"), str) else None,
             session_safety=self._extract_session_safety_from_message(inbound_message),
+            turn_index=next_turn_index,
         )
 
     async def submit_dm_reply(
@@ -342,6 +350,7 @@ class MEPClient:
                 priority=priority or "normal",
                 human_note=human_note,
                 session_safety=self._extract_session_safety_from_message(inbound_message),
+                turn_index=next_turn_index,
             )
             checkpoint_response["status"] = "checkpointed"
             checkpoint_response["reply_action"] = "checkpoint"
@@ -374,6 +383,7 @@ class MEPClient:
         priority: str = "normal",
         human_note: Optional[str] = None,
         session_safety: Optional[dict[str, Any]] = None,
+        turn_index: Optional[int] = None,
     ) -> dict[str, Any]:
         return self.build_interbot_message(
             summary,
@@ -387,6 +397,7 @@ class MEPClient:
             turn_type="checkpoint",
             human_note=human_note,
             session_safety=session_safety,
+            turn_index=turn_index,
         )
 
     async def submit_checkpoint_dm(
@@ -401,6 +412,7 @@ class MEPClient:
         priority: str = "normal",
         human_note: Optional[str] = None,
         session_safety: Optional[dict[str, Any]] = None,
+        turn_index: Optional[int] = None,
     ) -> dict:
         envelope = self.build_checkpoint_message(
             summary,
@@ -412,6 +424,7 @@ class MEPClient:
             priority=priority,
             human_note=human_note,
             session_safety=session_safety,
+            turn_index=turn_index,
         )
         response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
         response["message_id"] = envelope["message_id"]
@@ -433,6 +446,7 @@ class MEPClient:
         human_recommendation: Optional[str] = None,
         priority: str = "normal",
         human_note: Optional[str] = None,
+        turn_index: Optional[int] = None,
     ) -> dict[str, Any]:
         normalized_verdict = verdict.strip().lower()
         if normalized_verdict not in REVIEW_VERDICTS:
@@ -478,6 +492,7 @@ class MEPClient:
             human_note=human_note,
             task_title="Review verdict",
             task_inputs={"review_verdict": verdict_payload},
+            turn_index=turn_index,
         )
 
     async def submit_review_verdict_dm(
@@ -494,6 +509,7 @@ class MEPClient:
         human_recommendation: Optional[str] = None,
         priority: str = "normal",
         human_note: Optional[str] = None,
+        turn_index: Optional[int] = None,
     ) -> dict:
         envelope = self.build_review_verdict_message(
             verdict,
@@ -507,6 +523,7 @@ class MEPClient:
             human_recommendation=human_recommendation,
             priority=priority,
             human_note=human_note,
+            turn_index=turn_index,
         )
         response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
         response["message_id"] = envelope["message_id"]
@@ -529,6 +546,7 @@ class MEPClient:
         recommended_next_action: Optional[str] = None,
         priority: str = "high",
         human_note: Optional[str] = None,
+        turn_index: Optional[int] = None,
     ) -> dict[str, Any]:
         normalized_summary = summary.strip()
         if not normalized_summary:
@@ -582,6 +600,7 @@ class MEPClient:
             human_note=human_note,
             task_title="Human approval request",
             task_inputs={"human_approval_request": approval_payload},
+            turn_index=turn_index,
         )
 
     async def submit_human_approval_request_dm(
@@ -599,6 +618,7 @@ class MEPClient:
         recommended_next_action: Optional[str] = None,
         priority: str = "high",
         human_note: Optional[str] = None,
+        turn_index: Optional[int] = None,
     ) -> dict:
         envelope = self.build_human_approval_request_message(
             summary,
@@ -613,6 +633,7 @@ class MEPClient:
             recommended_next_action=recommended_next_action,
             priority=priority,
             human_note=human_note,
+            turn_index=turn_index,
         )
         response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
         response["message_id"] = envelope["message_id"]
@@ -866,6 +887,18 @@ class MEPClient:
         if inbound_turn_type == "review_request":
             return "review_response"
         return "chat_turn"
+
+    @staticmethod
+    def _derive_reply_turn_index(inbound_message: dict[str, Any]) -> Optional[int]:
+        conversation = inbound_message.get("conversation")
+        if not isinstance(conversation, dict):
+            return None
+        turn_index = conversation.get("turn_index")
+        if turn_index is None:
+            return None
+        if not isinstance(turn_index, int) or turn_index < 1:
+            raise ValueError("inbound inter-bot message has invalid conversation.turn_index")
+        return turn_index + 1
 
     @staticmethod
     def _normalize_string_list(values: Any) -> list[str]:

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -213,6 +213,26 @@ class StdioAdapter:
             return None
         return task_id, parts[2:]
 
+    def _derive_next_turn_index(self, task_id: str, message: dict[str, Any], *, require: bool = False) -> Optional[int]:
+        conversation = message.get("conversation") if isinstance(message, dict) else None
+        if not isinstance(conversation, dict):
+            if require:
+                print(f"[{self.platform_name}] stored structured dm result {task_id} is missing conversation")
+            return None
+        turn_index = conversation.get("turn_index")
+        if turn_index is None:
+            if require:
+                print(
+                    f"[{self.platform_name}] stored structured dm result {task_id} is missing conversation.turn_index; "
+                    "pass an explicit next_turn_index"
+                )
+            return None
+        if not isinstance(turn_index, int) or turn_index < 1:
+            if require:
+                print(f"[{self.platform_name}] stored structured dm result {task_id} has invalid conversation.turn_index")
+            return None
+        return turn_index + 1
+
     async def _submit(self, text: str) -> None:
         payload, bounty, model, target = parse_task_args(text, DEFAULT_BOUNTY, self.default_model)
         if not payload:
@@ -316,6 +336,7 @@ class StdioAdapter:
                 intent_type=options.get("--intent", "chat.request"),
                 priority=options.get("--priority", "normal"),
                 session_safety=session_safety,
+                turn_index=1,
             )
         except ValueError as exc:
             print(f"[{self.platform_name}] threaded dm error: {exc}")
@@ -338,7 +359,7 @@ class StdioAdapter:
         usage = (
             f"[{self.platform_name}] usage: mepdmreplysafe <task_id> <next_turn_index> <reply> "
             "[--checkpoint-summary text] [--turn-type type] [--intent type] [--priority <level>] [--human-note text] "
-            "or mepdmreplysafe --context <context_id> <next_turn_index> <reply> [options]"
+            "or mepdmreplysafe --context <context_id> <next_turn_index|auto> <reply> [options]"
         )
         resolved = self._resolve_stored_task_id_selector(parts, usage)
         if not resolved:
@@ -347,12 +368,6 @@ class StdioAdapter:
         if len(parts) < 2:
             print(usage)
             return
-        try:
-            next_turn_index = int(parts[0])
-        except ValueError:
-            print(f"[{self.platform_name}] next_turn_index must be an integer")
-            return
-
         options: dict[str, str] = {}
         reply_parts: list[str] = []
         allowed_options = {
@@ -387,6 +402,16 @@ class StdioAdapter:
         if not stored:
             return
         message, _source, _target_node, _context_id, _reply_to_message_id = stored
+        if parts[0] == "auto":
+            next_turn_index = self._derive_next_turn_index(task_id, message, require=True)
+            if next_turn_index is None:
+                return
+        else:
+            try:
+                next_turn_index = int(parts[0])
+            except ValueError:
+                print(f"[{self.platform_name}] next_turn_index must be an integer")
+                return
 
         try:
             response = await self.client.submit_safe_dm_reply(
@@ -530,25 +555,31 @@ class StdioAdapter:
         if not stored:
             return
         _message, source, cached_target_node, context_id, reply_to_message_id = stored
+        turn_index = self._derive_next_turn_index(task_id, _message)
         target_node = target_node_override or cached_target_node
         target_alias = target_alias_override
         if target_alias is None and not target_node_override and isinstance(source.get("alias"), str):
             target_alias = source.get("alias")
 
         try:
+            request_kwargs = {
+                "context_id": context_id,
+                "decision_type": decision_type,
+                "target_alias": target_alias,
+                "reply_to_task_id": task_id,
+                "reply_to_message_id": reply_to_message_id,
+                "review_decision": review_decision,
+                "blockers": blockers or None,
+                "recommended_next_action": next_action,
+                "priority": priority,
+                "human_note": human_note,
+            }
+            if turn_index is not None:
+                request_kwargs["turn_index"] = turn_index
             response = await self.client.submit_human_approval_request_dm(
                 summary,
                 target_node,
-                context_id=context_id,
-                decision_type=decision_type,
-                target_alias=target_alias,
-                reply_to_task_id=task_id,
-                reply_to_message_id=reply_to_message_id,
-                review_decision=review_decision,
-                blockers=blockers or None,
-                recommended_next_action=next_action,
-                priority=priority,
-                human_note=human_note,
+                **request_kwargs,
             )
         except ValueError as exc:
             print(f"[{self.platform_name}] human approval request error: {exc}")
@@ -635,20 +666,28 @@ class StdioAdapter:
         if not stored:
             return
         _message, source, target_node, context_id, reply_to_message_id = stored
+        turn_index = self._derive_next_turn_index(task_id, _message)
 
         try:
+            request_kwargs = {
+                "context_id": context_id,
+                "target_alias": source.get("alias")
+                if isinstance(source, dict) and isinstance(source.get("alias"), str)
+                else None,
+                "reply_to_task_id": task_id,
+                "reply_to_message_id": reply_to_message_id if isinstance(reply_to_message_id, str) else None,
+                "conditions": conditions or None,
+                "human_recommendation": recommendation,
+                "priority": priority,
+                "human_note": human_note,
+            }
+            if turn_index is not None:
+                request_kwargs["turn_index"] = turn_index
             response = await self.client.submit_review_verdict_dm(
                 verdict,
                 rationale,
                 target_node,
-                context_id=context_id,
-                target_alias=source.get("alias") if isinstance(source, dict) and isinstance(source.get("alias"), str) else None,
-                reply_to_task_id=task_id,
-                reply_to_message_id=reply_to_message_id if isinstance(reply_to_message_id, str) else None,
-                conditions=conditions or None,
-                human_recommendation=recommendation,
-                priority=priority,
-                human_note=human_note,
+                **request_kwargs,
             )
         except ValueError as exc:
             print(f"[{self.platform_name}] review verdict error: {exc}")

--- a/docs/threaded-review/SOAK_RUNBOOK.md
+++ b/docs/threaded-review/SOAK_RUNBOOK.md
@@ -138,13 +138,13 @@ mepdmverdict --context <context_id> approve_with_conditions "The thread is stayi
 3. When the thread should continue within the same session, use bounded replies:
 
 ```text
-mepdmreplysafe --context <context_id> 2 "Continuing the review relay. Keep the next reply focused on blocking concerns." --turn-type review_response --intent review.response
+mepdmreplysafe --context <context_id> auto "Continuing the review relay. Keep the next reply focused on blocking concerns." --turn-type review_response --intent review.response
 ```
 
 4. On the next bounded turn, keep using the same thread context:
 
 ```text
-mepdmreplysafe --context <context_id> 3 "Checkpoint follow-up: summarize the top two remaining blockers before we escalate." --checkpoint-summary "Checkpoint: three turns completed; preserve the same context and highlight unresolved blockers." --turn-type review_response --intent review.response --human-note "Soak run checkpoint one."
+mepdmreplysafe --context <context_id> auto "Checkpoint follow-up: summarize the top two remaining blockers before we escalate." --checkpoint-summary "Checkpoint: three turns completed; preserve the same context and highlight unresolved blockers." --turn-type review_response --intent review.response --human-note "Soak run checkpoint one."
 ```
 
 5. When bot review is complete and a human governor must decide, escalate in-thread:
@@ -153,7 +153,7 @@ mepdmreplysafe --context <context_id> 3 "Checkpoint follow-up: summarize the top
 mepdmhumanapproval --context <context_id> "The relay stayed inside the guarded thread and the bots completed their review pass." --review-decision <success_decision> --blocker "Need explicit human merge confirmation." --next-action "Decide whether to proceed based on the final human review." --target-node <human_governor_node_id> --target-alias Governor --human-note "Live soak session completed without thread drift."
 ```
 
-Use the cached `task_id` from `mepdmlist` when you want to target a specific stored inbound turn explicitly. Use `--context <context_id>` when you want the adapter to resolve the latest cached inbound turn for that thread automatically.
+Use the cached `task_id` from `mepdmlist` when you want to target a specific stored inbound turn explicitly. Use `--context <context_id>` when you want the adapter to resolve the latest cached inbound turn for that thread automatically. Use `auto` with `mepdmreplysafe` when that cached inbound turn already carries `conversation.turn_index`, which the current stdio threaded-review flow emits from the initial `mepdmx` onward.
 
 After the final handoff or stop condition, capture the ending `mepdmlist` snapshot and the final operator-visible line so the evidence bundle includes the terminal state of the thread.
 
@@ -163,6 +163,7 @@ During the session, verify these invariants:
 
 - every turn stays on the same `context_id`
 - follow-up turns reuse cached inbound `task_id` values from `mepdmlist --context <context_id>`
+- bounded replies keep advancing `conversation.turn_index` without manual turn math
 - no one invents new thread IDs or manual reply metadata
 - checkpoint turns appear at the declared cadence
 - safe replies print `safe reply task ...` or `safe checkpoint task ...`

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -114,6 +114,7 @@ class TestSharedMEPClient(unittest.TestCase):
                     reply_to_task_id="task_parent",
                     reply_to_message_id="message_parent",
                     turn_type="review_request",
+                    turn_index=1,
                 )
             )
 
@@ -126,6 +127,7 @@ class TestSharedMEPClient(unittest.TestCase):
         self.assertEqual(body["conversation"]["reply_to_task_id"], "task_parent")
         self.assertEqual(body["conversation"]["reply_to_message_id"], "message_parent")
         self.assertEqual(body["conversation"]["turn_type"], "review_request")
+        self.assertEqual(body["conversation"]["turn_index"], 1)
         self.assertEqual(body["intent"], {"type": "review.request", "priority": "normal"})
         self.assertEqual(body["task"]["instructions"], "Please review PR 154")
         self.assertEqual(body["delivery"], {"reply_mode": "new_dm", "settlement_mode": "task_result"})
@@ -196,6 +198,7 @@ class TestSharedMEPClient(unittest.TestCase):
                     reply_to_message_id="message_review_request",
                     conditions=["Document expected ack behavior", "Keep reply_mode=new_dm"],
                     human_recommendation="Merge after the follow-up docs note lands.",
+                    turn_index=2,
                 )
             )
 
@@ -203,6 +206,7 @@ class TestSharedMEPClient(unittest.TestCase):
         body = json.loads(submit_body["task"]["instructions"])
         self.assertEqual(body["intent"], {"type": "review.response", "priority": "normal"})
         self.assertEqual(body["conversation"]["turn_type"], "approval")
+        self.assertEqual(body["conversation"]["turn_index"], 2)
         self.assertEqual(body["conversation"]["context_id"], "pr154-review")
         self.assertEqual(body["conversation"]["reply_to_task_id"], "task_review_request")
         self.assertEqual(body["conversation"]["reply_to_message_id"], "message_review_request")
@@ -268,6 +272,7 @@ class TestSharedMEPClient(unittest.TestCase):
                     review_decision="approve_with_conditions",
                     blockers=["Need explicit merge confirmation from the human governor"],
                     recommended_next_action="Merge after human approval.",
+                    turn_index=3,
                 )
             )
 
@@ -275,6 +280,7 @@ class TestSharedMEPClient(unittest.TestCase):
         body = json.loads(submit_body["task"]["instructions"])
         self.assertEqual(body["intent"], {"type": "human.approval.request", "priority": "high"})
         self.assertEqual(body["conversation"]["turn_type"], "session_close")
+        self.assertEqual(body["conversation"]["turn_index"], 3)
         self.assertEqual(body["conversation"]["context_id"], "pr155-review")
         self.assertEqual(body["task"]["title"], "Human approval request")
         self.assertEqual(
@@ -337,7 +343,7 @@ class TestSharedMEPClient(unittest.TestCase):
                 "timestamp_ms": 1_777_000_000_000,
                 "source": {"node_id": "node_reviewer"},
                 "intent": {"type": "review.request", "priority": "high"},
-                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request", "turn_index": 1},
                 "task": {
                     "instructions": "Please review this PR.",
                     "inputs": {
@@ -366,6 +372,7 @@ class TestSharedMEPClient(unittest.TestCase):
         )
         self.assertEqual(body["conversation"]["reply_to_task_id"], "task_review_request")
         self.assertEqual(body["conversation"]["reply_to_message_id"], "message_review_request")
+        self.assertEqual(body["conversation"]["turn_index"], 2)
 
     def test_extract_session_safety_reads_structured_payload(self):
         payload = json.dumps(
@@ -486,7 +493,7 @@ class TestSharedMEPClient(unittest.TestCase):
                 "timestamp_ms": 1_777_000_000_000,
                 "source": {"node_id": "node_reviewer"},
                 "intent": {"type": "review.request", "priority": "high"},
-                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request", "turn_index": 1},
                 "task": {
                     "instructions": "Please review this PR.",
                     "inputs": {"session_safety": {"max_turns": 6, "checkpoint_interval": 3}},
@@ -509,6 +516,7 @@ class TestSharedMEPClient(unittest.TestCase):
         self.assertEqual(response["status"], "replied")
         self.assertFalse(response["safety"]["should_stop"])
         self.assertEqual(body["task"]["instructions"], "I approve with conditions.")
+        self.assertEqual(body["conversation"]["turn_index"], 2)
 
     def test_submit_safe_dm_reply_sends_checkpoint_when_interval_is_reached(self):
         with (
@@ -524,7 +532,7 @@ class TestSharedMEPClient(unittest.TestCase):
                 "timestamp_ms": 1_777_000_000_000,
                 "source": {"node_id": "node_reviewer", "alias": "Reviewer"},
                 "intent": {"type": "review.request", "priority": "high"},
-                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request", "turn_index": 2},
                 "task": {
                     "instructions": "Please review this PR.",
                     "inputs": {"session_safety": {"max_turns": 6, "checkpoint_interval": 3}},
@@ -548,6 +556,7 @@ class TestSharedMEPClient(unittest.TestCase):
         self.assertEqual(response["status"], "checkpointed")
         self.assertTrue(response["safety"]["should_checkpoint"])
         self.assertEqual(body["conversation"]["turn_type"], "checkpoint")
+        self.assertEqual(body["conversation"]["turn_index"], 3)
         self.assertEqual(body["task"]["instructions"], "Checkpoint: 3 turns reached.")
 
     def test_submit_safe_dm_reply_progresses_from_reply_to_checkpoint_to_stop(self):
@@ -568,7 +577,7 @@ class TestSharedMEPClient(unittest.TestCase):
                 "timestamp_ms": started_at_ms,
                 "source": {"node_id": "node_reviewer", "alias": "Reviewer"},
                 "intent": {"type": "review.request", "priority": "high"},
-                "conversation": {"context_id": "pr154-review", "turn_type": "review_request"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "review_request", "turn_index": 1},
                 "task": {
                     "instructions": "Please review this PR.",
                     "inputs": {
@@ -624,9 +633,11 @@ class TestSharedMEPClient(unittest.TestCase):
             reply_message["task"]["inputs"]["session_safety"]["started_at_ms"],
             started_at_ms,
         )
+        self.assertEqual(reply_message["conversation"]["turn_index"], 2)
         self.assertEqual(checkpoint_response["reply_action"], "checkpoint")
         self.assertEqual(checkpoint_response["status"], "checkpointed")
         self.assertEqual(checkpoint_message["conversation"]["turn_type"], "checkpoint")
+        self.assertEqual(checkpoint_message["conversation"]["turn_index"], 3)
         self.assertEqual(
             checkpoint_message["task"]["inputs"]["session_safety"]["started_at_ms"],
             started_at_ms,

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -84,6 +84,7 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
                 "checkpoint_interval": 3,
                 "started_at_ms": 1_777_000_000_000,
             },
+            turn_index=1,
         )
         print_mock.assert_any_call("[codex] sent threaded dm task task_threaded_dm to node_reviewer context=pr154-review")
 
@@ -654,6 +655,51 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
         )
         print_mock.assert_any_call("[codex] review verdict sent task task_review_verdict context=pr154-review")
 
+    async def test_dispatch_line_review_verdict_propagates_turn_index_when_available(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_request"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_request",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {
+                    "context_id": "pr154-review",
+                    "turn_type": "review_request",
+                    "turn_index": 1,
+                },
+                "task": {"instructions": "Please review this PR."},
+            },
+        }
+        client.submit_review_verdict_dm = AsyncMock(
+            return_value={
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_review_verdict"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmverdict task_review_request approve_with_conditions "Threading model is sound."'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_review_verdict_dm.assert_awaited_once_with(
+            "approve_with_conditions",
+            "Threading model is sound.",
+            "node_reviewer",
+            context_id="pr154-review",
+            target_alias=None,
+            reply_to_task_id="task_review_request",
+            reply_to_message_id="message_review_request",
+            conditions=None,
+            human_recommendation=None,
+            priority="normal",
+            human_note=None,
+            turn_index=2,
+        )
+        print_mock.assert_any_call("[codex] review verdict sent task task_review_verdict context=pr154-review")
+
     async def test_dispatch_line_review_verdict_reports_validation_errors(self):
         adapter, client = self._make_adapter()
         adapter._recent_interbot_results["task_review_request"] = {
@@ -772,6 +818,54 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             recommended_next_action=None,
             priority="high",
             human_note=None,
+        )
+        print_mock.assert_any_call(
+            "[codex] human approval request sent task task_human_approval context=pr154-review"
+        )
+
+    async def test_dispatch_line_human_approval_request_propagates_turn_index_when_available(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_review_verdict"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_review_verdict",
+                "source": {"node_id": "node_governor", "alias": "Governor"},
+                "conversation": {
+                    "context_id": "pr154-review",
+                    "turn_type": "approval",
+                    "turn_index": 2,
+                },
+                "task": {"instructions": "Review verdict ready."},
+            },
+        }
+        client.submit_human_approval_request_dm = AsyncMock(
+            return_value={
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_human_approval"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmhumanapproval task_review_verdict "Two bots approve with conditions."'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_human_approval_request_dm.assert_awaited_once_with(
+            "Two bots approve with conditions.",
+            "node_governor",
+            context_id="pr154-review",
+            decision_type="merge_decision",
+            target_alias="Governor",
+            reply_to_task_id="task_review_verdict",
+            reply_to_message_id="message_review_verdict",
+            review_decision=None,
+            blockers=None,
+            recommended_next_action=None,
+            priority="high",
+            human_note=None,
+            turn_index=3,
         )
         print_mock.assert_any_call(
             "[codex] human approval request sent task task_human_approval context=pr154-review"
@@ -1029,6 +1123,74 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
             human_note=None,
         )
         print_mock.assert_any_call("[codex] safe reply task task_followup context=pr154-review")
+
+    async def test_dispatch_line_safe_reply_accepts_auto_turn_index(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_checkpoint"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_checkpoint",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {
+                    "context_id": "pr154-review",
+                    "turn_type": "checkpoint",
+                    "turn_index": 3,
+                },
+                "task": {"instructions": "Checkpoint summary."},
+            },
+        }
+        client.submit_safe_dm_reply = AsyncMock(
+            return_value={
+                "reply_action": "reply",
+                "status_code": 200,
+                "json": {"status": "success", "task_id": "task_followup"},
+                "context_id": "pr154-review",
+            }
+        )
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmreplysafe task_checkpoint auto "I approve with conditions."'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_safe_dm_reply.assert_awaited_once_with(
+            "I approve with conditions.",
+            adapter._recent_interbot_results["task_checkpoint"]["message"],
+            next_turn_index=4,
+            checkpoint_summary=None,
+            inbound_task_id="task_checkpoint",
+            turn_type=None,
+            intent_type=None,
+            priority=None,
+            human_note=None,
+        )
+        print_mock.assert_any_call("[codex] safe reply task task_followup context=pr154-review")
+
+    async def test_dispatch_line_safe_reply_auto_turn_requires_turn_index(self):
+        adapter, client = self._make_adapter()
+        adapter._recent_interbot_results["task_checkpoint"] = {
+            "payload_text": "{}",
+            "message": {
+                "message_id": "message_checkpoint",
+                "source": {"node_id": "node_reviewer"},
+                "conversation": {"context_id": "pr154-review", "turn_type": "checkpoint"},
+                "task": {"instructions": "Checkpoint summary."},
+            },
+        }
+        client.submit_safe_dm_reply = AsyncMock()
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                'mepdmreplysafe task_checkpoint auto "I approve with conditions."'
+            )
+
+        self.assertTrue(keep_going)
+        client.submit_safe_dm_reply.assert_not_awaited()
+        print_mock.assert_any_call(
+            "[codex] stored structured dm result task_checkpoint is missing conversation.turn_index; "
+            "pass an explicit next_turn_index"
+        )
 
     async def test_dispatch_line_safe_reply_reports_missing_context_selector(self):
         adapter, client = self._make_adapter()


### PR DESCRIPTION
## Summary
- add `conversation.turn_index` to the structured threaded-review flow and propagate it on follow-up messages
- let `mepdmreplysafe` accept `auto` so the adapter can derive the next turn number from the cached inbound message
- document the lower-burden path in the operator docs and soak runbook

## Validation
- `python -m pytest tests/test_stdio_adapter.py tests/test_shared_mep_client.py`