### PR TITLE
fix(runtime): canonicalize local identity keys by node id

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -22,6 +22,8 @@ except ImportError:  # pragma: no cover - supports direct file execution
 
 DEFAULT_HUB_URL = os.getenv("HUB_URL", "http://localhost:8000")
 DEFAULT_WS_URL = os.getenv("WS_URL", "ws://localhost:8000")
+DEFAULT_RUNTIME_ALIAS = "mep-runtime"
+LEGACY_RUNTIME_KEY_NAME = "mep_runtime.pem"
 
 
 def _find_git_root(start_path: Optional[str] = None) -> Optional[str]:
@@ -50,11 +52,52 @@ def _default_key_path() -> str:
     explicit = os.getenv("MEP_PROVIDER_KEY_PATH")
     if explicit:
         return explicit
-    return os.path.join(_default_key_dir(), "mep_runtime.pem")
+    return os.path.join(_default_key_dir(), LEGACY_RUNTIME_KEY_NAME)
 
 
 def _ensure_key_parent(path: str) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
+
+
+def _same_path(left: str, right: str) -> bool:
+    return os.path.normcase(os.path.abspath(left)) == os.path.normcase(os.path.abspath(right))
+
+
+def _canonical_key_path(key_dir: str, node_id: str) -> str:
+    return os.path.join(key_dir, f"{node_id}.pem")
+
+
+def _enc_key_path(key_path: str) -> str:
+    return key_path.replace(".pem", "_enc.pem")
+
+
+def _pending_key_path(key_dir: str) -> str:
+    return os.path.join(key_dir, f".pending-runtime-{os.getpid()}-{int(time.time() * 1000)}.pem")
+
+
+def _is_identity_key_file(filename: str) -> bool:
+    return (
+        filename.endswith(".pem")
+        and not filename.endswith("_enc.pem")
+        and not filename.startswith(".pending-runtime-")
+    )
+
+
+def _list_local_identity_key_paths(key_dir: str) -> list[str]:
+    if not os.path.isdir(key_dir):
+        return []
+    return [
+        os.path.join(key_dir, name)
+        for name in sorted(os.listdir(key_dir))
+        if _is_identity_key_file(name) and os.path.isfile(os.path.join(key_dir, name))
+    ]
+
+
+def _move_file_if_present(source: str, destination: str) -> None:
+    if _same_path(source, destination) or not os.path.exists(source):
+        return
+    _ensure_key_parent(destination)
+    os.replace(source, destination)
 
 
 def _alias_sidecar_path(key_path: str) -> str:
@@ -81,7 +124,74 @@ def _resolve_runtime_alias(key_path: str, cli_alias: Optional[str]) -> str:
     persisted = _read_alias_sidecar(key_path)
     if persisted:
         return persisted
-    return "mep-runtime"
+    return DEFAULT_RUNTIME_ALIAS
+
+
+class RuntimeKeyPathError(ValueError):
+    """Raised when runtime identity selection is ambiguous or missing."""
+
+
+def _canonicalize_local_identity(key_path: str, key_dir: str) -> str:
+    identity = MEPIdentity(key_path)
+    canonical_path = _canonical_key_path(key_dir, identity.node_id)
+    if _same_path(key_path, canonical_path):
+        return canonical_path
+
+    _move_file_if_present(key_path, canonical_path)
+    _move_file_if_present(_enc_key_path(key_path), _enc_key_path(canonical_path))
+
+    source_alias = _alias_sidecar_path(key_path)
+    dest_alias = _alias_sidecar_path(canonical_path)
+    if os.path.exists(source_alias) and not os.path.exists(dest_alias):
+        _move_file_if_present(source_alias, dest_alias)
+
+    return canonical_path
+
+
+def _choose_existing_local_identity(key_dir: str, cli_alias: Optional[str]) -> Optional[str]:
+    candidates = _list_local_identity_key_paths(key_dir)
+    if not candidates:
+        return None
+
+    if cli_alias:
+        matching = [path for path in candidates if _read_alias_sidecar(path) == cli_alias]
+        if len(matching) == 1:
+            return _canonicalize_local_identity(matching[0], key_dir)
+        if len(matching) > 1:
+            raise RuntimeKeyPathError(
+                f"multiple local identities in {key_dir} use alias={cli_alias!r}; pass --key-path explicitly"
+            )
+
+    if len(candidates) == 1:
+        return _canonicalize_local_identity(candidates[0], key_dir)
+
+    raise RuntimeKeyPathError(
+        f"multiple local identities found in {key_dir}; pass --key-path or --alias for an existing node"
+    )
+
+
+def _create_new_local_identity(key_dir: str) -> str:
+    os.makedirs(key_dir, exist_ok=True)
+    pending_path = _pending_key_path(key_dir)
+    return _canonicalize_local_identity(pending_path, key_dir)
+
+
+def _resolve_default_runtime_key_path(command: str, cli_alias: Optional[str]) -> str:
+    explicit = os.getenv("MEP_PROVIDER_KEY_PATH")
+    if explicit:
+        return explicit
+
+    key_dir = _default_key_dir()
+    chosen = _choose_existing_local_identity(key_dir, cli_alias)
+    if chosen:
+        return chosen
+
+    if command in {"init", "up"}:
+        return _create_new_local_identity(key_dir)
+
+    raise RuntimeKeyPathError(
+        f"no local identity found in {key_dir}; run `init`/`up` first or pass --key-path explicitly"
+    )
 
 
 def _json_or_none(resp: requests.Response) -> Optional[dict[str, Any]]:
@@ -491,18 +601,18 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--key-path",
         default=None,
-        help="Path to provider private key (defaults to repo-local .mep/mep_runtime.pem).",
+        help="Path to provider private key (defaults to repo-local .mep/{node_id}.pem after discovery/provisioning).",
     )
     parser.add_argument("--adapter", default="mock", choices=["mock"], help="Provider adapter.")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
     init_p = sub.add_parser("init", help="Generate/load key and register node.")
-    init_p.add_argument("--alias", default="mep-runtime", help="Node alias for registration.")
+    init_p.add_argument("--alias", default=DEFAULT_RUNTIME_ALIAS, help="Node alias for registration.")
     init_p.set_defaults(func=cmd_init)
 
     up_p = sub.add_parser("up", help="One-command bootstrap: init + doctor + run.")
-    up_p.add_argument("--alias", default="mep-runtime", help="Node alias for registration.")
+    up_p.add_argument("--alias", default=DEFAULT_RUNTIME_ALIAS, help="Node alias for registration.")
     up_p.set_defaults(func=cmd_up)
 
     run_p = sub.add_parser("run", help="Run standardized listener runtime.")
@@ -538,7 +648,14 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     if getattr(args, "key_path", None) is None:
-        args.key_path = _default_key_path()
+        try:
+            args.key_path = _resolve_default_runtime_key_path(
+                command=str(getattr(args, "command", "") or ""),
+                cli_alias=getattr(args, "alias", None),
+            )
+        except RuntimeKeyPathError as exc:
+            print(f"[mep {args.command}] {exc}")
+            return 2
     return int(args.func(args))
 
 

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -22,7 +22,6 @@ except ImportError:  # pragma: no cover - supports direct file execution
 
 DEFAULT_HUB_URL = os.getenv("HUB_URL", "http://localhost:8000")
 DEFAULT_WS_URL = os.getenv("WS_URL", "ws://localhost:8000")
-DEFAULT_RUNTIME_ALIAS = "mep-runtime"
 LEGACY_RUNTIME_KEY_NAME = "mep_runtime.pem"
 
 
@@ -118,13 +117,13 @@ def _read_alias_sidecar(key_path: str) -> Optional[str]:
     return alias or None
 
 
-def _resolve_runtime_alias(key_path: str, cli_alias: Optional[str]) -> str:
+def _resolve_runtime_alias(key_path: str, cli_alias: Optional[str], *, node_id: str) -> str:
     if cli_alias:
         return cli_alias
     persisted = _read_alias_sidecar(key_path)
     if persisted:
         return persisted
-    return DEFAULT_RUNTIME_ALIAS
+    return node_id
 
 
 class RuntimeKeyPathError(ValueError):
@@ -461,19 +460,20 @@ def _print_listener_hint(args: argparse.Namespace) -> None:
 def cmd_init(args: argparse.Namespace) -> int:
     _ensure_key_parent(args.key_path)
     identity = MEPIdentity(args.key_path)
+    alias = _resolve_runtime_alias(args.key_path, args.alias, node_id=identity.node_id)
     print(f"[mep init] node_id={identity.node_id}")
     if identity.generated_new_key:
         print(f"[mep init] generated key={identity.key_path}")
     payload = {
         "pubkey": identity.pub_pem,
-        "alias": args.alias,
+        "alias": alias,
         "x25519_public_key": identity.x25519_public_key,
     }
     code, body, raw = _safe_request("POST", f"{args.hub_url.rstrip('/')}/register", json_body=payload)
     if code != 200:
         print(f"[mep init] register failed status={code} detail={raw}")
         return 2
-    _write_alias_sidecar(args.key_path, args.alias)
+    _write_alias_sidecar(args.key_path, alias)
     print(f"[mep init] register ok balance={body.get('balance') if body else '?'}")
     status_args = argparse.Namespace(
         hub_url=args.hub_url,
@@ -549,7 +549,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         return 2
     _ensure_key_parent(args.key_path)
     identity = MEPIdentity(args.key_path)
-    alias = _resolve_runtime_alias(args.key_path, args.alias)
+    alias = _resolve_runtime_alias(args.key_path, args.alias, node_id=identity.node_id)
     runtime = RuntimeNode(
         identity=identity,
         hub_url=args.hub_url,
@@ -608,15 +608,15 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     init_p = sub.add_parser("init", help="Generate/load key and register node.")
-    init_p.add_argument("--alias", default=DEFAULT_RUNTIME_ALIAS, help="Node alias for registration.")
+    init_p.add_argument("--alias", default=None, help="Node alias for registration; defaults to the node_id if no persisted alias exists.")
     init_p.set_defaults(func=cmd_init)
 
     up_p = sub.add_parser("up", help="One-command bootstrap: init + doctor + run.")
-    up_p.add_argument("--alias", default=DEFAULT_RUNTIME_ALIAS, help="Node alias for registration.")
+    up_p.add_argument("--alias", default=None, help="Node alias for registration; defaults to the node_id if no persisted alias exists.")
     up_p.set_defaults(func=cmd_up)
 
     run_p = sub.add_parser("run", help="Run standardized listener runtime.")
-    run_p.add_argument("--alias", default=None, help="Node alias for registration; defaults to persisted alias if present.")
+    run_p.add_argument("--alias", default=None, help="Node alias for registration; defaults to persisted alias or node_id if none exists.")
     run_p.set_defaults(func=cmd_run)
 
     status_p = sub.add_parser("status", help="Show quick node readiness badges.")

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+from node.identity import MEPIdentity
 from node import mep_runtime
 
 
@@ -183,7 +184,7 @@ class TestRuntimeUx(unittest.TestCase):
             patch("node.mep_runtime.MEPIdentity", return_value=_FakeIdentity()),
             patch("node.mep_runtime._resolve_runtime_alias", return_value="persisted-alias") as resolve_alias_mock,
             patch("node.mep_runtime.RuntimeNode", return_value=fake_runtime) as runtime_cls,
-            patch("node.mep_runtime.asyncio.run", return_value=0),
+            patch("node.mep_runtime.asyncio.run", side_effect=lambda coro: (coro.close(), 0)[1]),
         ):
             code = mep_runtime.cmd_run(args)
         self.assertEqual(code, 0)
@@ -259,6 +260,64 @@ class TestRuntimeKeyDirResolution(unittest.TestCase):
                 mep_runtime.main(["status"])
         args = status_mock.call_args.args[0]
         self.assertEqual(args.key_path, "/lazy/key.pem")
+
+    def test_create_new_local_identity_uses_node_id_canonical_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            key_path = mep_runtime._create_new_local_identity(tmpdir)  # noqa: SLF001
+            identity = MEPIdentity(key_path)
+            self.assertEqual(os.path.basename(key_path), f"{identity.node_id}.pem")
+            self.assertTrue(os.path.exists(key_path))
+            self.assertTrue(os.path.exists(key_path.replace(".pem", "_enc.pem")))
+
+    def test_choose_existing_local_identity_migrates_legacy_runtime_filename(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            legacy_path = os.path.join(tmpdir, "mep_runtime.pem")
+            identity = MEPIdentity(legacy_path)
+            mep_runtime._write_alias_sidecar(legacy_path, "legacy-node")  # noqa: SLF001
+
+            selected = mep_runtime._choose_existing_local_identity(tmpdir, None)  # noqa: SLF001
+
+            canonical_path = os.path.join(tmpdir, f"{identity.node_id}.pem")
+            self.assertEqual(selected, canonical_path)
+            self.assertTrue(os.path.exists(canonical_path))
+            self.assertFalse(os.path.exists(legacy_path))
+            self.assertEqual(mep_runtime._read_alias_sidecar(canonical_path), "legacy-node")  # noqa: SLF001
+
+    def test_choose_existing_local_identity_uses_alias_to_disambiguate(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            alpha = os.path.join(tmpdir, "alpha.pem")
+            beta = os.path.join(tmpdir, "beta.pem")
+            beta_id = MEPIdentity(beta)
+            MEPIdentity(alpha)
+            mep_runtime._write_alias_sidecar(alpha, "alpha-bot")  # noqa: SLF001
+            mep_runtime._write_alias_sidecar(beta, "beta-bot")  # noqa: SLF001
+
+            selected = mep_runtime._choose_existing_local_identity(tmpdir, "beta-bot")  # noqa: SLF001
+
+            self.assertEqual(selected, os.path.join(tmpdir, f"{beta_id.node_id}.pem"))
+            self.assertTrue(os.path.exists(alpha))
+            self.assertTrue(os.path.exists(os.path.join(tmpdir, f"{beta_id.node_id}.pem")))
+
+    def test_choose_existing_local_identity_rejects_ambiguous_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            MEPIdentity(os.path.join(tmpdir, "alpha.pem"))
+            MEPIdentity(os.path.join(tmpdir, "beta.pem"))
+
+            with self.assertRaises(mep_runtime.RuntimeKeyPathError):
+                mep_runtime._choose_existing_local_identity(tmpdir, None)  # noqa: SLF001
+
+    def test_main_rejects_run_without_key_when_identity_selection_is_ambiguous(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(mep_runtime, "_default_key_dir", return_value=tmpdir):
+                MEPIdentity(os.path.join(tmpdir, "alpha.pem"))
+                MEPIdentity(os.path.join(tmpdir, "beta.pem"))
+
+                with patch("builtins.print") as print_mock:
+                    code = mep_runtime.main(["run"])
+
+            self.assertEqual(code, 2)
+            printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list if call.args)
+            self.assertIn("multiple local identities found", printed)
 
 
 if __name__ == "__main__":

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -114,10 +114,10 @@ class TestRuntimeUx(unittest.TestCase):
             key_path = os.path.join(tmpdir, "runtime.pem")
             mep_runtime._write_alias_sidecar(key_path, "persisted-alias")  # noqa: SLF001
 
-            self.assertEqual(mep_runtime._resolve_runtime_alias(key_path, "cli-alias"), "cli-alias")  # noqa: SLF001
-            self.assertEqual(mep_runtime._resolve_runtime_alias(key_path, None), "persisted-alias")  # noqa: SLF001
+            self.assertEqual(mep_runtime._resolve_runtime_alias(key_path, "cli-alias", node_id="node_fallback"), "cli-alias")  # noqa: SLF001
+            self.assertEqual(mep_runtime._resolve_runtime_alias(key_path, None, node_id="node_fallback"), "persisted-alias")  # noqa: SLF001
             os.remove(mep_runtime._alias_sidecar_path(key_path))  # noqa: SLF001
-            self.assertEqual(mep_runtime._resolve_runtime_alias(key_path, None), "mep-runtime")  # noqa: SLF001
+            self.assertEqual(mep_runtime._resolve_runtime_alias(key_path, None, node_id="node_fallback"), "node_fallback")  # noqa: SLF001
 
     def test_init_persists_alias_sidecar(self):
         args = argparse.Namespace(
@@ -140,6 +140,29 @@ class TestRuntimeUx(unittest.TestCase):
             code = mep_runtime.cmd_init(args)
         self.assertEqual(code, 0)
         write_alias_mock.assert_called_once_with(args.key_path, "fresh-node")
+
+    def test_init_defaults_alias_to_node_id_when_none_is_provided(self):
+        args = argparse.Namespace(
+            hub_url="http://hub",
+            ws_url="ws://hub",
+            key_path="C:/tmp/test_key.pem",
+            adapter="mock",
+            alias=None,
+        )
+        fake_identity = _FakeIdentity()
+        fake_identity.generated_new_key = False
+        fake_identity.key_path = args.key_path
+        with (
+            patch("node.mep_runtime._ensure_key_parent"),
+            patch("node.mep_runtime.MEPIdentity", return_value=fake_identity),
+            patch("node.mep_runtime._safe_request", return_value=(200, {"balance": 10.0}, "")) as request_mock,
+            patch("node.mep_runtime._write_alias_sidecar") as write_alias_mock,
+            patch("node.mep_runtime.cmd_status", return_value=0),
+        ):
+            code = mep_runtime.cmd_init(args)
+        self.assertEqual(code, 0)
+        self.assertEqual(request_mock.call_args.kwargs["json_body"]["alias"], "node_runtime")
+        write_alias_mock.assert_called_once_with(args.key_path, "node_runtime")
 
     def test_up_runs_even_if_doctor_fails(self):
         args = argparse.Namespace(
@@ -188,7 +211,7 @@ class TestRuntimeUx(unittest.TestCase):
         ):
             code = mep_runtime.cmd_run(args)
         self.assertEqual(code, 0)
-        resolve_alias_mock.assert_called_once_with(args.key_path, None)
+        resolve_alias_mock.assert_called_once_with(args.key_path, None, node_id="node_runtime")
         self.assertEqual(runtime_cls.call_args.kwargs["alias"], "persisted-alias")
 
 


### PR DESCRIPTION
## Summary
- canonicalize runtime-managed local identity keys to repo-local `.mep/{node_id}.pem`
- migrate discovered legacy local runtime keys into canonical node-id naming without changing identity
- fail closed when multiple local identities exist and no unique selection is possible
- default unnamed runtime aliases to `node_id` instead of `mep-runtime`

## Validation
- focused runtime identity tests passed locally with Python 3.11
- `python -m unittest discover -s tests -p test_node_runtime.py -q`
