### PR TITLE
fix(runtime): reject alias mismatch for single local identity

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -160,6 +160,10 @@ def _choose_existing_local_identity(key_dir: str, cli_alias: Optional[str]) -> O
             raise RuntimeKeyPathError(
                 f"multiple local identities in {key_dir} use alias={cli_alias!r}; pass --key-path explicitly"
             )
+        if len(candidates) == 1:
+            raise RuntimeKeyPathError(
+                f"no local identity in {key_dir} matches alias={cli_alias!r}; pass --key-path explicitly"
+            )
 
     if len(candidates) == 1:
         return _canonicalize_local_identity(candidates[0], key_dir)

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -329,6 +329,15 @@ class TestRuntimeKeyDirResolution(unittest.TestCase):
             with self.assertRaises(mep_runtime.RuntimeKeyPathError):
                 mep_runtime._choose_existing_local_identity(tmpdir, None)  # noqa: SLF001
 
+    def test_choose_existing_local_identity_rejects_single_alias_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            only_key = os.path.join(tmpdir, "only.pem")
+            MEPIdentity(only_key)
+            mep_runtime._write_alias_sidecar(only_key, "alpha-bot")  # noqa: SLF001
+
+            with self.assertRaisesRegex(mep_runtime.RuntimeKeyPathError, "matches alias"):
+                mep_runtime._choose_existing_local_identity(tmpdir, "beta-bot")  # noqa: SLF001
+
     def test_main_rejects_run_without_key_when_identity_selection_is_ambiguous(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch.object(mep_runtime, "_default_key_dir", return_value=tmpdir):


### PR DESCRIPTION
## Summary
- reject explicit `--alias` mismatches when only one local identity exists
- preserve the fail-closed identity selection model introduced in Slice 2
- add a focused regression test for the single-key alias mismatch case

## Validation
- `python -m unittest discover -s tests -p test_node_runtime.py -q`
