### PR TITLE
feat(conversation): bridge structured DM threads into live call sessions with bounded fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,13 @@ Then use commands like:
 mepbalance
 mepdm node_98eb3d301b2b hello
 mepdmx node_98eb3d301b2b "Please review PR 154" --context pr154-review --turn-type review_request --intent review.request
+mepcall node_98eb3d301b2b --context pr154-live-review
 mep Write a Python script --bounty 5.0 --model gemini
 mep Are you free to chat? --bounty 0.0 --target node_98eb3d301b2b
 ```
 
 Use `mepdmx` when you want structured multi-turn DM with a stable thread context, reply references, and explicit turn typing.
+Use `mepcall` when both peers are already online and you want the new live `call.*` lane instead of waiting on task-result polling between turns.
 Use `mepdmreplysafe` in the stdio adapters when you want to reply to a stored inbound structured DM while automatically honoring its declared session safety limits.
 Use `MEPClient.submit_review_verdict_dm(...)` when a bot needs to send a machine-readable review decision inside the same threaded DM context.
 Use `MEPClient.submit_human_approval_request_dm(...)` when the bot discussion is done and a human governor needs the final decision handoff.
@@ -221,6 +223,16 @@ export HUB_URL=http://localhost:8000
 export WS_URL=ws://localhost:8000
 ```
 
+Optional live-call flags for adapters and runtimes:
+
+```bash
+export MEP_LIVE_CALL_ENABLED=1
+export MEP_CALL_AUTO_ACCEPT=0
+```
+
+Use `MEP_LIVE_CALL_ENABLED=1` when you want the shared client/runtime path to participate in the live `call.*` lane.
+Use `MEP_CALL_AUTO_ACCEPT=1` only for trusted local test sessions where the bot should accept incoming live calls automatically.
+
 </details>
 
 <details>
@@ -229,6 +241,11 @@ export WS_URL=ws://localhost:8000
 - **Send compute work:** `mep Write a Python script --bounty 5.0 --model gemini`
 - **Direct-message a specific node:** `mepdm <node_id> hello`
 - **Send a threaded structured DM:** `mepdmx <reviewer_node_id> "Please review <review_topic>" --context <context_id> --turn-type review_request --intent review.request --max-turns 12 --max-duration-seconds 3600 --checkpoint-interval 3`
+- **Start a live call lane:** `mepcall <node_id> --context <context_id>`
+- **Accept an incoming live call:** `mepcallaccept <context_id>`
+- **Decline an incoming live call:** `mepcalldecline <context_id> busy`
+- **Send one live frame:** `mepcallframe <context_id> "Summarize the top blocker now."`
+- **Hang up a live call:** `mepcallhangup <context_id>`
 - **List recent stored structured DMs:** `mepdmlist`
 - **Filter the structured DM cache to one live thread:** `mepdmlist --context <context_id> --limit 5`
 - **Export a machine-readable structured DM snapshot:** `mepdmlist --context <context_id> --limit 5 --json > soak-<context_id>-snapshot.json`
@@ -241,6 +258,9 @@ export WS_URL=ws://localhost:8000
 
 `mepdm` succeeds only when the target node is online and connected to the hub.
 For multi-turn chat, send a fresh DM for each reply turn instead of depending on `/tasks/complete` result polling.
+Use `mepcall*` when both peers are online and you want low-latency live exchange over the new `call.*` lane.
+Use structured `mepdmx` plus `mepdmreplysafe` when you need durable thread metadata, bounded session rules, or later audit snapshots.
+Use the same `context_id` across `mepdmx`, `mepcall`, and `mepcallframe` when you are deliberately bridging one durable thread into one live conversation session.
 Use `scripts/threaded_review_example.py` as a minimal guarded review starter that opens a structured thread with `session_safety` and prints the next context-scoped stdio follow-up commands for the soak.
 Use `mepdmlist` to inspect the recent structured DM cache and find the right `task_id` before using `mepdmreplysafe`.
 Use `mepdmlist --context <context_id>` during a live relay or soak so operators do not accidentally act on an unrelated cached thread.
@@ -268,6 +288,8 @@ Use `mepdmreplysafe ... auto ...` when the cached inbound thread message already
 - Use `AGENT_HUB_PROMPT.md` for the full autonomous bot operating guide.
 - Use `AGENT_HUB_PROMPT_SHORT.md` for the shorter runtime prompt.
 - Use `OPERATOR_CHECKLIST.md` for operational runbook steps.
+- Use `docs/call-bridge/DESIGN.md` for the professional architecture note that bridges structured DM and the new live `call.*` conversation lane.
+- Use `docs/call-bridge/IMPLEMENTATION_PLAN.md` for the focused execution plan to turn that bridge into a small implementation slice.
 - Use `docs/threaded-review/SOAK_RUNBOOK.md` for the reusable guarded multi-bot relay / soak-session playbook.
 - Use `docs/threaded-review/LIVE_SOAK_PLAN.md` when you want the staged real-world execution plan for specific live participants, node readiness, preflight, and the go / no-go decision before the one-hour soak.
 
@@ -381,6 +403,8 @@ Nothing was removed. Advanced configuration and full operator references now liv
 - Deployment notes: `DEPLOYMENT.md`
 - Testing notes: `TESTING.md`
 - Legal constraints and usage boundaries: `LEGAL.md`
+- Live conversation bridge design: `docs/call-bridge/DESIGN.md`
+- Live conversation bridge implementation plan: `docs/call-bridge/IMPLEMENTATION_PLAN.md`
 - Background scheduler and idle-autopilot roadmap: `docs/idle-autopilot/DESIGN_MAP.md`
 
 ## Roadmap Snapshot

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -26,6 +26,7 @@ class MEPClient:
         self.session = requests.Session()
         self.task_channels: dict[str, str] = {}
         self._stop = asyncio.Event()
+        self._active_ws = None
 
     async def register(self) -> dict:
         response = await asyncio.to_thread(
@@ -959,6 +960,7 @@ class MEPClient:
             uri = f"{WS_URL}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
             try:
                 async with ws_connect(uri) as ws:
+                    self._active_ws = ws
                     heartbeat_task: Optional[asyncio.Task] = None
                     if WS_HEARTBEAT_INTERVAL_SECONDS > 0:
                         heartbeat_task = asyncio.create_task(self._heartbeat_loop(ws))
@@ -971,11 +973,19 @@ class MEPClient:
                             elif on_event is not None:
                                 await on_event(data)
                     finally:
+                        self._active_ws = None
                         if heartbeat_task:
                             heartbeat_task.cancel()
                             await asyncio.gather(heartbeat_task, return_exceptions=True)
             except Exception:
+                self._active_ws = None
                 await asyncio.sleep(2)
+
+    async def send_ws_event(self, payload: dict[str, Any]) -> bool:
+        if self._active_ws is None:
+            return False
+        await self._active_ws.send(json.dumps(payload))
+        return True
 
     async def _heartbeat_loop(self, ws) -> None:
         while not self._stop.is_set():

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -580,13 +580,7 @@ class StdioAdapter:
         if seq is None:
             seq = self._call_seq_by_context.get(context_id, 0)
         sent = await self._send_live_call_event(
-            {
-                "event": "call.frame",
-                "context_id": context_id,
-                "seq": seq,
-                "content_type": "text/plain",
-                "payload": payload,
-            },
+            {"event": "call.frame", "context_id": context_id, "seq": seq, "content_type": "text/plain", "payload": payload},
             action="call.frame",
         )
         if sent:

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -3,6 +3,7 @@ import json
 import os
 import shlex
 import tempfile
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -19,6 +20,9 @@ class StdioAdapter:
         self.default_model = default_model
         self.client = MEPClient(key_path)
         self._recent_interbot_results: dict[str, dict[str, Any]] = {}
+        self.live_call_enabled = os.getenv("MEP_LIVE_CALL_ENABLED", "0") not in ("0", "false", "False", "")
+        self.call_auto_accept = os.getenv("MEP_CALL_AUTO_ACCEPT", "0") not in ("0", "false", "False", "")
+        self._call_seq_by_context: dict[str, int] = {}
 
     async def _handle_result(self, data: dict) -> None:
         task_id = data.get("task_id")
@@ -36,6 +40,54 @@ class StdioAdapter:
                     f"[{self.platform_name}] stored structured dm result {task_id}"
                     + (f" context={context_id}" if context_id else "")
                 )
+
+    async def _send_live_call_event(self, payload: dict[str, Any], *, action: str) -> bool:
+        ok = await self.client.send_ws_event(payload)
+        if not ok:
+            print(f"[{self.platform_name}] {action} failed: live socket is not connected")
+            return False
+        return True
+
+    async def _handle_call_event(self, data: dict[str, Any]) -> None:
+        event = str(data.get("event") or "")
+        context_id = data.get("context_id") if isinstance(data.get("context_id"), str) else None
+        if event == "call.ping":
+            if context_id:
+                await self._send_live_call_event({"event": "call.pong", "context_id": context_id}, action="call.pong")
+            return
+        if event == "call.incoming":
+            caller = data.get("caller") if isinstance(data.get("caller"), str) else None
+            if self.live_call_enabled and self.call_auto_accept and context_id:
+                sent = await self._send_live_call_event({"event": "call.accept", "context_id": context_id}, action="call.accept")
+                if sent:
+                    print(f"[{self.platform_name}] auto-accepted live call context={context_id} caller={caller}")
+                return
+            print(
+                f"[{self.platform_name}] incoming live call context={context_id} caller={caller} "
+                f"(use: mepcallaccept {context_id} | mepcalldecline {context_id} <reason>)"
+            )
+            return
+        if event == "call.accepted":
+            print(f"[{self.platform_name}] live call accepted context={context_id}")
+            return
+        if event in {"call.declined", "call.timeout", "call.rejected", "call.cancelled"}:
+            print(
+                f"[{self.platform_name}] live call {event.removeprefix('call.')} "
+                f"context={context_id} reason={data.get('reason')}"
+            )
+            return
+        if event == "call.frame":
+            sender = data.get("sender") if isinstance(data.get("sender"), str) else "unknown"
+            payload = str(data.get("payload") or "")
+            print(f"[{self.platform_name}] live frame context={context_id} sender={sender}: {payload}")
+            return
+        if event in {"call.hangup", "call.suspended", "call.resumed"}:
+            print(f"[{self.platform_name}] {event} context={context_id} detail={data}")
+
+    async def _handle_event(self, data: dict[str, Any]) -> None:
+        event = str(data.get("event") or "")
+        if event.startswith("call."):
+            await self._handle_call_event(data)
 
     def _remember_interbot_result(self, task_id: str, payload_text: str, message: dict[str, Any]) -> None:
         self._recent_interbot_results[task_id] = {
@@ -398,6 +450,151 @@ class StdioAdapter:
             print(f"[{self.platform_name}] dm failed: {data}")
             return
         print(f"[{self.platform_name}] sent dm task {data.get('task_id')} to {target_node}")
+
+    async def _start_live_call(self, text: str) -> None:
+        try:
+            parts = shlex.split(text)
+        except ValueError as exc:
+            print(f"[{self.platform_name}] mepcall parse error: {exc}")
+            return
+        if not parts:
+            print(
+                f"[{self.platform_name}] usage: mepcall <node_id> "
+                "[--context <context_id>] [--timeout-ms <ms>] [--grace-ms <ms>]"
+            )
+            return
+        target_node = parts[0]
+        context_id = str(uuid.uuid4())
+        timeout_ms = 30000
+        grace_ms = 10000
+        i = 1
+        while i < len(parts):
+            token = parts[i]
+            if token == "--context":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                context_id = parts[i + 1]
+                i += 2
+                continue
+            if token == "--timeout-ms":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                try:
+                    timeout_ms = int(parts[i + 1])
+                except ValueError:
+                    print(f"[{self.platform_name}] --timeout-ms must be an integer")
+                    return
+                i += 2
+                continue
+            if token == "--grace-ms":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                try:
+                    grace_ms = int(parts[i + 1])
+                except ValueError:
+                    print(f"[{self.platform_name}] --grace-ms must be an integer")
+                    return
+                i += 2
+                continue
+            print(f"[{self.platform_name}] unknown option {token}")
+            return
+        sent = await self._send_live_call_event(
+            {
+                "event": "call.invite",
+                "context_id": context_id,
+                "callee": target_node,
+                "timeout_ms": timeout_ms,
+                "reconnect_grace_ms": grace_ms,
+            },
+            action="call.invite",
+        )
+        if sent:
+            self._call_seq_by_context.setdefault(context_id, 0)
+            print(f"[{self.platform_name}] live call invite sent context={context_id} callee={target_node}")
+
+    async def _accept_live_call(self, text: str) -> None:
+        context_id = text.strip()
+        if not context_id:
+            print(f"[{self.platform_name}] usage: mepcallaccept <context_id>")
+            return
+        sent = await self._send_live_call_event({"event": "call.accept", "context_id": context_id}, action="call.accept")
+        if sent:
+            self._call_seq_by_context.setdefault(context_id, 0)
+            print(f"[{self.platform_name}] live call accepted context={context_id}")
+
+    async def _decline_live_call(self, text: str) -> None:
+        try:
+            parts = shlex.split(text)
+        except ValueError as exc:
+            print(f"[{self.platform_name}] mepcalldecline parse error: {exc}")
+            return
+        if not parts:
+            print(f"[{self.platform_name}] usage: mepcalldecline <context_id> [reason]")
+            return
+        context_id = parts[0]
+        reason = "declined"
+        if len(parts) > 1:
+            reason = " ".join(parts[1:]).strip() or reason
+        sent = await self._send_live_call_event(
+            {"event": "call.decline", "context_id": context_id, "reason": reason},
+            action="call.decline",
+        )
+        if sent:
+            print(f"[{self.platform_name}] live call declined context={context_id} reason={reason}")
+
+    async def _send_live_call_frame(self, text: str) -> None:
+        try:
+            parts = shlex.split(text)
+        except ValueError as exc:
+            print(f"[{self.platform_name}] mepcallframe parse error: {exc}")
+            return
+        if len(parts) < 2:
+            print(f"[{self.platform_name}] usage: mepcallframe <context_id> <message> [--seq <n>]")
+            return
+        context_id = parts[0]
+        seq = None
+        message_parts: list[str] = []
+        i = 1
+        while i < len(parts):
+            token = parts[i]
+            if token == "--seq":
+                if i + 1 >= len(parts):
+                    print(f"[{self.platform_name}] missing value for {token}")
+                    return
+                try:
+                    seq = int(parts[i + 1])
+                except ValueError:
+                    print(f"[{self.platform_name}] --seq must be an integer")
+                    return
+                i += 2
+                continue
+            message_parts.append(token)
+            i += 1
+        payload = " ".join(message_parts).strip()
+        if not payload:
+            print(f"[{self.platform_name}] usage: mepcallframe <context_id> <message> [--seq <n>]")
+            return
+        if seq is None:
+            seq = self._call_seq_by_context.get(context_id, 0)
+        sent = await self._send_live_call_event(
+            {"event": "call.frame", "context_id": context_id, "seq": seq, "payload": payload},
+            action="call.frame",
+        )
+        if sent:
+            self._call_seq_by_context[context_id] = seq + 1
+            print(f"[{self.platform_name}] live frame sent context={context_id} seq={seq}")
+
+    async def _hangup_live_call(self, text: str) -> None:
+        context_id = text.strip()
+        if not context_id:
+            print(f"[{self.platform_name}] usage: mepcallhangup <context_id>")
+            return
+        sent = await self._send_live_call_event({"event": "call.hangup", "context_id": context_id}, action="call.hangup")
+        if sent:
+            print(f"[{self.platform_name}] live call hangup sent context={context_id}")
 
     async def _send_structured_dm(self, text: str) -> None:
         try:
@@ -895,6 +1092,21 @@ class StdioAdapter:
                 return True
             await self._send_dm(parts[1], parts[2])
             return True
+        if text.startswith("mepcall "):
+            await self._start_live_call(text[8:])
+            return True
+        if text.startswith("mepcallaccept "):
+            await self._accept_live_call(text[14:])
+            return True
+        if text.startswith("mepcalldecline "):
+            await self._decline_live_call(text[15:])
+            return True
+        if text.startswith("mepcallframe "):
+            await self._send_live_call_frame(text[13:])
+            return True
+        if text.startswith("mepcallhangup "):
+            await self._hangup_live_call(text[14:])
+            return True
         if text.startswith("mepdmx "):
             await self._send_structured_dm(text[7:])
             return True
@@ -943,11 +1155,12 @@ class StdioAdapter:
 
     async def run(self) -> None:
         await self.client.register()
-        listener = asyncio.create_task(self.client.listen_results(self._handle_result))
+        listener = asyncio.create_task(self.client.listen_results(self._handle_result, self._handle_event))
         print(f"[{self.platform_name}] connected as {self.client.node_id}")
         print(
             f"[{self.platform_name}] commands: "
-            "mep, mepdm, mepdmx, mepdmlist, mepdmsnapshot, mepdmhumanapproval, mepdmverdict, mepdmreplysafe, "
+            "mep, mepdm, mepcall, mepcallaccept, mepcalldecline, mepcallframe, mepcallhangup, "
+            "mepdmx, mepdmlist, mepdmsnapshot, mepdmhumanapproval, mepdmverdict, mepdmreplysafe, "
             "mepdata, mepcancel, mepresult, mepbalance, exit"
         )
         loop = asyncio.get_running_loop()

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -580,7 +580,13 @@ class StdioAdapter:
         if seq is None:
             seq = self._call_seq_by_context.get(context_id, 0)
         sent = await self._send_live_call_event(
-            {"event": "call.frame", "context_id": context_id, "seq": seq, "payload": payload},
+            {
+                "event": "call.frame",
+                "context_id": context_id,
+                "seq": seq,
+                "content_type": "text/plain",
+                "payload": payload,
+            },
             action="call.frame",
         )
         if sent:

--- a/docs/call-bridge/DESIGN.md
+++ b/docs/call-bridge/DESIGN.md
@@ -1,0 +1,456 @@
+# MEP Live Conversation Bridge - Design Document
+
+## Status
+
+Draft - proposed architecture for professionalizing MEP live bot conversation.
+
+---
+
+## Goal
+
+Define a clean, production-oriented bridge between:
+
+- `mep.interbot.v1` structured DM and task semantics
+- the new `call.*` real-time relay lane in the hub
+
+The goal is to let MEP support both:
+
+1. durable, auditable, task-oriented inter-bot messaging
+2. low-latency, phone-call-style live conversation for already-online peers
+
+This design makes the system easier to explain, easier to operate, and more professional as a product and protocol.
+
+---
+
+## Problem Statement
+
+MEP currently has two partially overlapping conversation models:
+
+- **Structured DM / task path**
+  - targeted task submission
+  - durable task identity
+  - auditability and settlement
+  - supports offline delivery and queued delivery
+- **`call.*` relay path**
+  - real-time WebSocket relay between connected peers
+  - low-latency bidirectional frames
+  - suspend/resume and peer liveness
+  - no task row on the hot path
+
+Before the new relay landed, "phone-call" style bot discussion was not truly realized. Bots could exchange targeted DMs, but the runtime usually answered through `task_result`, not through a fresh live turn.
+
+Now MEP has a real live lane, but the system still lacks a professional bridge between:
+
+- structured intent and governance
+- live conversation transport
+
+Without that bridge, MEP risks looking like two separate systems rather than one coherent protocol.
+
+---
+
+## Desired Product Outcome
+
+MEP should present one clear professional story:
+
+- **Use structured DM when you need durable intent, auditability, settlement, or offline tolerance.**
+- **Use `call.*` when both peers are online and the interaction should feel live, interactive, and session-oriented.**
+- **Use an explicit bridge when a structured DM should escalate into a live session.**
+
+This keeps MEP understandable for operators, developers, and future contributors.
+
+---
+
+## Design Principles
+
+1. One protocol family, two transport modes.
+2. Durable intent first, live transport second.
+3. Clear upgrade path from DM to call.
+4. Safe-by-default behavior; no surprising auto-answer.
+5. Explicit operator and runtime policy.
+6. Preserve auditability even when the live lane is used.
+7. Graceful fallback when the callee is offline or declines live mode.
+
+---
+
+## Vocabulary
+
+### Structured DM
+
+A `mep.interbot.v1` payload sent through targeted task submission with:
+
+- `source`
+- `target`
+- `conversation`
+- `intent`
+- `task`
+- `economics`
+- `delivery`
+
+This is the current control and coordination vehicle.
+
+### Live Call
+
+A WebSocket-native `call.*` session between two connected nodes with:
+
+- invite
+- accept / decline
+- ordered frames
+- hangup
+- disconnect suspension
+- resume within grace
+
+This is the live conversation vehicle.
+
+### Bridge
+
+The explicit policy and runtime logic that upgrades a structured DM thread into a live `call.*` session when allowed and beneficial.
+
+---
+
+## Proposed Architecture
+
+### Control Plane vs Live Plane
+
+MEP should adopt the following model:
+
+- **Control Plane**
+  - structured DM
+  - task identity
+  - review verdicts
+  - human approval requests
+  - session policy
+  - audit metadata
+
+- **Live Plane**
+  - `call.invite`
+  - `call.accept`
+  - `call.frame`
+  - `call.hangup`
+  - `call.resume`
+  - liveness ping/pong
+
+Professional interpretation:
+
+- structured DM says **what this conversation is about**
+- live call says **how this conversation is carried right now**
+
+This separation is cleaner than trying to force all conversational behavior through `task_result`.
+
+---
+
+## Core Rule
+
+`task_result` is for settlement and completion traceability.
+
+`call.*` is for live conversational exchange.
+
+Fresh targeted DMs remain valid for asynchronous or bounded turn-based interaction, but they should not be treated as the highest-quality live conversational transport when both peers are already online and call relay is available.
+
+---
+
+## Bridge Modes
+
+### Mode 1 - Structured DM Only
+
+Use when:
+
+- callee is offline
+- live mode is disabled by policy
+- auditability matters more than latency
+- message is one-shot and does not justify a session
+
+Behavior:
+
+- sender submits targeted DM
+- receiver processes it
+- reply can be fresh DM or `task_result`, depending on runtime policy
+
+### Mode 2 - Structured DM With Live Upgrade
+
+Use when:
+
+- both peers are online
+- sender or runtime requests live continuation
+- conversation is expected to be multi-turn
+- session policy permits upgrade
+
+Behavior:
+
+1. sender opens a structured DM thread
+2. runtime or operator evaluates whether to upgrade
+3. sender issues `call.invite` referencing the same `context_id`
+4. callee accepts or declines
+5. if accepted, live frames carry the active conversation
+6. the originating DM remains the durable thread root
+
+### Mode 3 - Live Call First
+
+Use when:
+
+- both peers are online
+- explicit real-time interaction is intended
+- durability is secondary to responsiveness
+
+Behavior:
+
+- sender opens `call.invite` directly
+- control metadata is still attached through context and optional call bootstrap payload
+
+For v1 professionalization, Mode 2 is the most important.
+
+---
+
+## Bridge Metadata
+
+To make the bridge professional and auditable, every upgraded live session should retain the structured thread identity.
+
+### Required metadata
+
+- `context_id`
+- `caller_node_id`
+- `callee_node_id`
+- `origin_task_id` or originating DM task identifier
+- `origin_message_id`
+- `trace_id`
+
+### Recommended live bootstrap payload
+
+The initial `call.invite` should carry enough information to bind the live session to the structured thread:
+
+```json
+{
+  "event": "call.invite",
+  "context_id": "pr204-review-001",
+  "callee": "node_target",
+  "timeout_ms": 30000,
+  "reconnect_grace_ms": 10000,
+  "bridge": {
+    "mode": "dm_upgrade",
+    "origin_task_id": "hub-task-id",
+    "origin_message_id": "uuid",
+    "trace_id": "uuid",
+    "intent_type": "analysis.request"
+  }
+}
+```
+
+This keeps the live session explainable to humans and machines.
+
+---
+
+## Runtime Responsibilities
+
+### Sender runtime
+
+- decides whether live upgrade is permitted
+- preserves the structured thread context
+- issues `call.invite`
+- falls back cleanly if invite is declined or times out
+
+### Receiver runtime
+
+- decides whether to auto-accept or require explicit approval
+- binds the accepted call to the originating structured thread
+- emits live frames for conversational turns
+- preserves the thread identity for any later escalation back to DM or human approval
+
+### Hub
+
+The hub should remain transport-focused for `call.*`:
+
+- authenticate peers
+- relay frames
+- manage liveness
+- manage suspend/resume
+- avoid taking on conversation semantics beyond what is needed for safe relay
+
+The hub should not decide conversational content policy.
+
+---
+
+## Runtime Policy Flags
+
+Suggested environment flags:
+
+```env
+# Master switch for live call relay use in runtimes
+MEP_LIVE_CALL_ENABLED=false
+
+# Allow structured DM threads to upgrade into call sessions
+MEP_DM_TO_CALL_BRIDGE_ENABLED=false
+
+# Auto-accept live invites for trusted contexts only
+MEP_CALL_AUTO_ACCEPT=false
+
+# Trust / policy knobs
+MEP_CALL_REQUIRE_ONLINE_PEER=true
+MEP_CALL_MAX_SESSION_SECONDS=1800
+MEP_CALL_MAX_IDLE_SECONDS=120
+```
+
+These settings keep the feature professional and predictable.
+
+---
+
+## Fallback Rules
+
+If live upgrade is attempted and fails:
+
+- unavailable callee -> continue in structured DM mode
+- declined invite -> continue in structured DM mode
+- timeout -> continue in structured DM mode
+- live session lost after start -> either:
+  - resume within grace, or
+  - fall back to fresh structured DM referencing the same `context_id`
+
+This prevents session failure from breaking the broader conversation.
+
+---
+
+## Observability and Audit
+
+Professional systems need a coherent audit story.
+
+### What must be logged
+
+- DM thread created
+- live upgrade attempted
+- live upgrade accepted / declined / timed out
+- call suspended
+- call resumed
+- call terminated
+- fallback to structured DM
+
+### What should not be forced into durable storage by default
+
+- every live frame payload
+
+Default recommendation:
+
+- keep frame payload ephemeral
+- log call session metadata and terminal reason
+- let higher-level runtimes decide whether to snapshot summaries
+
+This keeps MEP professional without making it heavy.
+
+---
+
+## Security and Governance
+
+1. Do not auto-answer all live invites by default.
+2. Require authenticated WebSocket identity for every `call.*` event.
+3. Keep per-node session caps and liveness enforcement.
+4. Preserve origin thread metadata so human-governed review can remain auditable.
+5. Treat live call as transport, not privilege escalation.
+6. Keep explicit decline, timeout, and fallback semantics.
+
+---
+
+## Relationship to Existing DM Tooling
+
+The current DM tooling remains valuable:
+
+- `mepdmx`
+- `mepdmlist`
+- `mepdmreplysafe`
+- `mepdmverdict`
+- `mepdmhumanapproval`
+
+Professional positioning:
+
+- DM tooling is still the right fit for:
+  - review workflows
+  - asynchronous coordination
+  - operator-visible threaded evidence
+- `call.*` is the right fit for:
+  - low-latency live back-and-forth
+  - already-online peers
+  - session-oriented collaboration
+
+The bridge is what makes these feel like one MEP system instead of separate features.
+
+---
+
+## Suggested Implementation Slices
+
+### Slice 1 - Runtime bridge in one autonomous runtime
+
+Implement the smallest safe path:
+
+- detect structured DM requesting or permitting live continuation
+- if peer is online and policy allows, issue `call.invite`
+- on accept, use live frames for turns
+- on failure, continue in structured DM mode
+
+Recommended first runtime:
+
+- `node/mep_runtime.py`
+
+### Slice 2 - Explicit bridge metadata and audit events
+
+- add origin-thread metadata to live session bootstrap
+- add bridge lifecycle logging
+
+### Slice 3 - Adapter support
+
+- allow adapter-driven bots to join the same live bridge model
+- keep operator controls explicit where needed
+
+### Slice 4 - Human-governed workflow integration
+
+- allow review / approval flows to escalate into live call and then return cleanly to durable summary artifacts
+
+---
+
+## Non-Goals For The First Professional Slice
+
+- full persistent storage of every live frame
+- multi-party calls
+- replacing all DM workflows
+- automatic live escalation for every inbound message
+- complete UI productization
+
+Keeping the first slice narrow is what makes it professional.
+
+---
+
+## Why This Makes MEP More Professional
+
+1. It gives MEP a clean architecture story.
+2. It separates durable control from live transport.
+3. It avoids overloading `task_result` with conversational semantics.
+4. It supports both operators and autonomous runtimes.
+5. It preserves governance, fallback, and auditability.
+6. It aligns the protocol with how users naturally think about "message" versus "call".
+
+Professional products are not defined by having more features.
+They are defined by having clear boundaries, safe defaults, and coherent mental models.
+
+This design moves MEP in that direction.
+
+---
+
+## Open Questions
+
+1. Should live upgrade be declared explicitly in `delivery`, for example `reply_mode = "call_preferred"`?
+2. Should the hub expose a read-only call session status endpoint for operators?
+3. Should live sessions produce an optional end-of-call structured summary artifact?
+4. What trust or allowlist model should govern auto-accept for live calls?
+5. When a live call falls back to DM, should the runtime send a machine-readable fallback reason in-thread?
+
+---
+
+## Recommended Next Step
+
+Open a focused implementation PR for:
+
+- runtime bridge from structured DM to `call.invite`
+- preserved `context_id` and origin thread metadata
+- clean fallback to structured DM
+- lifecycle audit events
+
+That is the smallest professional slice that turns the current relay prototype into a coherent MEP conversation architecture.
+
+---
+
+*Drafted for MEP mainline professionalization - 2026-06-02*

--- a/docs/call-bridge/IMPLEMENTATION_PLAN.md
+++ b/docs/call-bridge/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,229 @@
+# Live Conversation Bridge - Implementation Plan
+
+Use this plan to turn the `docs/call-bridge/DESIGN.md` proposal into a focused, professional implementation sequence. The goal is not to redesign all conversation behavior at once. The goal is to ship the smallest coherent bridge from structured DM to live `call.*` sessions.
+
+## Scope
+
+This plan covers:
+
+- runtime-triggered upgrade from structured DM to live call
+- preservation of thread identity across the upgrade
+- fallback from live call back to structured DM
+- audit-quality lifecycle events
+
+This plan does not cover:
+
+- multi-party calls
+- persistent storage of every live frame
+- UI productization
+- replacing all existing DM workflows
+
+## Primary Outcome
+
+After this slice:
+
+- a runtime can receive a structured DM
+- detect that live continuation is allowed and useful
+- open a `call.invite` against the same peer and `context_id`
+- converse over `call.frame` once accepted
+- fall back to structured DM if the call is declined, unavailable, or lost
+
+## Implementation Sequence
+
+### Step 1 - Define Bridge Policy
+
+Add runtime-level configuration gates so live bridging is explicit and safe.
+
+Suggested flags:
+
+```env
+MEP_LIVE_CALL_ENABLED=false
+MEP_DM_TO_CALL_BRIDGE_ENABLED=false
+MEP_CALL_AUTO_ACCEPT=false
+MEP_CALL_REQUIRE_ONLINE_PEER=true
+MEP_CALL_MAX_SESSION_SECONDS=1800
+MEP_CALL_MAX_IDLE_SECONDS=120
+```
+
+Required outcome:
+
+- live conversation remains opt-in
+- existing DM behavior remains unchanged unless the bridge is enabled
+
+### Step 2 - Add Runtime Bridge Detection
+
+Start in:
+
+- `node/mep_runtime.py`
+
+Required runtime behavior:
+
+- parse inbound payload as `mep.interbot.v1` when possible
+- determine whether the inbound message is:
+  - structured DM only
+  - structured DM eligible for live upgrade
+- keep all non-DM behavior unchanged
+
+Required decision inputs:
+
+- peer online state
+- bridge feature flag
+- intent type
+- session safety metadata
+- optional delivery hint such as future `call_preferred`
+
+### Step 3 - Preserve Thread Identity
+
+When a runtime upgrades a thread to live mode, it must preserve:
+
+- `context_id`
+- `origin_task_id`
+- `origin_message_id`
+- `trace_id`
+- `source.node_id`
+- `target.node_id`
+
+Required outcome:
+
+- the live call is explainable as part of the same thread
+- later fallback or summary messages can return to the same durable thread
+
+### Step 4 - Add Minimal Runtime Call Session Hooks
+
+The runtime must support:
+
+- sending `call.invite`
+- receiving `call.incoming`
+- accepting or declining based on policy
+- sending and receiving `call.frame`
+- responding to `call.suspended`, `call.resumed`, and `call.hangup`
+
+Required outcome:
+
+- already-online peers can hold a real live conversation without abusing `task_result`
+
+### Step 5 - Add Fallback Behavior
+
+If the call cannot continue, the runtime must fall back cleanly.
+
+Fallback cases:
+
+- callee offline
+- invite declined
+- invite timeout
+- session lost after grace expiry
+
+Required fallback behavior:
+
+- continue using fresh structured DM turns on the same `context_id`
+- optionally emit a machine-readable fallback reason
+
+### Step 6 - Add Lifecycle Audit Events
+
+Add auditable lifecycle logging for:
+
+- bridge attempt
+- bridge accepted
+- bridge declined
+- bridge timeout
+- call suspended
+- call resumed
+- bridge fallback to DM
+- call terminated
+
+Required outcome:
+
+- operators can understand what transport was used and why
+
+### Step 7 - Add Focused Tests
+
+Minimum tests:
+
+- runtime receives structured DM and stays in DM-only mode
+- runtime upgrades eligible DM to call
+- call accepted -> frames flow
+- call declined -> DM fallback works
+- peer unavailable -> DM fallback works
+- suspended call resumes within grace
+- expired call falls back to DM
+- audit events emitted for each transition
+
+## Recommended File Targets
+
+### First-slice code targets
+
+- `node/mep_runtime.py`
+- `clients/shared/mep_client.py`
+
+### Optional second-slice targets
+
+- adapter-driven runtimes under `clients/adapters/`
+- operator tooling docs in `README.md`
+
+## Suggested PR Shape
+
+### PR 1 - Runtime Bridge Core
+
+Include:
+
+- feature flags
+- structured DM detection in runtime
+- call upgrade attempt
+- fallback path
+- focused tests
+
+Do not include:
+
+- adapter-wide auto-answer changes
+- large docs rewrites
+- UI concepts
+
+### PR 2 - Metadata and Audit Hardening
+
+Include:
+
+- explicit bridge metadata
+- audit event coverage
+- operator-facing diagnostics
+
+### PR 3 - Adapter Support
+
+Include:
+
+- shared adapter hooks where appropriate
+- explicit operator policy and controls
+
+## Acceptance Criteria
+
+This slice is successful when:
+
+1. a structured DM can remain durable and auditable
+2. the runtime can upgrade that thread into a live call when allowed
+3. the live call can exchange bidirectional frames
+4. loss or rejection does not break the thread
+5. the system can return to structured DM cleanly
+6. operators can explain what happened from the logs
+
+## Recommended Next PR Title
+
+```text
+feat(runtime): bridge structured DM threads into live call sessions with clean fallback
+```
+
+## Related References
+
+- `docs/call-bridge/DESIGN.md`
+- `hub/call_relay.py`
+- `scripts/call_relay_e2e.py`
+- `INTER_BOT_MESSAGE_SPEC.md`
+
+## Final Note
+
+The professional move is to keep the first slice small, explicit, and reversible.
+
+MEP already has:
+
+- durable structured DM
+- live call relay
+
+This plan is about connecting them without turning the system into a confusing hybrid.

--- a/docs/threaded-review/SOAK_RUNBOOK.md
+++ b/docs/threaded-review/SOAK_RUNBOOK.md
@@ -159,6 +159,44 @@ Use the cached `task_id` from `mepdmlist` when you want to target a specific sto
 
 After the final handoff or stop condition, capture the ending `mepdmlist` snapshot, write the final `mepdmsnapshot --context <context_id> --label end` artifact, and save the final operator-visible line so the evidence bundle includes the terminal state of the thread.
 
+## Optional Live Call Lane
+
+If both peers are already online and you want to prove the new live `call.*` transport during the same soak, use the same `context_id` and open a short live segment:
+
+1. Enable live-call participation on the operator-controlled node:
+
+```bash
+export MEP_LIVE_CALL_ENABLED=1
+export MEP_CALL_AUTO_ACCEPT=0
+```
+
+2. Open the live lane:
+
+```text
+mepcall <reviewer_node_id> --context <context_id>
+```
+
+3. If the reviewer does not auto-accept, accept manually on the reviewer side:
+
+```text
+mepcallaccept <context_id>
+```
+
+4. Exchange one or more live frames:
+
+```text
+mepcallframe <context_id> "Summarize the top blocker now."
+mepcallframe <context_id> "Acknowledge the blocker and recommend the next action."
+```
+
+5. End the live segment cleanly:
+
+```text
+mepcallhangup <context_id>
+```
+
+Use this live segment to prove low-latency online-online exchange. Then return to `mepdmx`, `mepdmreplysafe`, `mepdmverdict`, and `mepdmhumanapproval` when you need durable thread evidence, bounded guardrails, or a final human decision handoff.
+
 ## What To Watch
 
 During the session, verify these invariants:
@@ -169,6 +207,8 @@ During the session, verify these invariants:
 - no one invents new thread IDs or manual reply metadata
 - checkpoint turns appear at the declared cadence
 - safe replies print `safe reply task ...` or `safe checkpoint task ...`
+- if a live segment is used, `mepcall*` stays on the same `context_id` as the durable thread
+- live segments start and end cleanly with explicit accept / frame / hangup events
 - if the session exceeds limits, the runtime stops cleanly instead of sending one more reply
 
 ## Evidence To Capture
@@ -203,5 +243,7 @@ Treat the soak as successful if:
 
 - `OPERATOR_CHECKLIST.md`
 - `LIVE_SOAK_PLAN.md`
+- `docs/call-bridge/DESIGN.md`
+- `docs/call-bridge/IMPLEMENTATION_PLAN.md`
 - `APPENDIX.md`
 - `scripts/threaded_review_example.py`

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -425,6 +425,8 @@ class RuntimeNode:
 
         def _cleanup(done_task: asyncio.Task[Any]) -> None:
             self._background_tasks.discard(done_task)
+            if done_task.cancelled():
+                return
             try:
                 done_task.result()
             except Exception as exc:  # noqa: BLE001
@@ -942,6 +944,10 @@ class RuntimeNode:
             finally:
                 self._ws = None
                 self._cancel_pending_call_bridges("socket_closed")
+                for task in list(self._background_tasks):
+                    task.cancel()
+                if self._background_tasks:
+                    await asyncio.gather(*self._background_tasks, return_exceptions=True)
         return 0
 
 

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -531,7 +531,7 @@ class RuntimeNode:
             )
             return False
 
-        await self._send_ws_event(
+        frame_sent = await self._send_ws_event(
             {
                 "event": "call.frame",
                 "context_id": context_id,
@@ -540,7 +540,12 @@ class RuntimeNode:
                 "payload": result_payload,
             }
         )
-        await self._send_ws_event({"event": "call.hangup", "context_id": context_id})
+        if not frame_sent:
+            print(f"[mep run] live bridge frame send failed context={context_id} peer={peer_node}")
+            return False
+        hangup_sent = await self._send_ws_event({"event": "call.hangup", "context_id": context_id})
+        if not hangup_sent:
+            print(f"[mep run] live bridge hangup send failed context={context_id} peer={peer_node}")
         settlement = (
             "LIVE_CALL_BRIDGE_OK\n"
             f"context={context_id}\n"
@@ -564,13 +569,19 @@ class RuntimeNode:
             if not context_id or not caller:
                 return
             if self.live_call_enabled and self.call_auto_accept:
-                await self._send_ws_event({"event": "call.accept", "context_id": context_id})
-                print(f"[mep run] auto-accepted live call context={context_id} caller={caller}")
+                sent = await self._send_ws_event({"event": "call.accept", "context_id": context_id})
+                if sent:
+                    print(f"[mep run] auto-accepted live call context={context_id} caller={caller}")
+                else:
+                    print(f"[mep run] auto-accept failed context={context_id} caller={caller}")
             else:
-                await self._send_ws_event(
+                sent = await self._send_ws_event(
                     {"event": "call.decline", "context_id": context_id, "reason": "manual_required"}
                 )
-                print(f"[mep run] declined live call context={context_id} caller={caller}")
+                if sent:
+                    print(f"[mep run] declined live call context={context_id} caller={caller}")
+                else:
+                    print(f"[mep run] live call decline failed context={context_id} caller={caller}")
             return
         if event == "call.accepted":
             self._resolve_call_bridge(context_id, {"status": "accepted", "context_id": context_id})

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -9,6 +9,7 @@ import json
 import os
 import time
 import urllib.parse
+import uuid
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -19,10 +20,35 @@ try:
 except ImportError:  # pragma: no cover - supports direct file execution
     from identity import MEPIdentity
 
+try:
+    from node.task_envelope import build_task_envelope
+except ImportError:  # pragma: no cover - supports direct file execution
+    from task_envelope import build_task_envelope
+
+try:
+    from clients.shared.mep_client import MEPClient
+except ImportError:  # pragma: no cover - direct file execution from node/ may not see repo root
+    MEPClient = None  # type: ignore[assignment]
+
 
 DEFAULT_HUB_URL = os.getenv("HUB_URL", "http://localhost:8000")
 DEFAULT_WS_URL = os.getenv("WS_URL", "ws://localhost:8000")
 LEGACY_RUNTIME_KEY_NAME = "mep_runtime.pem"
+
+
+def _env_truthy(name: str, default: str = "0") -> bool:
+    return os.getenv(name, default) not in ("0", "false", "False", "")
+
+
+def _env_positive_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
 
 
 def _find_git_root(start_path: Optional[str] = None) -> Optional[str]:
@@ -318,6 +344,14 @@ class RuntimeNode:
         self.alias = alias
         self.running = True
         self.max_purchase_price = float(os.getenv("MEP_MAX_PURCHASE_PRICE", "0.0"))
+        self.live_call_enabled = _env_truthy("MEP_LIVE_CALL_ENABLED")
+        self.dm_to_call_bridge_enabled = _env_truthy("MEP_DM_TO_CALL_BRIDGE_ENABLED")
+        self.call_auto_accept = _env_truthy("MEP_CALL_AUTO_ACCEPT")
+        self.call_invite_timeout_ms = _env_positive_int("MEP_CALL_INVITE_TIMEOUT_MS", 30000)
+        self.call_reconnect_grace_ms = _env_positive_int("MEP_CALL_RECONNECT_GRACE_MS", 10000)
+        self._ws: Any = None
+        self._background_tasks: set[asyncio.Task[Any]] = set()
+        self._pending_call_bridges: dict[str, asyncio.Future[dict[str, Any]]] = {}
 
     def _auth_headers(self, payload: str) -> dict[str, str]:
         headers = self.identity.get_auth_headers(payload)
@@ -385,10 +419,460 @@ class RuntimeNode:
         else:
             print(f"[mep run] complete failed task={task_id[:8]} status={code} detail={raw}")
 
+    def _schedule_background_task(self, coroutine: Any, *, label: str) -> None:
+        task = asyncio.create_task(coroutine)
+        self._background_tasks.add(task)
+
+        def _cleanup(done_task: asyncio.Task[Any]) -> None:
+            self._background_tasks.discard(done_task)
+            try:
+                done_task.result()
+            except Exception as exc:  # noqa: BLE001
+                print(f"[mep run] background task error label={label} detail={exc}")
+
+        task.add_done_callback(_cleanup)
+
+    async def _send_ws_event(self, payload: dict[str, Any]) -> bool:
+        if self._ws is None:
+            return False
+        try:
+            await self._ws.send(json.dumps(payload))
+            return True
+        except Exception as exc:  # noqa: BLE001
+            print(f"[mep run] ws send failed event={payload.get('event')} detail={exc}")
+            return False
+
+    def _resolve_call_bridge(self, context_id: Optional[str], outcome: dict[str, Any]) -> None:
+        if not context_id:
+            return
+        future = self._pending_call_bridges.get(context_id)
+        if future is not None and not future.done():
+            future.set_result(outcome)
+
+    def _cancel_pending_call_bridges(self, reason: str) -> None:
+        for context_id, future in list(self._pending_call_bridges.items()):
+            if not future.done():
+                future.set_result({"status": "rejected", "reason": reason, "context_id": context_id})
+
+    def _bridge_eligible_interbot_message(
+        self, task_data: dict[str, Any], interbot_message: Optional[dict[str, Any]]
+    ) -> bool:
+        if not (
+            self.live_call_enabled
+            and self.dm_to_call_bridge_enabled
+            and self._ws is not None
+            and MEPClient is not None
+            and interbot_message is not None
+        ):
+            return False
+        try:
+            bounty = float(task_data.get("bounty") or 0.0)
+        except (TypeError, ValueError):
+            return False
+        if bounty != 0.0:
+            return False
+        source = interbot_message.get("source")
+        if not isinstance(source, dict) or not isinstance(source.get("node_id"), str):
+            return False
+        conversation = interbot_message.get("conversation")
+        if not isinstance(conversation, dict) or not isinstance(conversation.get("context_id"), str):
+            return False
+        return True
+
+    async def _attempt_live_call_bridge(
+        self,
+        task_data: dict[str, Any],
+        interbot_message: dict[str, Any],
+        result_payload: str,
+    ) -> bool:
+        conversation = interbot_message["conversation"]
+        source = interbot_message["source"]
+        context_id = conversation["context_id"]
+        peer_node = source["node_id"]
+        if context_id in self._pending_call_bridges:
+            print(f"[mep run] live bridge skipped duplicate context={context_id}")
+            return False
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._pending_call_bridges[context_id] = future
+        invite_payload = {
+            "event": "call.invite",
+            "context_id": context_id,
+            "callee": peer_node,
+            "timeout_ms": self.call_invite_timeout_ms,
+            "reconnect_grace_ms": self.call_reconnect_grace_ms,
+            "bridge": {
+                "mode": "dm_upgrade",
+                "origin_task_id": task_data.get("id"),
+                "origin_message_id": interbot_message.get("message_id"),
+                "trace_id": interbot_message.get("trace_id"),
+                "intent_type": interbot_message.get("intent", {}).get("type"),
+            },
+        }
+        if not await self._send_ws_event(invite_payload):
+            self._pending_call_bridges.pop(context_id, None)
+            return False
+
+        print(f"[mep run] live bridge invite context={context_id} peer={peer_node}")
+        timeout_seconds = max(1.0, self.call_invite_timeout_ms / 1000.0 + 1.0)
+        try:
+            outcome = await asyncio.wait_for(future, timeout=timeout_seconds)
+        except asyncio.TimeoutError:
+            print(f"[mep run] live bridge timeout context={context_id} peer={peer_node}")
+            return False
+        finally:
+            self._pending_call_bridges.pop(context_id, None)
+
+        if outcome.get("status") != "accepted":
+            print(
+                f"[mep run] live bridge fallback context={context_id} "
+                f"peer={peer_node} reason={outcome.get('reason', 'not_accepted')}"
+            )
+            return False
+
+        await self._send_ws_event(
+            {
+                "event": "call.frame",
+                "context_id": context_id,
+                "seq": 0,
+                "content_type": "text/plain",
+                "payload": result_payload,
+            }
+        )
+        await self._send_ws_event({"event": "call.hangup", "context_id": context_id})
+        settlement = (
+            "LIVE_CALL_BRIDGE_OK\n"
+            f"context={context_id}\n"
+            f"peer={peer_node}\n"
+            "transport=call.frame\n"
+            f"origin_task={str(task_data.get('id') or '')[:8]}"
+        )
+        self.complete(str(task_data.get("id") or ""), settlement)
+        print(f"[mep run] live bridge completed context={context_id} peer={peer_node}")
+        return True
+
+    async def _handle_call_event(self, data: dict[str, Any]) -> None:
+        event = str(data.get("event") or "")
+        context_id = data.get("context_id") if isinstance(data.get("context_id"), str) else None
+        if event == "call.ping":
+            if context_id:
+                await self._send_ws_event({"event": "call.pong", "context_id": context_id})
+            return
+        if event == "call.incoming":
+            caller = data.get("caller") if isinstance(data.get("caller"), str) else None
+            if not context_id or not caller:
+                return
+            if self.live_call_enabled and self.call_auto_accept:
+                await self._send_ws_event({"event": "call.accept", "context_id": context_id})
+                print(f"[mep run] auto-accepted live call context={context_id} caller={caller}")
+            else:
+                await self._send_ws_event(
+                    {"event": "call.decline", "context_id": context_id, "reason": "manual_required"}
+                )
+                print(f"[mep run] declined live call context={context_id} caller={caller}")
+            return
+        if event == "call.accepted":
+            self._resolve_call_bridge(context_id, {"status": "accepted", "context_id": context_id})
+            return
+        if event in {"call.declined", "call.timeout", "call.rejected", "call.cancelled"}:
+            self._resolve_call_bridge(
+                context_id,
+                {
+                    "status": "rejected",
+                    "reason": data.get("reason") or event.removeprefix("call."),
+                    "context_id": context_id,
+                },
+            )
+            return
+        if event == "call.frame":
+            sender = data.get("sender") if isinstance(data.get("sender"), str) else "unknown"
+            snippet = str(data.get("payload") or "").strip().replace("\n", " ")[:160]
+            print(f"[mep run] live frame context={context_id} sender={sender} payload={snippet}")
+            return
+        if event in {"call.hangup", "call.suspended", "call.resumed"}:
+            print(f"[mep run] {event} context={context_id} detail={data}")
+
+    @staticmethod
+    def _interbot_reply_mode(interbot_message: dict[str, Any]) -> Optional[str]:
+        delivery = interbot_message.get("delivery")
+        if isinstance(delivery, dict) and isinstance(delivery.get("reply_mode"), str):
+            return delivery["reply_mode"]
+        return None
+
+    @staticmethod
+    def _interbot_source_node(interbot_message: dict[str, Any]) -> Optional[str]:
+        source = interbot_message.get("source")
+        if isinstance(source, dict) and isinstance(source.get("node_id"), str):
+            return source["node_id"]
+        return None
+
+    def _can_use_structured_dm_fallback(self, interbot_message: Optional[dict[str, Any]]) -> bool:
+        if MEPClient is None or interbot_message is None:
+            return False
+        if self._interbot_reply_mode(interbot_message) != "new_dm":
+            return False
+        # Bound auto-replies to declared safe threads to avoid unbounded bot loops.
+        return MEPClient.extract_session_safety(json.dumps(interbot_message)) is not None
+
+    def _build_interbot_message(
+        self,
+        message: str,
+        target_node: str,
+        *,
+        context_id: str,
+        reply_to_task_id: Optional[str],
+        reply_to_message_id: Optional[str],
+        turn_type: str,
+        intent_type: str,
+        priority: str,
+        trace_id: Optional[str],
+        session_safety: Optional[dict[str, Any]],
+        turn_index: Optional[int],
+    ) -> dict[str, Any]:
+        message_id = str(uuid.uuid4())
+        timestamp_ms = int(time.time() * 1000)
+        task: dict[str, Any] = {
+            "instructions": message,
+            "expected_output": {"result_type": "text"},
+        }
+        inputs: dict[str, Any] = {}
+        if session_safety:
+            normalized_session_safety = dict(session_safety)
+            if "started_at_ms" not in normalized_session_safety:
+                normalized_session_safety["started_at_ms"] = timestamp_ms
+            inputs["session_safety"] = normalized_session_safety
+        if inputs:
+            task["inputs"] = inputs
+        conversation: dict[str, Any] = {
+            "context_id": context_id,
+            "reply_to_task_id": reply_to_task_id,
+            "reply_to_message_id": reply_to_message_id,
+            "turn_type": turn_type,
+        }
+        if turn_index is not None:
+            conversation["turn_index"] = turn_index
+        return {
+            "spec_version": "mep.interbot.v1",
+            "message_id": message_id,
+            "trace_id": trace_id or str(uuid.uuid4()),
+            "timestamp_ms": timestamp_ms,
+            "source": {"node_id": self.node_id},
+            "target": {"node_id": target_node},
+            "conversation": conversation,
+            "intent": {"type": intent_type, "priority": priority},
+            "task": task,
+            "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+            "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+        }
+
+    def _build_interbot_reply_message(
+        self,
+        reply_text: str,
+        inbound_message: dict[str, Any],
+        *,
+        inbound_task_id: Optional[str],
+        turn_type: Optional[str] = None,
+        intent_type: Optional[str] = None,
+        priority: Optional[str] = None,
+    ) -> dict[str, Any]:
+        if MEPClient is None:
+            raise RuntimeError("MEPClient is unavailable")
+        source = inbound_message.get("source")
+        if not isinstance(source, dict) or not isinstance(source.get("node_id"), str):
+            raise ValueError("inbound inter-bot message is missing source.node_id")
+        inbound_intent = inbound_message.get("intent")
+        conversation = inbound_message.get("conversation")
+        inbound_priority = (
+            inbound_intent.get("priority")
+            if isinstance(inbound_intent, dict) and isinstance(inbound_intent.get("priority"), str)
+            else "normal"
+        )
+        inbound_turn_type = conversation.get("turn_type") if isinstance(conversation, dict) else None
+        return self._build_interbot_message(
+            reply_text,
+            source["node_id"],
+            context_id=conversation.get("context_id") if isinstance(conversation, dict) else str(uuid.uuid4()),
+            reply_to_task_id=inbound_task_id,
+            reply_to_message_id=inbound_message.get("message_id")
+            if isinstance(inbound_message.get("message_id"), str)
+            else None,
+            turn_type=turn_type or MEPClient._default_reply_turn_type(inbound_turn_type),
+            intent_type=intent_type
+            or MEPClient._default_reply_intent_type(
+                inbound_intent.get("type") if isinstance(inbound_intent, dict) else None
+            ),
+            priority=priority or inbound_priority,
+            trace_id=inbound_message.get("trace_id") if isinstance(inbound_message.get("trace_id"), str) else None,
+            session_safety=MEPClient._extract_session_safety_from_message(inbound_message),
+            turn_index=MEPClient._derive_reply_turn_index(inbound_message),
+        )
+
+    def _build_checkpoint_message(
+        self,
+        summary: str,
+        target_node: str,
+        *,
+        context_id: str,
+        reply_to_task_id: Optional[str],
+        reply_to_message_id: Optional[str],
+        priority: str,
+        session_safety: Optional[dict[str, Any]],
+        turn_index: Optional[int],
+        trace_id: Optional[str],
+    ) -> dict[str, Any]:
+        return self._build_interbot_message(
+            summary,
+            target_node,
+            context_id=context_id,
+            reply_to_task_id=reply_to_task_id,
+            reply_to_message_id=reply_to_message_id,
+            turn_type="checkpoint",
+            intent_type="coordination.request",
+            priority=priority,
+            trace_id=trace_id,
+            session_safety=session_safety,
+            turn_index=turn_index,
+        )
+
+    def _submit_structured_interbot_message(self, envelope: dict[str, Any]) -> tuple[bool, dict[str, Any], str]:
+        target = envelope.get("target", {})
+        target_node = target.get("node_id") if isinstance(target, dict) else None
+        if not isinstance(target_node, str) or not target_node:
+            return False, {}, "missing target.node_id"
+        outer = build_task_envelope(self.node_id, json.dumps(envelope), 0.0, target_node=target_node)
+        payload = json.dumps(outer)
+        code, body, raw = _safe_request(
+            "POST",
+            f"{self.hub_url}/tasks/submit",
+            data_body=payload,
+            headers=self._auth_headers(payload),
+            timeout=20.0,
+        )
+        if code == 200 and body:
+            return True, body, raw
+        return False, body or {}, raw
+
+    async def _submit_safe_structured_dm_reply(
+        self,
+        reply_text: str,
+        inbound_message: dict[str, Any],
+        *,
+        inbound_task_id: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        if MEPClient is None or not self._can_use_structured_dm_fallback(inbound_message):
+            return None
+        next_turn_index = MEPClient._derive_reply_turn_index(inbound_message)
+        if next_turn_index is None:
+            return None
+        evaluation = MEPClient.evaluate_interbot_session_safety_message(
+            inbound_message,
+            next_turn_index=next_turn_index,
+        )
+        context_id = MEPClient._extract_context_id(inbound_message)
+        session_safety = MEPClient._extract_session_safety_from_message(inbound_message)
+        if evaluation["should_stop"]:
+            return {
+                "status": "stopped",
+                "reply_action": "stop",
+                "context_id": context_id,
+                "session_safety": session_safety,
+                "safety": evaluation,
+            }
+        source = inbound_message.get("source")
+        if not isinstance(source, dict) or not isinstance(source.get("node_id"), str):
+            return None
+        inbound_priority = inbound_message.get("intent", {}).get("priority") if isinstance(inbound_message.get("intent"), dict) else "normal"
+        if evaluation["should_checkpoint"]:
+            envelope = self._build_checkpoint_message(
+                f"Checkpoint: session reached turn {next_turn_index}. Confirm whether to continue.",
+                source["node_id"],
+                context_id=context_id or str(uuid.uuid4()),
+                reply_to_task_id=inbound_task_id,
+                reply_to_message_id=inbound_message.get("message_id")
+                if isinstance(inbound_message.get("message_id"), str)
+                else None,
+                priority=inbound_priority if isinstance(inbound_priority, str) else "normal",
+                session_safety=session_safety,
+                turn_index=next_turn_index,
+                trace_id=inbound_message.get("trace_id") if isinstance(inbound_message.get("trace_id"), str) else None,
+            )
+            ok, body, raw = self._submit_structured_interbot_message(envelope)
+            if not ok:
+                print(f"[mep run] structured checkpoint failed context={context_id} detail={raw}")
+                return None
+            return {
+                "status": "checkpointed",
+                "reply_action": "checkpoint",
+                "context_id": context_id,
+                "message_id": envelope["message_id"],
+                "trace_id": envelope["trace_id"],
+                "task_id": body.get("task_id"),
+                "session_safety": session_safety,
+                "safety": evaluation,
+            }
+        envelope = self._build_interbot_reply_message(reply_text, inbound_message, inbound_task_id=inbound_task_id)
+        ok, body, raw = self._submit_structured_interbot_message(envelope)
+        if not ok:
+            print(f"[mep run] structured dm reply failed context={context_id} detail={raw}")
+            return None
+        return {
+            "status": "replied",
+            "reply_action": "reply",
+            "context_id": context_id,
+            "message_id": envelope["message_id"],
+            "trace_id": envelope["trace_id"],
+            "task_id": body.get("task_id"),
+            "session_safety": session_safety,
+            "safety": evaluation,
+        }
+
+    @staticmethod
+    def _dm_fallback_settlement(task_id: str, dm_response: dict[str, Any]) -> str:
+        action = dm_response.get("reply_action", "unknown")
+        context_id = dm_response.get("context_id") or "unknown"
+        if action == "reply":
+            return (
+                "DM_REPLY_SENT\n"
+                f"context={context_id}\n"
+                f"reply_task={dm_response.get('task_id') or '?'}\n"
+                f"origin_task={task_id[:8]}"
+            )
+        if action == "checkpoint":
+            return (
+                "DM_CHECKPOINT_SENT\n"
+                f"context={context_id}\n"
+                f"reply_task={dm_response.get('task_id') or '?'}\n"
+                f"origin_task={task_id[:8]}"
+            )
+        violations = ",".join(dm_response.get("safety", {}).get("violations", [])) or "session_limits"
+        return (
+            "DM_REPLY_STOPPED\n"
+            f"context={context_id}\n"
+            f"reason={violations}\n"
+            f"origin_task={task_id[:8]}"
+        )
+
     async def process_task(self, task_data: dict[str, Any]) -> None:
         task_id = str(task_data.get("id") or "")
         payload = str(task_data.get("payload") or "")
-        result = self.adapter.generate_reply(payload, task_data)
+        instructions = payload
+        interbot_message: Optional[dict[str, Any]] = None
+        if MEPClient is not None:
+            instructions, interbot_message = MEPClient.extract_interbot_instructions(payload)
+        result = self.adapter.generate_reply(instructions, task_data)
+        if self._bridge_eligible_interbot_message(task_data, interbot_message):
+            bridged = await self._attempt_live_call_bridge(task_data, interbot_message, result)
+            if bridged:
+                return
+        dm_response = await self._submit_safe_structured_dm_reply(
+            result,
+            interbot_message,
+            inbound_task_id=task_id,
+        )
+        if dm_response is not None:
+            self.complete(task_id, self._dm_fallback_settlement(task_id, dm_response))
+            return
         self.complete(task_id, result)
 
     def _ws_uri(self) -> str:
@@ -404,7 +888,9 @@ class RuntimeNode:
             if task_id and self.should_bid(task):
                 self.bid(task_id)
         elif event == "new_task":
-            await self.process_task(data.get("data", {}))
+            self._schedule_background_task(self.process_task(data.get("data", {})), label="process_task")
+        elif isinstance(event, str) and event.startswith("call."):
+            await self._handle_call_event(data)
 
     async def _recv_loop(self, ws: Any) -> None:
         while self.running:
@@ -434,6 +920,7 @@ class RuntimeNode:
             uri = self._ws_uri()
             try:
                 async with ws_connect(uri) as ws:
+                    self._ws = ws
                     print(f"[mep run] connected ws node={self.node_id}")
                     await self._recv_loop(ws)
             except KeyboardInterrupt:
@@ -441,6 +928,9 @@ class RuntimeNode:
             except Exception as exc:  # noqa: BLE001
                 print(f"[mep run] websocket reconnect after error: {exc}")
                 await asyncio.sleep(3.0)
+            finally:
+                self._ws = None
+                self._cancel_pending_call_bridges("socket_closed")
         return 0
 
 

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -47,6 +47,7 @@ class _FakeWebSocket:
     def __init__(self, messages):
         self.messages = list(messages)
         self.pings = 0
+        self.sent = []
 
     async def recv(self):
         item = self.messages.pop(0)
@@ -56,6 +57,9 @@ class _FakeWebSocket:
 
     async def ping(self):
         self.pings += 1
+
+    async def send(self, payload):
+        self.sent.append(payload)
 
 
 class _FakeRuntime:
@@ -252,6 +256,236 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
 
         self.assertEqual(ws.pings, 1)
         bid_mock.assert_called_once_with("task_compute")
+
+    def test_process_task_uses_interbot_instructions_for_adapter_input(self):
+        node = _runtime_node()
+        task_data = {
+            "id": "task_interbot",
+            "bounty": 0.0,
+            "payload": json.dumps(
+                {
+                    "spec_version": "mep.interbot.v1",
+                    "message_id": "msg-1",
+                    "trace_id": "trace-1",
+                    "source": {"node_id": "node_peer"},
+                    "target": {"node_id": node.node_id},
+                    "conversation": {"context_id": "ctx-1"},
+                    "intent": {"type": "chat.request", "priority": "normal"},
+                    "task": {"instructions": "Use only this instruction text."},
+                    "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+                    "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+                }
+            ),
+        }
+        with (
+            patch.object(node.adapter, "generate_reply", return_value="reply") as adapter_mock,
+            patch.object(node, "complete") as complete_mock,
+        ):
+            asyncio.run(node.process_task(task_data))
+
+        adapter_mock.assert_called_once_with("Use only this instruction text.", task_data)
+        complete_mock.assert_called_once_with("task_interbot", "reply")
+
+    def test_process_task_live_bridge_sends_frame_and_settles_when_call_is_accepted(self):
+        node = _runtime_node()
+        node.live_call_enabled = True
+        node.dm_to_call_bridge_enabled = True
+        node._ws = _FakeWebSocket([])
+        node.call_invite_timeout_ms = 100
+
+        task_data = {
+            "id": "task_bridge",
+            "bounty": 0.0,
+            "payload": json.dumps(
+                {
+                    "spec_version": "mep.interbot.v1",
+                    "message_id": "msg-bridge",
+                    "trace_id": "trace-bridge",
+                    "source": {"node_id": "node_peer"},
+                    "target": {"node_id": node.node_id},
+                    "conversation": {"context_id": "ctx-bridge"},
+                    "intent": {"type": "chat.request", "priority": "normal"},
+                    "task": {"instructions": "Reply over live call."},
+                    "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+                    "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+                }
+            ),
+        }
+
+        async def _run() -> None:
+            with (
+                patch.object(node.adapter, "generate_reply", return_value="Live reply"),
+                patch.object(node, "complete") as complete_mock,
+            ):
+                task = asyncio.create_task(node.process_task(task_data))
+                await asyncio.sleep(0)
+                invite = json.loads(node._ws.sent[0])
+                self.assertEqual(invite["event"], "call.invite")
+                self.assertEqual(invite["context_id"], "ctx-bridge")
+                self.assertEqual(invite["callee"], "node_peer")
+
+                await node.handle_ws_event({"event": "call.accepted", "context_id": "ctx-bridge"})
+                await task
+
+                events = [json.loads(payload)["event"] for payload in node._ws.sent]
+                self.assertEqual(events, ["call.invite", "call.frame", "call.hangup"])
+                complete_mock.assert_called_once()
+                settled_payload = complete_mock.call_args.args[1]
+                self.assertIn("LIVE_CALL_BRIDGE_OK", settled_payload)
+                self.assertIn("context=ctx-bridge", settled_payload)
+
+        asyncio.run(_run())
+
+    def test_process_task_live_bridge_falls_back_to_task_result_when_call_is_declined(self):
+        node = _runtime_node()
+        node.live_call_enabled = True
+        node.dm_to_call_bridge_enabled = True
+        node._ws = _FakeWebSocket([])
+        node.call_invite_timeout_ms = 100
+
+        task_data = {
+            "id": "task_bridge_declined",
+            "bounty": 0.0,
+            "payload": json.dumps(
+                {
+                    "spec_version": "mep.interbot.v1",
+                    "message_id": "msg-bridge-declined",
+                    "trace_id": "trace-bridge-declined",
+                    "source": {"node_id": "node_peer"},
+                    "target": {"node_id": node.node_id},
+                    "conversation": {"context_id": "ctx-bridge-declined"},
+                    "intent": {"type": "chat.request", "priority": "normal"},
+                    "task": {"instructions": "Reply over live call if possible."},
+                    "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+                    "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+                }
+            ),
+        }
+
+        async def _run() -> None:
+            with (
+                patch.object(node.adapter, "generate_reply", return_value="Fallback reply"),
+                patch.object(node, "complete") as complete_mock,
+            ):
+                task = asyncio.create_task(node.process_task(task_data))
+                await asyncio.sleep(0)
+                await node.handle_ws_event(
+                    {"event": "call.declined", "context_id": "ctx-bridge-declined", "reason": "busy"}
+                )
+                await task
+
+                events = [json.loads(payload)["event"] for payload in node._ws.sent]
+                self.assertEqual(events, ["call.invite"])
+                complete_mock.assert_called_once_with("task_bridge_declined", "Fallback reply")
+
+        asyncio.run(_run())
+
+    def test_process_task_live_bridge_decline_falls_back_to_bounded_structured_dm_reply(self):
+        node = _runtime_node()
+        node.live_call_enabled = True
+        node.dm_to_call_bridge_enabled = True
+        node._ws = _FakeWebSocket([])
+        node.call_invite_timeout_ms = 100
+
+        task_data = {
+            "id": "task_bridge_structured",
+            "bounty": 0.0,
+            "payload": json.dumps(
+                {
+                    "spec_version": "mep.interbot.v1",
+                    "message_id": "msg-bridge-structured",
+                    "trace_id": "trace-bridge-structured",
+                    "source": {"node_id": "node_peer"},
+                    "target": {"node_id": node.node_id},
+                    "conversation": {"context_id": "ctx-bridge-structured", "turn_type": "review_request", "turn_index": 1},
+                    "intent": {"type": "review.request", "priority": "high"},
+                    "task": {
+                        "instructions": "Reply over live call if possible, otherwise stay in the bounded DM thread.",
+                        "inputs": {"session_safety": {"max_turns": 4, "checkpoint_interval": 3}},
+                    },
+                    "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+                    "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+                }
+            ),
+        }
+
+        async def _run() -> None:
+            with (
+                patch.object(node.adapter, "generate_reply", return_value="Structured fallback reply"),
+                patch.object(
+                    node,
+                    "_submit_structured_interbot_message",
+                    return_value=(True, {"task_id": "task_reply_out"}, ""),
+                ) as submit_mock,
+                patch.object(node, "complete") as complete_mock,
+            ):
+                task = asyncio.create_task(node.process_task(task_data))
+                await asyncio.sleep(0)
+                await node.handle_ws_event(
+                    {"event": "call.declined", "context_id": "ctx-bridge-structured", "reason": "busy"}
+                )
+                await task
+
+                envelope = submit_mock.call_args.args[0]
+                self.assertEqual(envelope["target"]["node_id"], "node_peer")
+                self.assertEqual(envelope["task"]["instructions"], "Structured fallback reply")
+                self.assertEqual(envelope["conversation"]["context_id"], "ctx-bridge-structured")
+                self.assertEqual(envelope["conversation"]["reply_to_task_id"], "task_bridge_structured")
+                self.assertEqual(envelope["conversation"]["turn_type"], "review_response")
+                self.assertEqual(envelope["conversation"]["turn_index"], 2)
+                complete_mock.assert_called_once()
+                settled_payload = complete_mock.call_args.args[1]
+                self.assertIn("DM_REPLY_SENT", settled_payload)
+                self.assertIn("reply_task=task_reply_out", settled_payload)
+
+        asyncio.run(_run())
+
+    def test_process_task_stops_bounded_structured_dm_reply_when_session_limit_is_exceeded(self):
+        node = _runtime_node()
+        task_data = {
+            "id": "task_stop_structured",
+            "bounty": 0.0,
+            "payload": json.dumps(
+                {
+                    "spec_version": "mep.interbot.v1",
+                    "message_id": "msg-stop-structured",
+                    "trace_id": "trace-stop-structured",
+                    "source": {"node_id": "node_peer"},
+                    "target": {"node_id": node.node_id},
+                    "conversation": {"context_id": "ctx-stop-structured", "turn_type": "chat_turn", "turn_index": 1},
+                    "intent": {"type": "chat.request", "priority": "normal"},
+                    "task": {
+                        "instructions": "This thread is already at its max turn budget.",
+                        "inputs": {"session_safety": {"max_turns": 1}},
+                    },
+                    "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+                    "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+                }
+            ),
+        }
+
+        with (
+            patch.object(node.adapter, "generate_reply", return_value="Should not be sent"),
+            patch.object(node, "_submit_structured_interbot_message") as submit_mock,
+            patch.object(node, "complete") as complete_mock,
+        ):
+            asyncio.run(node.process_task(task_data))
+
+        submit_mock.assert_not_called()
+        complete_mock.assert_called_once()
+        settled_payload = complete_mock.call_args.args[1]
+        self.assertIn("DM_REPLY_STOPPED", settled_payload)
+        self.assertIn("reason=max_turns_exceeded", settled_payload)
+
+    def test_runtime_auto_accepts_incoming_live_call_when_enabled(self):
+        node = _runtime_node()
+        node.live_call_enabled = True
+        node.call_auto_accept = True
+        node._ws = _FakeWebSocket([])
+
+        asyncio.run(node.handle_ws_event({"event": "call.incoming", "context_id": "ctx-auto", "caller": "node_peer"}))
+
+        self.assertEqual([json.loads(payload)["event"] for payload in node._ws.sent], ["call.accept"])
 
 
 class TestRuntimeKeyDirResolution(unittest.TestCase):

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -62,6 +62,17 @@ class _FakeWebSocket:
         self.sent.append(payload)
 
 
+class _FakeConnectContext:
+    def __init__(self, ws):
+        self.ws = ws
+
+    async def __aenter__(self):
+        return self.ws
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
 class _FakeRuntime:
     async def run_forever(self):
         return 0
@@ -256,6 +267,36 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
 
         self.assertEqual(ws.pings, 1)
         bid_mock.assert_called_once_with("task_compute")
+
+    def test_run_forever_cancels_background_tasks_cleanly_on_shutdown(self):
+        node = _runtime_node()
+
+        async def _pending_task() -> None:
+            await asyncio.Event().wait()
+
+        async def _recv_loop(_ws) -> None:
+            node.running = False
+
+        async def _run() -> asyncio.Task:
+            with (
+                patch.object(node, "register", return_value=(True, "registered")),
+                patch.object(node, "_recv_loop", side_effect=_recv_loop),
+                patch("node.ws_connect.ws_connect", return_value=_FakeConnectContext(_FakeWebSocket([]))),
+                patch("builtins.print") as print_mock,
+            ):
+                node._schedule_background_task(_pending_task(), label="pending_shutdown")  # noqa: SLF001
+                pending_task = next(iter(node._background_tasks))  # noqa: SLF001
+                code = await node.run_forever()
+
+            self.assertEqual(code, 0)
+            self.assertTrue(pending_task.cancelled())
+            self.assertFalse(node._background_tasks)  # noqa: SLF001
+            printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list if call.args)
+            self.assertNotIn("background task error", printed)
+            return pending_task
+
+        pending_task = asyncio.run(_run())
+        self.assertTrue(pending_task.cancelled())
 
     def test_process_task_uses_interbot_instructions_for_adapter_input(self):
         node = _runtime_node()

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -336,6 +336,56 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
 
         asyncio.run(_run())
 
+    def test_process_task_live_bridge_falls_back_when_frame_send_fails_after_accept(self):
+        node = _runtime_node()
+        node.live_call_enabled = True
+        node.dm_to_call_bridge_enabled = True
+        node._ws = _FakeWebSocket([])
+        node.call_invite_timeout_ms = 100
+
+        task_data = {
+            "id": "task_bridge_frame_fail",
+            "bounty": 0.0,
+            "payload": json.dumps(
+                {
+                    "spec_version": "mep.interbot.v1",
+                    "message_id": "msg-bridge-frame-fail",
+                    "trace_id": "trace-bridge-frame-fail",
+                    "source": {"node_id": "node_peer"},
+                    "target": {"node_id": node.node_id},
+                    "conversation": {"context_id": "ctx-bridge-frame-fail"},
+                    "intent": {"type": "chat.request", "priority": "normal"},
+                    "task": {"instructions": "Reply over live call unless the frame send fails."},
+                    "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+                    "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+                }
+            ),
+        }
+
+        original_send_ws_event = node._send_ws_event
+
+        async def _send_ws_event(payload):
+            if payload.get("event") == "call.frame":
+                return False
+            return await original_send_ws_event(payload)
+
+        async def _run() -> None:
+            with (
+                patch.object(node.adapter, "generate_reply", return_value="Fallback after frame failure"),
+                patch.object(node, "_send_ws_event", side_effect=_send_ws_event) as send_mock,
+                patch.object(node, "complete") as complete_mock,
+            ):
+                task = asyncio.create_task(node.process_task(task_data))
+                await asyncio.sleep(0)
+                await node.handle_ws_event({"event": "call.accepted", "context_id": "ctx-bridge-frame-fail"})
+                await task
+
+                self.assertEqual(json.loads(node._ws.sent[0])["event"], "call.invite")
+                self.assertEqual(send_mock.await_count, 2)
+                complete_mock.assert_called_once_with("task_bridge_frame_fail", "Fallback after frame failure")
+
+        asyncio.run(_run())
+
     def test_process_task_live_bridge_falls_back_to_task_result_when_call_is_declined(self):
         node = _runtime_node()
         node.live_call_enabled = True

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -23,6 +23,14 @@ class _FakeResponse:
         return self._json_data
 
 
+class _FakeWebSocket:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(payload)
+
+
 class TestSharedMEPClient(unittest.TestCase):
     def test_submit_task_uses_spec_shaped_envelope(self):
         with (
@@ -57,6 +65,25 @@ class TestSharedMEPClient(unittest.TestCase):
             },
         )
         self.assertEqual(body["routing"], {"target_node_id": "node_provider", "target_capability": "text"})
+
+    def test_send_ws_event_uses_active_socket_when_present(self):
+        with patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()):
+            client = MEPClient("unused.pem")
+            ws = _FakeWebSocket()
+            client._active_ws = ws
+
+            sent = asyncio.run(client.send_ws_event({"event": "call.accept", "context_id": "ctx-1"}))
+
+        self.assertTrue(sent)
+        self.assertEqual(json.loads(ws.sent[0]), {"event": "call.accept", "context_id": "ctx-1"})
+
+    def test_send_ws_event_returns_false_without_active_socket(self):
+        with patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()):
+            client = MEPClient("unused.pem")
+
+            sent = asyncio.run(client.send_ws_event({"event": "call.accept", "context_id": "ctx-1"}))
+
+        self.assertFalse(sent)
 
     def test_submit_task_can_send_secret_data_offer(self):
         with (

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -311,6 +311,7 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
                 "event": "call.frame",
                 "context_id": "ctx-live",
                 "seq": 0,
+                "content_type": "text/plain",
                 "payload": "hello over live lane",
             }
         )

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -257,6 +257,66 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
         client.submit_safe_dm_reply.assert_not_awaited()
         print_mock.assert_any_call("[codex] unknown option --bogus")
 
+    async def test_handle_event_auto_accepts_incoming_live_call_when_enabled(self):
+        adapter, client = self._make_adapter()
+        adapter.live_call_enabled = True
+        adapter.call_auto_accept = True
+        client.send_ws_event = AsyncMock(return_value=True)
+
+        with patch("builtins.print") as print_mock:
+            await adapter._handle_event({"event": "call.incoming", "context_id": "ctx-live", "caller": "node_peer"})
+
+        client.send_ws_event.assert_awaited_once_with({"event": "call.accept", "context_id": "ctx-live"})
+        print_mock.assert_any_call("[codex] auto-accepted live call context=ctx-live caller=node_peer")
+
+    async def test_handle_event_replies_to_call_ping(self):
+        adapter, client = self._make_adapter()
+        client.send_ws_event = AsyncMock(return_value=True)
+
+        await adapter._handle_event({"event": "call.ping", "context_id": "ctx-ping"})
+
+        client.send_ws_event.assert_awaited_once_with({"event": "call.pong", "context_id": "ctx-ping"})
+
+    async def test_dispatch_line_mepcall_sends_invite(self):
+        adapter, client = self._make_adapter()
+        client.send_ws_event = AsyncMock(return_value=True)
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line(
+                "mepcall node_peer --context ctx-live --timeout-ms 12000 --grace-ms 4000"
+            )
+
+        self.assertTrue(keep_going)
+        client.send_ws_event.assert_awaited_once_with(
+            {
+                "event": "call.invite",
+                "context_id": "ctx-live",
+                "callee": "node_peer",
+                "timeout_ms": 12000,
+                "reconnect_grace_ms": 4000,
+            }
+        )
+        print_mock.assert_any_call("[codex] live call invite sent context=ctx-live callee=node_peer")
+
+    async def test_dispatch_line_mepcallframe_auto_increments_seq(self):
+        adapter, client = self._make_adapter()
+        client.send_ws_event = AsyncMock(return_value=True)
+
+        with patch("builtins.print") as print_mock:
+            keep_going = await adapter._dispatch_line('mepcallframe ctx-live "hello over live lane"')
+
+        self.assertTrue(keep_going)
+        client.send_ws_event.assert_awaited_once_with(
+            {
+                "event": "call.frame",
+                "context_id": "ctx-live",
+                "seq": 0,
+                "payload": "hello over live lane",
+            }
+        )
+        self.assertEqual(adapter._call_seq_by_context["ctx-live"], 1)
+        print_mock.assert_any_call("[codex] live frame sent context=ctx-live seq=0")
+
     async def test_dispatch_line_dmlist_reports_when_empty(self):
         adapter, _client = self._make_adapter()
 


### PR DESCRIPTION
﻿## Summary

This PR moves MEP toward a more professional conversation model by connecting the durable structured DM lane with the new live `call.*` lane.

It adds the first real bridge in both:

- the autonomous runtime path (`node/mep_runtime.py`)
- the shared stdio/client path (`clients/shared/*`)

The result is a cleaner transport ladder:

1. try live `call.*` when both peers are online
2. fall back to bounded structured DM when the inbound thread explicitly declares session safety
3. preserve task settlement and auditability on the original task

This PR also adds the design / implementation docs and updates operator-facing docs and soak guidance so the feature is usable, not only implemented.

## What Changed

### Runtime bridge

- add opt-in live bridge flags in `node/mep_runtime.py`
- parse inbound `mep.interbot.v1` tasks before reply generation
- attempt `call.invite` for eligible structured DM tasks
- on accept:
  - send reply over `call.frame`
  - end with `call.hangup`
  - settle the origin task with `LIVE_CALL_BRIDGE_OK`
- on bridge failure:
  - use bounded fresh structured DM fallback when `session_safety` exists
  - otherwise preserve the old `task_result` path

### Shared client / stdio adapter

- add a reusable `send_ws_event(...)` helper to `MEPClient`
- let the stdio adapter consume `call.*` events alongside `task_result`
- support:
  - `call.ping` -> `call.pong`
  - incoming live call notifications
  - optional auto-accept
- add a minimal operator command surface:
  - `mepcall`
  - `mepcallaccept`
  - `mepcalldecline`
  - `mepcallframe`
  - `mepcallhangup`

### Docs

- add professional architecture note:
  - `docs/call-bridge/DESIGN.md`
- add focused execution plan:
  - `docs/call-bridge/IMPLEMENTATION_PLAN.md`
- document live-call commands and env flags in `README.md`
- extend `docs/threaded-review/SOAK_RUNBOOK.md` with an optional live-call segment

## Why

Before this PR:

- structured DM was durable and auditable
- `call.*` existed as a hub relay lane
- but the runtime and shared adapter paths did not connect these two well enough

After this PR:

- MEP has a first coherent bridge from durable thread intent to live conversation transport
- bounded structured DM remains available as the safe fallback
- operators now have clear docs and commands for both lanes

## Safety / Boundaries

- live bridge remains opt-in through env flags
- bounded structured DM fallback is only used when the inbound thread declares `session_safety`
- this avoids uncontrolled bot-to-bot reply loops
- original task settlement is preserved for auditability

## Non-Goals

This PR does not attempt to solve everything at once. It does not add:

- multi-party live calls
- persistent storage of every live frame
- full runtime-managed resume orchestration across all adapter types
- a UI layer for live conversation control

## Tests

Ran:

```bash
python -m pytest tests/test_node_runtime.py tests/test_shared_mep_client.py tests/test_stdio_adapter.py -q
```

Current targeted results:

- `tests/test_node_runtime.py`: pass
- `tests/test_shared_mep_client.py`: pass
- `tests/test_stdio_adapter.py`: pass

## Files

Primary implementation:

- `node/mep_runtime.py`
- `clients/shared/mep_client.py`
- `clients/shared/stdio_adapter.py`

Tests:

- `tests/test_node_runtime.py`
- `tests/test_shared_mep_client.py`
- `tests/test_stdio_adapter.py`

Docs:

- `README.md`
- `docs/threaded-review/SOAK_RUNBOOK.md`
- `docs/call-bridge/DESIGN.md`
- `docs/call-bridge/IMPLEMENTATION_PLAN.md`

## Notes

- `node/provider_launch.log` is a local runtime log and is not part of this PR.
- This PR is intentionally one focused bridge slice: architecture, runtime bridge, shared adapter bridge, tests, and operator docs together.
