### PR TITLE
fix(hub): settle task completion atomically

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -426,6 +426,89 @@ def assign_task_if_open(task_id: str, provider_id: str, updated_at: float) -> bo
     _release_conn(conn)
     return updated > 0
 
+def assign_data_task_with_escrow_if_open(task_id: str, provider_id: str, cost: float, updated_at: float) -> dict:
+    """Atomically assign a data-market task and escrow the buyer's SECONDS.
+
+    Data-market payloads are revealed to the provider in the bid response, so the
+    buyer must be charged/escrowed before the route returns secret_data.
+    """
+    conn = _get_conn()
+    cursor = conn.cursor()
+    try:
+        if not _is_postgres():
+            cursor.execute("BEGIN IMMEDIATE")
+        if _is_postgres():
+            cursor.execute(
+                "SELECT status, provider_id, bounty FROM tasks WHERE task_id = %s FOR UPDATE",
+                (task_id,),
+            )
+        else:
+            cursor.execute(
+                "SELECT status, provider_id, bounty FROM tasks WHERE task_id = ?",
+                (task_id,),
+            )
+        row = cursor.fetchone()
+        if not row:
+            conn.rollback()
+            return {"status": "not_found"}
+        status, assigned_provider, bounty = row[0], row[1], float(row[2])
+        if status != "bidding" or assigned_provider is not None:
+            conn.rollback()
+            return {"status": "already_assigned"}
+        if bounty >= 0:
+            conn.rollback()
+            return {"status": "not_data_market"}
+
+        if _is_postgres():
+            cursor.execute(
+                "UPDATE ledger SET balance = balance - %s WHERE node_id = %s AND balance >= %s",
+                (cost, provider_id, cost),
+            )
+        else:
+            cursor.execute(
+                "UPDATE ledger SET balance = balance - ? WHERE node_id = ? AND balance >= ?",
+                (cost, provider_id, cost),
+            )
+        if cursor.rowcount == 0:
+            conn.rollback()
+            return {"status": "insufficient_balance"}
+
+        if _is_postgres():
+            cursor.execute(
+                """
+                INSERT INTO escrows (task_id, consumer_id, provider_id, amount, status, created_at, updated_at)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (task_id) DO NOTHING
+                """,
+                (task_id, provider_id, None, cost, "held", updated_at, updated_at),
+            )
+            cursor.execute(
+                "UPDATE tasks SET provider_id = %s, status = 'assigned', updated_at = %s WHERE task_id = %s AND status = 'bidding' AND provider_id IS NULL",
+                (provider_id, updated_at, task_id),
+            )
+        else:
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO escrows (task_id, consumer_id, provider_id, amount, status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (task_id, provider_id, None, cost, "held", updated_at, updated_at),
+            )
+            cursor.execute(
+                "UPDATE tasks SET provider_id = ?, status = 'assigned', updated_at = ? WHERE task_id = ? AND status = 'bidding' AND provider_id IS NULL",
+                (provider_id, updated_at, task_id),
+            )
+        if cursor.rowcount == 0:
+            conn.rollback()
+            return {"status": "already_assigned"}
+        conn.commit()
+        return {"status": "accepted"}
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        _release_conn(conn)
+
 def cancel_task_if_open(task_id: str, updated_at: float) -> bool:
     conn = _get_conn()
     cursor = conn.cursor()
@@ -758,6 +841,216 @@ def set_idempotency(node_id: str, endpoint: str, idem_key: str, response: dict, 
         )
     conn.commit()
     _release_conn(conn)
+
+def complete_task_atomic(
+    task_id: str,
+    provider_id: str,
+    result_payload: str,
+    updated_at: float,
+    result_uri: Optional[str] = None,
+    idem_node_id: Optional[str] = None,
+    idem_endpoint: Optional[str] = None,
+    idem_key: Optional[str] = None,
+) -> dict:
+    """Complete a task and settle its bounty in one database transaction."""
+    conn = _get_conn()
+    cursor = conn.cursor()
+    try:
+        if not _is_postgres():
+            cursor.execute("BEGIN IMMEDIATE")
+
+        if idem_node_id and idem_endpoint and idem_key:
+            if _is_postgres():
+                cursor.execute(
+                    "SELECT response, status_code FROM idempotency WHERE node_id = %s AND endpoint = %s AND idem_key = %s",
+                    (idem_node_id, idem_endpoint, idem_key),
+                )
+            else:
+                cursor.execute(
+                    "SELECT response, status_code FROM idempotency WHERE node_id = ? AND endpoint = ? AND idem_key = ?",
+                    (idem_node_id, idem_endpoint, idem_key),
+                )
+            existing = cursor.fetchone()
+            if existing:
+                conn.rollback()
+                return {
+                    "status": "idempotent",
+                    "response": json.loads(existing[0]),
+                    "status_code": existing[1],
+                }
+
+        if _is_postgres():
+            cursor.execute(
+                """
+                SELECT task_id, consumer_id, provider_id, payload, bounty, status,
+                       target_node, model_requirement, expires_in_seconds, result_payload,
+                       payload_uri, result_uri, created_at, updated_at
+                FROM tasks
+                WHERE task_id = %s
+                FOR UPDATE
+                """,
+                (task_id,),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT task_id, consumer_id, provider_id, payload, bounty, status,
+                       target_node, model_requirement, expires_in_seconds, result_payload,
+                       payload_uri, result_uri, created_at, updated_at
+                FROM tasks
+                WHERE task_id = ?
+                """,
+                (task_id,),
+            )
+        row = cursor.fetchone()
+        if not row:
+            conn.rollback()
+            return {"status": "not_found"}
+
+        columns = [
+            "task_id", "consumer_id", "provider_id", "payload", "bounty", "status",
+            "target_node", "model_requirement", "expires_in_seconds", "result_payload",
+            "payload_uri", "result_uri", "created_at", "updated_at",
+        ]
+        task = dict(zip(columns, row))
+        task_status = task["status"]
+        assigned_provider = task.get("provider_id")
+        if task_status != "assigned":
+            conn.rollback()
+            return {"status": "not_active", "task_status": task_status}
+        if assigned_provider != provider_id:
+            conn.rollback()
+            return {"status": "assigned_to_other", "assigned_provider": assigned_provider}
+
+        bounty = float(task["bounty"])
+        ledger_events: list[dict] = []
+
+        if bounty > 0:
+            if _is_postgres():
+                cursor.execute(
+                    "SELECT amount, status FROM escrows WHERE task_id = %s FOR UPDATE",
+                    (task_id,),
+                )
+            else:
+                cursor.execute(
+                    "SELECT amount, status FROM escrows WHERE task_id = ?",
+                    (task_id,),
+                )
+            escrow = cursor.fetchone()
+            if not escrow or escrow[1] != "held":
+                conn.rollback()
+                return {"status": "escrow_not_held"}
+            amount = float(escrow[0])
+            if _is_postgres():
+                cursor.execute(
+                    "UPDATE escrows SET provider_id = %s, status = %s, updated_at = %s WHERE task_id = %s AND status = %s",
+                    (provider_id, "released", updated_at, task_id, "held"),
+                )
+                cursor.execute("UPDATE ledger SET balance = balance + %s WHERE node_id = %s", (amount, provider_id))
+            else:
+                cursor.execute(
+                    "UPDATE escrows SET provider_id = ?, status = ?, updated_at = ? WHERE task_id = ? AND status = ?",
+                    (provider_id, "released", updated_at, task_id, "held"),
+                )
+                cursor.execute("UPDATE ledger SET balance = balance + ? WHERE node_id = ?", (amount, provider_id))
+            ledger_events.append({"kind": "ESCROW_RELEASE", "node_id": provider_id, "amount": amount})
+        elif bounty < 0:
+            cost = abs(bounty)
+            if _is_postgres():
+                cursor.execute(
+                    "SELECT consumer_id, amount, status FROM escrows WHERE task_id = %s FOR UPDATE",
+                    (task_id,),
+                )
+            else:
+                cursor.execute(
+                    "SELECT consumer_id, amount, status FROM escrows WHERE task_id = ?",
+                    (task_id,),
+                )
+            escrow = cursor.fetchone()
+            if escrow and escrow[2] == "held":
+                amount = float(escrow[1])
+                if _is_postgres():
+                    cursor.execute(
+                        "UPDATE escrows SET provider_id = %s, status = %s, updated_at = %s WHERE task_id = %s AND status = %s",
+                        (provider_id, "released", updated_at, task_id, "held"),
+                    )
+                    cursor.execute("UPDATE ledger SET balance = balance + %s WHERE node_id = %s", (amount, task["consumer_id"]))
+                else:
+                    cursor.execute(
+                        "UPDATE escrows SET provider_id = ?, status = ?, updated_at = ? WHERE task_id = ? AND status = ?",
+                        (provider_id, "released", updated_at, task_id, "held"),
+                    )
+                    cursor.execute("UPDATE ledger SET balance = balance + ? WHERE node_id = ?", (amount, task["consumer_id"]))
+                ledger_events.append({"kind": "SELL_DATA", "node_id": task["consumer_id"], "amount": amount})
+            else:
+                # Compatibility path for data tasks assigned before bid-time escrow existed.
+                if _is_postgres():
+                    cursor.execute(
+                        "UPDATE ledger SET balance = balance - %s WHERE node_id = %s AND balance >= %s",
+                        (cost, provider_id, cost),
+                    )
+                else:
+                    cursor.execute(
+                        "UPDATE ledger SET balance = balance - ? WHERE node_id = ? AND balance >= ?",
+                        (cost, provider_id, cost),
+                    )
+                if cursor.rowcount == 0:
+                    conn.rollback()
+                    return {"status": "insufficient_balance"}
+                if _is_postgres():
+                    cursor.execute("UPDATE ledger SET balance = balance + %s WHERE node_id = %s", (cost, task["consumer_id"]))
+                else:
+                    cursor.execute("UPDATE ledger SET balance = balance + ? WHERE node_id = ?", (cost, task["consumer_id"]))
+                ledger_events.append({"kind": "BUY_DATA", "node_id": provider_id, "amount": -cost})
+                ledger_events.append({"kind": "SELL_DATA", "node_id": task["consumer_id"], "amount": cost})
+
+        if _is_postgres():
+            cursor.execute(
+                "UPDATE tasks SET provider_id = %s, result_payload = %s, result_uri = %s, status = %s, updated_at = %s WHERE task_id = %s AND status = %s",
+                (provider_id, result_payload, result_uri, "completed", updated_at, task_id, "assigned"),
+            )
+            cursor.execute("SELECT balance FROM ledger WHERE node_id = %s", (provider_id,))
+        else:
+            cursor.execute(
+                "UPDATE tasks SET provider_id = ?, result_payload = ?, result_uri = ?, status = ?, updated_at = ? WHERE task_id = ? AND status = ?",
+                (provider_id, result_payload, result_uri, "completed", updated_at, task_id, "assigned"),
+            )
+            cursor.execute("SELECT balance FROM ledger WHERE node_id = ?", (provider_id,))
+        provider_balance_row = cursor.fetchone()
+        provider_balance = float(provider_balance_row[0]) if provider_balance_row else 0.0
+
+        task["status"] = "completed"
+        task["provider_id"] = provider_id
+        task["result_payload"] = result_payload
+        task["result_uri"] = result_uri
+        task["updated_at"] = updated_at
+
+        response_payload = {"status": "success", "earned": bounty, "new_balance": provider_balance}
+        if idem_node_id and idem_endpoint and idem_key:
+            payload = json.dumps(response_payload)
+            if _is_postgres():
+                cursor.execute(
+                    "INSERT INTO idempotency (node_id, endpoint, idem_key, response, status_code, created_at) VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (node_id, endpoint, idem_key) DO NOTHING",
+                    (idem_node_id, idem_endpoint, idem_key, payload, 200, updated_at),
+                )
+            else:
+                cursor.execute(
+                    "INSERT OR IGNORE INTO idempotency (node_id, endpoint, idem_key, response, status_code, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+                    (idem_node_id, idem_endpoint, idem_key, payload, 200, updated_at),
+                )
+
+        conn.commit()
+        return {
+            "status": "success",
+            "response": response_payload,
+            "task": task,
+            "ledger_events": ledger_events,
+        }
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        _release_conn(conn)
 
 def delete_idempotency_before(cutoff_ts: float) -> int:
     conn = _get_conn()

--- a/hub/main.py
+++ b/hub/main.py
@@ -1388,6 +1388,12 @@ async def _sweep_assigned_timeouts():
         return
     for task in expired_tasks:
         if TIMEOUT_POLICY == "rebroadcast" and not task["target_node"]:
+            if task["bounty"] < 0:
+                refunded = db.refund_escrow(task["task_id"], now)
+                if refunded is not None:
+                    buyer_id = task.get("provider_id") or ""
+                    new_balance = db.get_balance(buyer_id) or 0.0
+                    log_audit("DATA_TIMEOUT_REFUND", buyer_id, refunded, new_balance, task["task_id"])
             if not db.requeue_task_if_assigned(task["task_id"], now):
                 continue
             task_data = {
@@ -1433,6 +1439,12 @@ async def _sweep_assigned_timeouts():
                 db.add_balance(task["consumer_id"], task["bounty"])
             new_balance = db.get_balance(task["consumer_id"])
             log_audit("TIMEOUT_REFUND", task["consumer_id"], task["bounty"], new_balance, task["task_id"])
+        elif task["bounty"] < 0:
+            refunded = db.refund_escrow(task["task_id"], now)
+            if refunded is not None:
+                buyer_id = task.get("provider_id") or ""
+                new_balance = db.get_balance(buyer_id) or 0.0
+                log_audit("DATA_TIMEOUT_REFUND", buyer_id, refunded, new_balance, task["task_id"])
         async with task_lock:
             if task["task_id"] in active_tasks:
                 del active_tasks[task["task_id"]]
@@ -2258,7 +2270,18 @@ async def place_bid(bid: TaskBid, authenticated_node: str = Depends(verify_reque
         if assignment_profile["risk_reasons"]:
             risk_reasons = ", ".join(assignment_profile["risk_reasons"])
             return {"status": "rejected", "detail": f"Provider rejected by risk control: {risk_reasons}"}
-        if not db.assign_task_if_open(bid.task_id, bid.provider_id, time.time()):
+        bounty = task["bounty"]
+        now = time.time()
+        if bounty < 0:
+            cost = abs(float(bounty))
+            assignment = db.assign_data_task_with_escrow_if_open(bid.task_id, bid.provider_id, cost, now)
+            if assignment["status"] == "insufficient_balance":
+                return {"status": "rejected", "detail": "Provider lacks SECONDS to buy this data"}
+            if assignment["status"] != "accepted":
+                return {"status": "rejected", "detail": "Task already assigned to another node"}
+            new_balance = db.get_balance(bid.provider_id) or 0.0
+            log_audit("BUY_DATA_ESCROW", bid.provider_id, -cost, new_balance, bid.task_id)
+        elif not db.assign_task_if_open(bid.task_id, bid.provider_id, now):
             return {"status": "rejected", "detail": "Task already assigned to another node"}
         task["status"] = "assigned"
         task["provider_id"] = bid.provider_id
@@ -2266,7 +2289,6 @@ async def place_bid(bid: TaskBid, authenticated_node: str = Depends(verify_reque
         consumer_id = task["consumer_id"]
         model_requirement = task.get("model_requirement")
         payload_uri = task.get("payload_uri")
-        bounty = task["bounty"]
 
     log_event("bid_accepted", f"Task {bid.task_id[:8]} assigned to {bid.provider_id}", task_id=bid.task_id, provider_id=bid.provider_id, bounty=bounty)
 
@@ -2296,75 +2318,58 @@ async def complete_task(
     if len(result_payload) > MAX_PAYLOAD_CHARS:
         raise HTTPException(status_code=413, detail="Result payload too large")
     
-    if x_mep_idempotency_key:
-        existing = db.get_idempotency(authenticated_node, "/tasks/complete", x_mep_idempotency_key)
-        if existing:
-            return existing["response"]
-
-    async with task_lock:
-        task = active_tasks.get(result.task_id)
-    if not task:
-        db_task = db.get_task(result.task_id)
-        if not db_task or db_task["status"] not in ("bidding", "assigned"):
-            raise HTTPException(status_code=404, detail="Task not found or already claimed")
-        task = {
-            "id": db_task["task_id"],
-            "consumer_id": db_task["consumer_id"],
-            "payload": db_task["payload"],
-            "bounty": db_task["bounty"],
-            "status": db_task["status"],
-            "target_node": db_task["target_node"],
-            "model_requirement": db_task["model_requirement"],
-            "provider_id": db_task["provider_id"],
-            "payload_uri": db_task.get("payload_uri"),
-            "secret_data": db_task.get("result_payload")
-        }
-        async with task_lock:
-            active_tasks[result.task_id] = task
-
-    assigned_provider = task.get("provider_id")
-    if assigned_provider and assigned_provider != result.provider_id:
+    settled = db.complete_task_atomic(
+        result.task_id,
+        result.provider_id,
+        result_payload,
+        time.time(),
+        result_uri=normalized_result_uri,
+        idem_node_id=authenticated_node if x_mep_idempotency_key else None,
+        idem_endpoint="/tasks/complete" if x_mep_idempotency_key else None,
+        idem_key=x_mep_idempotency_key,
+    )
+    if settled["status"] == "idempotent":
+        return settled["response"]
+    if settled["status"] in ("not_found", "not_active"):
+        raise HTTPException(status_code=404, detail="Task not found or already claimed")
+    if settled["status"] == "assigned_to_other":
         raise HTTPException(status_code=409, detail="Task assigned to another provider")
+    if settled["status"] == "insufficient_balance":
+        log_event("data_purchase_failed", f"Provider {result.provider_id} lacks SECONDS to buy {result.task_id}", task_id=result.task_id, provider_id=result.provider_id)
+        raise HTTPException(status_code=400, detail="Provider lacks SECONDS to buy this data")
+    if settled["status"] == "escrow_not_held":
+        raise HTTPException(status_code=409, detail="Escrow is not held for this task")
+    if settled["status"] != "success":
+        raise HTTPException(status_code=409, detail="Task could not be settled")
 
-    provider_balance = db.get_balance(result.provider_id)
-    if provider_balance is None:
-        db.set_balance(result.provider_id, 0.0)
-
-    # Transfer SECONDS based on positive or negative bounty
+    task = settled["task"]
     bounty = task["bounty"]
-    if bounty >= 0:
-        released = db.release_escrow(result.task_id, result.provider_id, time.time())
-        if released is None:
-            db.add_balance(result.provider_id, bounty)
-        new_balance = db.get_balance(result.provider_id)
-        log_audit("ESCROW_RELEASE", result.provider_id, bounty, new_balance, result.task_id)
-    else:
-        # Data Market: Provider PAYS to receive this payload/task
-        cost = abs(bounty)
-        success = db.deduct_balance(result.provider_id, cost)
-        if not success:
-            log_event("data_purchase_failed", f"Provider {result.provider_id} lacks SECONDS to buy {result.task_id}", task_id=result.task_id, provider_id=result.provider_id, cost=cost)
-            raise HTTPException(status_code=400, detail="Provider lacks SECONDS to buy this data")
-
-        p_balance = db.get_balance(result.provider_id) or 0.0
-        log_audit("BUY_DATA", result.provider_id, -cost, p_balance, result.task_id)
-
-        db.add_balance(task["consumer_id"], cost) # The sender earns SECONDS
-        c_balance = db.get_balance(task["consumer_id"]) or 0.0
-        log_audit("SELL_DATA", task["consumer_id"], cost, c_balance, result.task_id)
+    for event in settled.get("ledger_events", []):
+        node_id = event["node_id"]
+        amount = event["amount"]
+        new_balance = db.get_balance(node_id) or 0.0
+        log_audit(event["kind"], node_id, amount, new_balance, result.task_id)
 
     log_event("task_completed", f"Task {result.task_id[:8]} completed by {result.provider_id}", task_id=result.task_id, provider_id=result.provider_id, bounty=bounty)
 
-    # Move task to completed
     async with task_lock:
-        task["status"] = "completed"
-        task["provider_id"] = result.provider_id
-        task["result"] = result_payload
-        task["completed_at"] = time.time()
-        completed_tasks[result.task_id] = task
+        completed_entry = {
+            "id": task["task_id"],
+            "consumer_id": task["consumer_id"],
+            "payload": task["payload"],
+            "bounty": bounty,
+            "status": "completed",
+            "target_node": task.get("target_node"),
+            "model_requirement": task.get("model_requirement"),
+            "provider_id": result.provider_id,
+            "payload_uri": task.get("payload_uri"),
+            "result": result_payload,
+            "result_uri": normalized_result_uri,
+            "completed_at": task["updated_at"],
+        }
+        completed_tasks[result.task_id] = completed_entry
         if result.task_id in active_tasks:
             del active_tasks[result.task_id]
-    db.update_task_result(result.task_id, result.provider_id, result_payload, "completed", time.time(), result_uri=normalized_result_uri)
     await _evict_completed_tasks_cache()
 
     # ROUTE RESULT BACK TO CONSUMER VIA WEBSOCKET
@@ -2380,7 +2385,7 @@ async def complete_task(
                     "provider_id": result.provider_id,
                     "result_payload": result_payload,
                     "result_uri": normalized_result_uri,
-                    "bounty_spent": task["bounty"]
+                    "bounty_spent": bounty
                 }
             })
         except Exception as exc:
@@ -2389,10 +2394,7 @@ async def complete_task(
                 if connected_nodes.get(consumer_id) is consumer_ws:
                     del connected_nodes[consumer_id]
 
-    response_payload = {"status": "success", "earned": task["bounty"], "new_balance": db.get_balance(result.provider_id)}
-    if x_mep_idempotency_key:
-        db.set_idempotency(authenticated_node, "/tasks/complete", x_mep_idempotency_key, response_payload, 200, time.time())
-    return response_payload
+    return settled["response"]
 
 @app.get("/tasks/result/{task_id}")
 async def get_task_result(task_id: str, authenticated_node: str = Depends(verify_request)):

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -4,6 +4,7 @@ No running server or Postgres needed; uses SQLite backend automatically.
 """
 import base64
 from contextlib import contextmanager
+from concurrent.futures import ThreadPoolExecutor
 import json
 import os
 import sys
@@ -200,6 +201,93 @@ class TestTaskLifecycle(unittest.TestCase):
         resp = client.get(f"/balance/{provider_id}")
         self.assertGreater(resp.json()["balance_seconds"], 10.0)  # 10 starting + 1 earned
 
+    def test_duplicate_completion_does_not_double_settle(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "once", "bounty": 1.0})
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(submit.status_code, 200, submit.text)
+        task_id = submit.json()["task_id"]
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "done"})
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        first = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(first.status_code, 200, first.text)
+
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        second = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(second.status_code, 404, second.text)
+
+        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        self.assertEqual(provider_after, provider_before + 1.0)
+        escrow = db.get_escrow(task_id)
+        self.assertEqual(escrow["status"], "released")
+
+    def test_completion_idempotency_replays_response_without_double_settlement(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "idem", "bounty": 1.0})
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+        task_id = submit.json()["task_id"]
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "done"})
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        headers["X-MEP-Idempotency-Key"] = "complete-once"
+        first = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(first.status_code, 200, first.text)
+
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        headers["X-MEP-Idempotency-Key"] = "complete-once"
+        second = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(second.status_code, 200, second.text)
+        self.assertEqual(second.json(), first.json())
+
+        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        self.assertEqual(provider_after, provider_before + 1.0)
+
+    def test_atomic_completion_allows_only_one_concurrent_settlement(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "race", "bounty": 1.0})
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+        task_id = submit.json()["task_id"]
+        self.assertTrue(db.assign_task_if_open(task_id, provider_id, time.time()))
+
+        def settle_once():
+            return db.complete_task_atomic(task_id, provider_id, "done", time.time())
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(lambda _: settle_once(), range(2)))
+
+        statuses = [item["status"] for item in results]
+        self.assertEqual(statuses.count("success"), 1, statuses)
+        self.assertEqual(statuses.count("not_active"), 1, statuses)
+        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        self.assertEqual(provider_after, provider_before + 1.0)
+
     def test_insufficient_balance_rejected(self):
         consumer_priv, consumer_pub, consumer_id = _make_identity()
         _register(consumer_pub)
@@ -375,6 +463,11 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
 
         bid_data = self._bid(buyer_priv, buyer_id, task_id)
         self.assertEqual(bid_data["secret_data"], "encrypted-premium-data")
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
+        escrow = db.get_escrow(task_id)
+        self.assertEqual(escrow["status"], "held")
+        self.assertEqual(escrow["consumer_id"], buyer_id)
+
         result = self._complete(buyer_priv, buyer_id, task_id, "data received")
         self.assertEqual(result["earned"], -0.5)
         self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before + 0.5)
@@ -1174,6 +1267,56 @@ class TestBiddingTimeout(unittest.TestCase):
         resp = client.get(f"/balance/{consumer_id}")
         self.assertEqual(resp.json()["balance_seconds"], initial_balance,
                         "Consumer balance should be restored after refund")
+
+    def test_assigned_data_market_timeout_refunds_buyer_escrow(self):
+        seller_priv, seller_pub, seller_id = _make_identity()
+        buyer_priv, buyer_pub, buyer_id = _make_identity()
+        _register(seller_pub)
+        _register(buyer_pub)
+
+        seller_before = client.get(f"/balance/{seller_id}").json()["balance_seconds"]
+        buyer_before = client.get(f"/balance/{buyer_id}").json()["balance_seconds"]
+        task_payload = json.dumps(
+            {
+                "consumer_id": seller_id,
+                "payload": "Premium dataset",
+                "bounty": -0.5,
+                "secret_data": "encrypted-premium-data",
+            }
+        )
+        headers = _auth_headers(seller_priv, seller_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+        task_id = resp.json()["task_id"]
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": buyer_id})
+        headers = _auth_headers(buyer_priv, buyer_id, bid_payload)
+        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Bid failed: {resp.text}")
+        self.assertEqual(resp.json()["status"], "accepted")
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
+
+        old_time = time.time() - 7200
+        conn = db._get_conn()
+        conn.execute(
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+            (old_time, task_id)
+        )
+        conn.commit()
+        db._release_conn(conn)
+
+        import asyncio
+        from main import _sweep_assigned_timeouts
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(_sweep_assigned_timeouts())
+        finally:
+            loop.close()
+
+        task = db.get_task(task_id)
+        self.assertEqual(task["status"], "expired")
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before)
+        self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before)
 
 
 class TestConsumerDefinedTimeout(unittest.TestCase):


### PR DESCRIPTION
﻿@Hub-Sentinel please review this production-readiness PR.

## Summary
- Move `/tasks/complete` settlement into `db.complete_task_atomic(...)` so task status, escrow release, balance movement, and idempotency response commit together.
- Add data-market bid-time escrow so buyers are charged before `secret_data` is returned.
- Refund data-market buyer escrow on assigned-task timeout/rebroadcast.
- Add regression tests for duplicate completion, idempotent replay, concurrent settlement, data escrow-before-secret, and data timeout refund.

## Review focus
- Verify no double-settlement path remains for concurrent or replayed `/tasks/complete` calls.
- Verify positive-bounty compute settlement requires held escrow and status=`assigned`.
- Verify data-market `secret_data` is not returned until buyer funds are escrowed.
- Verify timeout paths do not strand held data-market escrow.
- Verify no unrelated node/runtime/client behavior changed.

## Tests
- `python -m unittest discover -s C:\Users\Aibing\mep-review\MEP\tests -p test_hub_api.py -v` — 48 tests OK
- `python -m pytest C:\Users\Aibing\mep-review\MEP\tests\test_hub_auth.py -q` — 8 passed
- `python -m ruff check C:\Users\Aibing\mep-review\MEP\hub\db.py C:\Users\Aibing\mep-review\MEP\hub\main.py C:\Users\Aibing\mep-review\MEP\tests\test_hub_api.py` — passed
- `python -m py_compile hub/db.py hub/main.py tests/test_hub_api.py` — passed
