### PR TITLE
feat(hub): gate settlement on verifier acceptance

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -94,6 +94,20 @@ def _ensure_tasks_envelope_json_column(cursor):
         if "envelope_json" not in columns:
             cursor.execute("ALTER TABLE tasks ADD COLUMN envelope_json TEXT")
 
+
+def _ensure_tasks_verifier_type_column(cursor):
+    if _is_postgres():
+        cursor.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = 'tasks' AND column_name = 'verifier_type'"
+        )
+        if not cursor.fetchone():
+            cursor.execute("ALTER TABLE tasks ADD COLUMN verifier_type TEXT")
+    else:
+        cursor.execute("PRAGMA table_info(tasks)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if "verifier_type" not in columns:
+            cursor.execute("ALTER TABLE tasks ADD COLUMN verifier_type TEXT")
+
 def init_db():
     conn = _get_conn()
     cursor = conn.cursor()
@@ -118,12 +132,14 @@ def init_db():
             result_payload TEXT,
             payload_uri TEXT,
             result_uri TEXT,
+            verifier_type TEXT,
             created_at REAL NOT NULL,
             updated_at REAL NOT NULL
         )
     ''')
     _ensure_tasks_expires_in_seconds_column(cursor)
     _ensure_tasks_envelope_json_column(cursor)
+    _ensure_tasks_verifier_type_column(cursor)
     if not _is_postgres():
         try:
             cursor.execute("ALTER TABLE tasks ADD COLUMN payload_uri TEXT")
@@ -326,18 +342,19 @@ def create_task(
     result_payload: Optional[str] = None,
     payload_uri: Optional[str] = None,
     expires_in_seconds: Optional[int] = None,
+    verifier_type: Optional[str] = None,
 ):
     conn = _get_conn()
     cursor = conn.cursor()
     if _is_postgres():
         cursor.execute(
-            "INSERT INTO tasks (task_id, consumer_id, provider_id, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, created_at, updated_at) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-            (task_id, consumer_id, None, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, created_at, created_at)
+            "INSERT INTO tasks (task_id, consumer_id, provider_id, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, verifier_type, created_at, updated_at) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            (task_id, consumer_id, None, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, verifier_type, created_at, created_at)
         )
     else:
         cursor.execute(
-            "INSERT INTO tasks (task_id, consumer_id, provider_id, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (task_id, consumer_id, None, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, created_at, created_at)
+            "INSERT INTO tasks (task_id, consumer_id, provider_id, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, verifier_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (task_id, consumer_id, None, payload, bounty, status, target_node, model_requirement, expires_in_seconds, result_payload, payload_uri, verifier_type, created_at, created_at)
         )
     conn.commit()
     _release_conn(conn)
@@ -391,6 +408,120 @@ def update_task_result(task_id: str, provider_id: str, result_payload: str, stat
         )
     conn.commit()
     _release_conn(conn)
+
+def submit_task_result_for_verification(
+    task_id: str,
+    provider_id: str,
+    result_payload: str,
+    updated_at: float,
+    result_uri: Optional[str] = None,
+    idem_node_id: Optional[str] = None,
+    idem_endpoint: Optional[str] = None,
+    idem_key: Optional[str] = None,
+    expected_status: str = "assigned",
+) -> dict:
+    """Store a provider result without releasing escrow until the verifier accepts."""
+    conn = _get_conn()
+    cursor = conn.cursor()
+    try:
+        if not _is_postgres():
+            cursor.execute("BEGIN IMMEDIATE")
+
+        if idem_node_id and idem_endpoint and idem_key:
+            if _is_postgres():
+                cursor.execute(
+                    "SELECT response, status_code FROM idempotency WHERE node_id = %s AND endpoint = %s AND idem_key = %s",
+                    (idem_node_id, idem_endpoint, idem_key),
+                )
+            else:
+                cursor.execute(
+                    "SELECT response, status_code FROM idempotency WHERE node_id = ? AND endpoint = ? AND idem_key = ?",
+                    (idem_node_id, idem_endpoint, idem_key),
+                )
+            existing = cursor.fetchone()
+            if existing:
+                conn.rollback()
+                return {
+                    "status": "idempotent",
+                    "response": json.loads(existing[0]),
+                    "status_code": existing[1],
+                }
+
+        if _is_postgres():
+            cursor.execute(
+                "SELECT provider_id, status, verifier_type FROM tasks WHERE task_id = %s FOR UPDATE",
+                (task_id,),
+            )
+        else:
+            cursor.execute(
+                "SELECT provider_id, status, verifier_type FROM tasks WHERE task_id = ?",
+                (task_id,),
+            )
+        row = cursor.fetchone()
+        if not row:
+            conn.rollback()
+            return {"status": "not_found"}
+        assigned_provider, task_status, verifier_type = row[0], row[1], row[2]
+        if verifier_type != "manual_acceptance":
+            conn.rollback()
+            return {"status": "not_verifier_gated"}
+        if task_status == "submitted_result" and assigned_provider == provider_id:
+            response_payload = {"status": "pending_verification", "task_id": task_id, "verifier_type": verifier_type}
+            if idem_node_id and idem_endpoint and idem_key:
+                payload = json.dumps(response_payload)
+                if _is_postgres():
+                    cursor.execute(
+                        "INSERT INTO idempotency (node_id, endpoint, idem_key, response, status_code, created_at) VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (node_id, endpoint, idem_key) DO NOTHING",
+                        (idem_node_id, idem_endpoint, idem_key, payload, 200, updated_at),
+                    )
+                else:
+                    cursor.execute(
+                        "INSERT OR IGNORE INTO idempotency (node_id, endpoint, idem_key, response, status_code, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+                        (idem_node_id, idem_endpoint, idem_key, payload, 200, updated_at),
+                    )
+            conn.commit()
+            return {"status": "pending_verification", "response": response_payload}
+        if task_status != expected_status:
+            conn.rollback()
+            return {"status": "not_active", "task_status": task_status}
+        if assigned_provider != provider_id:
+            conn.rollback()
+            return {"status": "assigned_to_other", "assigned_provider": assigned_provider}
+
+        if _is_postgres():
+            cursor.execute(
+                "UPDATE tasks SET result_payload = %s, result_uri = %s, status = %s, updated_at = %s WHERE task_id = %s AND status = %s AND provider_id = %s",
+                (result_payload, result_uri, "submitted_result", updated_at, task_id, "assigned", provider_id),
+            )
+        else:
+            cursor.execute(
+                "UPDATE tasks SET result_payload = ?, result_uri = ?, status = ?, updated_at = ? WHERE task_id = ? AND status = ? AND provider_id = ?",
+                (result_payload, result_uri, "submitted_result", updated_at, task_id, "assigned", provider_id),
+            )
+        if cursor.rowcount == 0:
+            conn.rollback()
+            return {"status": "not_active", "task_status": task_status}
+
+        response_payload = {"status": "pending_verification", "task_id": task_id, "verifier_type": verifier_type}
+        if idem_node_id and idem_endpoint and idem_key:
+            payload = json.dumps(response_payload)
+            if _is_postgres():
+                cursor.execute(
+                    "INSERT INTO idempotency (node_id, endpoint, idem_key, response, status_code, created_at) VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (node_id, endpoint, idem_key) DO NOTHING",
+                    (idem_node_id, idem_endpoint, idem_key, payload, 200, updated_at),
+                )
+            else:
+                cursor.execute(
+                    "INSERT OR IGNORE INTO idempotency (node_id, endpoint, idem_key, response, status_code, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+                    (idem_node_id, idem_endpoint, idem_key, payload, 200, updated_at),
+                )
+        conn.commit()
+        return {"status": "pending_verification", "response": response_payload}
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        _release_conn(conn)
 
 def update_task_status(task_id: str, status: str, updated_at: float):
     conn = _get_conn()
@@ -851,6 +982,7 @@ def complete_task_atomic(
     idem_node_id: Optional[str] = None,
     idem_endpoint: Optional[str] = None,
     idem_key: Optional[str] = None,
+    expected_status: str = "assigned",
 ) -> dict:
     """Complete a task and settle its bounty in one database transaction."""
     conn = _get_conn()
@@ -884,7 +1016,7 @@ def complete_task_atomic(
                 """
                 SELECT task_id, consumer_id, provider_id, payload, bounty, status,
                        target_node, model_requirement, expires_in_seconds, result_payload,
-                       payload_uri, result_uri, created_at, updated_at
+                       payload_uri, result_uri, verifier_type, created_at, updated_at
                 FROM tasks
                 WHERE task_id = %s
                 FOR UPDATE
@@ -896,7 +1028,7 @@ def complete_task_atomic(
                 """
                 SELECT task_id, consumer_id, provider_id, payload, bounty, status,
                        target_node, model_requirement, expires_in_seconds, result_payload,
-                       payload_uri, result_uri, created_at, updated_at
+                       payload_uri, result_uri, verifier_type, created_at, updated_at
                 FROM tasks
                 WHERE task_id = ?
                 """,
@@ -910,12 +1042,12 @@ def complete_task_atomic(
         columns = [
             "task_id", "consumer_id", "provider_id", "payload", "bounty", "status",
             "target_node", "model_requirement", "expires_in_seconds", "result_payload",
-            "payload_uri", "result_uri", "created_at", "updated_at",
+            "payload_uri", "result_uri", "verifier_type", "created_at", "updated_at",
         ]
         task = dict(zip(columns, row))
         task_status = task["status"]
         assigned_provider = task.get("provider_id")
-        if task_status != "assigned":
+        if task_status != expected_status:
             conn.rollback()
             return {"status": "not_active", "task_status": task_status}
         if assigned_provider != provider_id:
@@ -1007,13 +1139,13 @@ def complete_task_atomic(
         if _is_postgres():
             cursor.execute(
                 "UPDATE tasks SET provider_id = %s, result_payload = %s, result_uri = %s, status = %s, updated_at = %s WHERE task_id = %s AND status = %s",
-                (provider_id, result_payload, result_uri, "completed", updated_at, task_id, "assigned"),
+                (provider_id, result_payload, result_uri, "completed", updated_at, task_id, expected_status),
             )
             cursor.execute("SELECT balance FROM ledger WHERE node_id = %s", (provider_id,))
         else:
             cursor.execute(
                 "UPDATE tasks SET provider_id = ?, result_payload = ?, result_uri = ?, status = ?, updated_at = ? WHERE task_id = ? AND status = ?",
-                (provider_id, result_payload, result_uri, "completed", updated_at, task_id, "assigned"),
+                (provider_id, result_payload, result_uri, "completed", updated_at, task_id, expected_status),
             )
             cursor.execute("SELECT balance FROM ledger WHERE node_id = ?", (provider_id,))
         provider_balance_row = cursor.fetchone()

--- a/hub/main.py
+++ b/hub/main.py
@@ -26,6 +26,7 @@ from models import (
     TaskResult,
     TaskBid,
     TaskCancel,
+    TaskVerificationAccept,
     RegistryUpdate,
     AvailabilityUpdate,
     RegistryHeartbeat,
@@ -478,6 +479,7 @@ async def _load_active_tasks_from_db():
             "status": task["status"],
             "target_node": task["target_node"],
             "model_requirement": task["model_requirement"],
+            "verifier_type": task.get("verifier_type"),
             "expires_in_seconds": task.get("expires_in_seconds"),
             "provider_id": task["provider_id"],
             "payload_uri": task.get("payload_uri"),
@@ -685,6 +687,22 @@ def _task_target_capability(task: TaskCreate) -> Optional[str]:
     if isinstance(task.model_requirement, str) and task.model_requirement.strip():
         return task.model_requirement.strip()
     return None
+
+
+def _task_verifier_type(task: TaskCreate) -> Optional[str]:
+    verifier_type = task.verifier_type
+    if verifier_type is None and isinstance(task.verifier, dict):
+        verifier_type = task.verifier.get("type")
+    if verifier_type is None and isinstance(task.task, dict) and isinstance(task.task.get("verifier"), dict):
+        verifier_type = task.task["verifier"].get("type")
+    if verifier_type is None:
+        return None
+    normalized = str(verifier_type).strip().lower()
+    if not normalized:
+        return None
+    if normalized not in {"manual_acceptance"}:
+        raise HTTPException(status_code=400, detail="Unsupported verifier_type")
+    return normalized
 
 
 async def _coerce_live_availability(node_id: str, availability: Optional[str]) -> Optional[str]:
@@ -1404,6 +1422,7 @@ async def _sweep_assigned_timeouts():
                 "status": "bidding",
                 "target_node": task["target_node"],
                 "model_requirement": task["model_requirement"],
+                "verifier_type": task.get("verifier_type"),
                 "expires_in_seconds": task.get("expires_in_seconds"),
                 "payload_uri": task.get("payload_uri"),
                 "secret_data": task.get("result_payload")
@@ -2024,6 +2043,7 @@ async def submit_task(
         raise HTTPException(status_code=413, detail="Task payload too large")
     target_node = _task_target_node(task)
     target_capability = _task_target_capability(task)
+    verifier_type = _task_verifier_type(task)
     economics = _task_economics(task)
     bounty = float(economics["bounty_seconds"])
     if task.task or task.economics or task.source or task.routing:
@@ -2084,6 +2104,7 @@ async def submit_task(
         "economics": economics,
         "target_node": target_node,
         "model_requirement": target_capability,
+        "verifier_type": verifier_type,
         "expires_in_seconds": task.expires_in_seconds,
         "payload_uri": normalized_payload_uri,
         "secret_data": task.secret_data
@@ -2100,6 +2121,7 @@ async def submit_task(
         result_payload=task.secret_data,
         payload_uri=normalized_payload_uri,
         expires_in_seconds=task.expires_in_seconds,
+        verifier_type=verifier_type,
     )
     async with task_lock:
         active_tasks[task_id] = task_data
@@ -2302,6 +2324,62 @@ async def place_bid(bid: TaskBid, authenticated_node: str = Depends(verify_reque
         "assignment_score": assignment_profile["assignment_score"]
     }
 
+async def _finalize_settled_task(settled: dict, task_id: str, provider_id: str, result_payload: str, result_uri: Optional[str]):
+    task = settled["task"]
+    bounty = task["bounty"]
+    for event in settled.get("ledger_events", []):
+        node_id = event["node_id"]
+        amount = event["amount"]
+        new_balance = db.get_balance(node_id) or 0.0
+        log_audit(event["kind"], node_id, amount, new_balance, task_id)
+
+    log_event("task_completed", f"Task {task_id[:8]} completed by {provider_id}", task_id=task_id, provider_id=provider_id, bounty=bounty)
+
+    async with task_lock:
+        completed_entry = {
+            "id": task["task_id"],
+            "consumer_id": task["consumer_id"],
+            "payload": task["payload"],
+            "bounty": bounty,
+            "status": "completed",
+            "target_node": task.get("target_node"),
+            "model_requirement": task.get("model_requirement"),
+            "verifier_type": task.get("verifier_type"),
+            "provider_id": provider_id,
+            "payload_uri": task.get("payload_uri"),
+            "result": result_payload,
+            "result_uri": result_uri,
+            "completed_at": task["updated_at"],
+        }
+        completed_tasks[task_id] = completed_entry
+        if task_id in active_tasks:
+            del active_tasks[task_id]
+    await _evict_completed_tasks_cache()
+
+    consumer_id = task["consumer_id"]
+    async with node_lock:
+        consumer_ws = connected_nodes.get(consumer_id)
+    if consumer_ws:
+        try:
+            await consumer_ws.send_json({
+                "event": "task_result",
+                "data": {
+                    "task_id": task_id,
+                    "provider_id": provider_id,
+                    "result_payload": result_payload,
+                    "result_uri": result_uri,
+                    "bounty_spent": bounty
+                }
+            })
+        except Exception as exc:
+            log_event("deliver_result_failed", f"Failed to deliver result {task_id[:8]} to {consumer_id}: {exc}", task_id=task_id, consumer_id=consumer_id)
+            async with node_lock:
+                if connected_nodes.get(consumer_id) is consumer_ws:
+                    del connected_nodes[consumer_id]
+
+    return settled["response"]
+
+
 @app.post("/tasks/complete")
 async def complete_task(
     result: TaskResult,
@@ -2318,6 +2396,35 @@ async def complete_task(
     if len(result_payload) > MAX_PAYLOAD_CHARS:
         raise HTTPException(status_code=413, detail="Result payload too large")
     
+    task = db.get_task(result.task_id)
+    if task and task.get("verifier_type") == "manual_acceptance":
+        submitted = db.submit_task_result_for_verification(
+            result.task_id,
+            result.provider_id,
+            result_payload,
+            time.time(),
+            result_uri=normalized_result_uri,
+            idem_node_id=authenticated_node if x_mep_idempotency_key else None,
+            idem_endpoint="/tasks/complete" if x_mep_idempotency_key else None,
+            idem_key=x_mep_idempotency_key,
+        )
+        if submitted["status"] == "idempotent":
+            return submitted["response"]
+        if submitted["status"] in ("not_found", "not_active"):
+            raise HTTPException(status_code=404, detail="Task not found or already claimed")
+        if submitted["status"] == "assigned_to_other":
+            raise HTTPException(status_code=409, detail="Task assigned to another provider")
+        if submitted["status"] != "pending_verification":
+            raise HTTPException(status_code=409, detail="Task result could not be submitted for verification")
+
+        async with task_lock:
+            if result.task_id in active_tasks:
+                active_tasks[result.task_id]["status"] = "submitted_result"
+                active_tasks[result.task_id]["result"] = result_payload
+                active_tasks[result.task_id]["result_uri"] = normalized_result_uri
+        log_event("task_result_submitted", f"Task {result.task_id[:8]} submitted for verification", task_id=result.task_id, provider_id=result.provider_id)
+        return submitted["response"]
+
     settled = db.complete_task_atomic(
         result.task_id,
         result.provider_id,
@@ -2342,59 +2449,55 @@ async def complete_task(
     if settled["status"] != "success":
         raise HTTPException(status_code=409, detail="Task could not be settled")
 
-    task = settled["task"]
-    bounty = task["bounty"]
-    for event in settled.get("ledger_events", []):
-        node_id = event["node_id"]
-        amount = event["amount"]
-        new_balance = db.get_balance(node_id) or 0.0
-        log_audit(event["kind"], node_id, amount, new_balance, result.task_id)
+    return await _finalize_settled_task(settled, result.task_id, result.provider_id, result_payload, normalized_result_uri)
 
-    log_event("task_completed", f"Task {result.task_id[:8]} completed by {result.provider_id}", task_id=result.task_id, provider_id=result.provider_id, bounty=bounty)
+@app.post("/tasks/verify/accept")
+async def accept_verified_task(
+    verification: TaskVerificationAccept,
+    authenticated_node: str = Depends(verify_request),
+    x_mep_idempotency_key: Optional[str] = Header(default=None)
+):
+    task = db.get_task(verification.task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    if authenticated_node != task["consumer_id"]:
+        raise HTTPException(status_code=403, detail="Only the consumer can accept a submitted result")
+    if task.get("verifier_type") != "manual_acceptance":
+        raise HTTPException(status_code=400, detail="Task is not verifier-gated")
+    if task["status"] != "submitted_result" and not x_mep_idempotency_key:
+        raise HTTPException(status_code=400, detail="Task is not pending verification")
 
-    async with task_lock:
-        completed_entry = {
-            "id": task["task_id"],
-            "consumer_id": task["consumer_id"],
-            "payload": task["payload"],
-            "bounty": bounty,
-            "status": "completed",
-            "target_node": task.get("target_node"),
-            "model_requirement": task.get("model_requirement"),
-            "provider_id": result.provider_id,
-            "payload_uri": task.get("payload_uri"),
-            "result": result_payload,
-            "result_uri": normalized_result_uri,
-            "completed_at": task["updated_at"],
-        }
-        completed_tasks[result.task_id] = completed_entry
-        if result.task_id in active_tasks:
-            del active_tasks[result.task_id]
-    await _evict_completed_tasks_cache()
+    provider_id = task.get("provider_id")
+    if not provider_id:
+        raise HTTPException(status_code=409, detail="Task has no assigned provider")
+    result_payload = task.get("result_payload") or ""
+    result_uri = task.get("result_uri")
+    if not result_payload and not result_uri:
+        raise HTTPException(status_code=409, detail="Task has no submitted result")
 
-    # ROUTE RESULT BACK TO CONSUMER VIA WEBSOCKET
-    consumer_id = task["consumer_id"]
-    async with node_lock:
-        consumer_ws = connected_nodes.get(consumer_id)
-    if consumer_ws:
-        try:
-            await consumer_ws.send_json({
-                "event": "task_result",
-                "data": {
-                    "task_id": result.task_id,
-                    "provider_id": result.provider_id,
-                    "result_payload": result_payload,
-                    "result_uri": normalized_result_uri,
-                    "bounty_spent": bounty
-                }
-            })
-        except Exception as exc:
-            log_event("deliver_result_failed", f"Failed to deliver result {result.task_id[:8]} to {consumer_id}: {exc}", task_id=result.task_id, consumer_id=consumer_id)
-            async with node_lock:
-                if connected_nodes.get(consumer_id) is consumer_ws:
-                    del connected_nodes[consumer_id]
+    settled = db.complete_task_atomic(
+        verification.task_id,
+        provider_id,
+        result_payload,
+        time.time(),
+        result_uri=result_uri,
+        idem_node_id=authenticated_node if x_mep_idempotency_key else None,
+        idem_endpoint="/tasks/verify/accept" if x_mep_idempotency_key else None,
+        idem_key=x_mep_idempotency_key,
+        expected_status="submitted_result",
+    )
+    if settled["status"] == "idempotent":
+        return settled["response"]
+    if settled["status"] in ("not_found", "not_active"):
+        raise HTTPException(status_code=404, detail="Task not found or not pending verification")
+    if settled["status"] == "assigned_to_other":
+        raise HTTPException(status_code=409, detail="Task assigned to another provider")
+    if settled["status"] == "escrow_not_held":
+        raise HTTPException(status_code=409, detail="Escrow is not held for this task")
+    if settled["status"] != "success":
+        raise HTTPException(status_code=409, detail="Task could not be settled")
+    return await _finalize_settled_task(settled, verification.task_id, provider_id, result_payload, result_uri)
 
-    return settled["response"]
 
 @app.get("/tasks/result/{task_id}")
 async def get_task_result(task_id: str, authenticated_node: str = Depends(verify_request)):

--- a/hub/models.py
+++ b/hub/models.py
@@ -21,6 +21,8 @@ class TaskCreate(BaseModel):
     bounty_ns: Optional[Any] = None
     target_node: Optional[str] = None
     routing: Optional[Dict[str, Any]] = None
+    verifier: Optional[Dict[str, Any]] = None
+    verifier_type: Optional[str] = None
     model_requirement: Optional[str] = None
     expires_in_seconds: Optional[int] = Field(default=None, ge=1)
     secret_data: Optional[str] = None
@@ -43,6 +45,9 @@ class TaskResult(BaseModel):
     error: Optional[Dict[str, Any]] = None
 
 class TaskCancel(BaseModel):
+    task_id: str
+
+class TaskVerificationAccept(BaseModel):
     task_id: str
 
 class NodeBalance(BaseModel):

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -201,6 +201,53 @@ class TestTaskLifecycle(unittest.TestCase):
         resp = client.get(f"/balance/{provider_id}")
         self.assertGreater(resp.json()["balance_seconds"], 10.0)  # 10 starting + 1 earned
 
+    def test_manual_verification_gates_settlement_until_consumer_accepts(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "Requires review",
+            "bounty": 1.0,
+            "verifier_type": "manual_acceptance",
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(submit.status_code, 200, submit.text)
+        task_id = submit.json()["task_id"]
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+        bid = client.post("/tasks/bid", content=bid_payload, headers=headers)
+        self.assertEqual(bid.status_code, 200, bid.text)
+        self.assertEqual(bid.json()["status"], "accepted")
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "review me"})
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        complete = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(complete.status_code, 200, complete.text)
+        self.assertEqual(complete.json()["status"], "pending_verification")
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
+        task = db.get_task(task_id)
+        self.assertEqual(task["status"], "submitted_result")
+        self.assertEqual(db.get_escrow(task_id)["status"], "held")
+
+        accept_payload = json.dumps({"task_id": task_id})
+        headers = _auth_headers(provider_priv, provider_id, accept_payload)
+        forbidden = client.post("/tasks/verify/accept", content=accept_payload, headers=headers)
+        self.assertEqual(forbidden.status_code, 403, forbidden.text)
+
+        headers = _auth_headers(consumer_priv, consumer_id, accept_payload)
+        accepted = client.post("/tasks/verify/accept", content=accept_payload, headers=headers)
+        self.assertEqual(accepted.status_code, 200, accepted.text)
+        self.assertEqual(accepted.json()["status"], "success")
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before + 1.0)
+        self.assertEqual(db.get_task(task_id)["status"], "completed")
+        self.assertEqual(db.get_escrow(task_id)["status"], "released")
+
     def test_duplicate_completion_does_not_double_settle(self):
         consumer_priv, consumer_pub, consumer_id = _make_identity()
         provider_priv, provider_pub, provider_id = _make_identity()


### PR DESCRIPTION
﻿@Hub-Sentinel please review this production-readiness PR.

## Summary
- Adds `verifier_type=manual_acceptance` task metadata and persists it in the hub DB.
- Changes `/tasks/complete` for verifier-gated tasks to store provider output as `submitted_result` and keep escrow held.
- Adds `/tasks/verify/accept` so only the consumer can atomically release settlement from `submitted_result` to `completed`.
- Reuses the PR #207 atomic settlement helper for verifier acceptance via `expected_status="submitted_result"`.
- Adds regression coverage that provider completion does not pay until consumer acceptance, and non-consumer acceptance is rejected.

## Review focus
- Verify verifier-gated tasks cannot settle through `/tasks/complete` alone.
- Verify escrow remains held while status is `submitted_result`.
- Verify `/tasks/verify/accept` is consumer-only and settles atomically once.
- Verify existing non-verifier task completion behavior is unchanged.
- Verify DB migration is backward-compatible for existing SQLite/Postgres deployments.

## Tests
- `python -m py_compile hub/db.py hub/main.py hub/models.py tests/test_hub_api.py` — passed
- `python -m ruff check hub/db.py hub/main.py hub/models.py tests/test_hub_api.py` — passed
- `python -m unittest discover -s C:\Users\Aibing\mep-review\MEP\tests -p test_hub_api.py -v` — 49 tests OK
- `python -m pytest C:\Users\Aibing\mep-review\MEP\tests\test_hub_auth.py -q` — 8 passed

Note: this repo has mixed line endings in hub/test files. The semantic diff is about 347 lines (`git diff --ignore-space-at-eol --stat`), though the raw diff includes some EOL churn in `tests/test_hub_api.py`.
