### PR TITLE
fix(node): require opt-in for local code execution

### DIFF
--- a/node/mep_cli_provider.py
+++ b/node/mep_cli_provider.py
@@ -44,6 +44,7 @@ class MEPCLIProvider:
         os.makedirs(self.workspace_dir, exist_ok=True)
         self.upload_code = os.getenv("MEP_CLI_UPLOAD_CODE", "false").lower() in ("1", "true", "yes")
         self.max_code_chars = int(os.getenv("MEP_CLI_MAX_CODE_CHARS", "12000"))
+        self.allow_execution = os.getenv("MEP_CLI_ALLOW_EXECUTION", "false").lower() in ("1", "true", "yes")
         # Safety: maximum SECONDS a node will spend to buy data (negative bounty)
         self.max_purchase_price = float(os.getenv("MEP_MAX_PURCHASE_PRICE", "0.0"))
 
@@ -110,6 +111,11 @@ class MEPCLIProvider:
         model = rfc_data.get("model_requirement")
         
         if model not in self.capabilities and model is not None:
+            return
+
+        if bounty != 0 and not self.allow_execution:
+            print(f"[CLI Provider] Execution disabled; refusing executable task {task_id[:8]}. "
+                  "Set MEP_CLI_ALLOW_EXECUTION=true only in a sandboxed environment.")
             return
         
         # 🛡️ CRITICAL SAFETY CHECK: DO NOT BUY DATA UNLESS EXPLICITLY ENABLED
@@ -257,6 +263,16 @@ class MEPCLIProvider:
         
         print(f"  ✅ Result saved to {results_file}")
 
+    @staticmethod
+    def _build_agent_argv(agent_cmd: str, payload: str) -> list[str]:
+        """Build an argv list for a local agent without invoking a shell."""
+        argv = shlex.split(agent_cmd, posix=os.name != "nt")
+        if not argv:
+            raise ValueError("MEP_CLI_AGENT_CMD is empty")
+        if any("{payload}" in arg for arg in argv):
+            return [arg.replace("{payload}", payload) for arg in argv]
+        return [*argv, payload]
+
     async def process_task(self, task_data: dict, secret_data: Optional[str] = None):
         """Execute the task using a local CLI agent."""
         task_id = task_data["id"]
@@ -268,6 +284,11 @@ class MEPCLIProvider:
             await self._handle_dm(task_data)
             return
         # ===== END DM DETECTION =====
+
+        if not self.allow_execution:
+            print(f"[CLI Provider] Execution disabled; skipping task {task_id[:8]}. "
+                  "Set MEP_CLI_ALLOW_EXECUTION=true only in a sandboxed environment.")
+            return
         
         # If this is a Data Market purchase, save the secret data!
         if secret_data:
@@ -307,53 +328,29 @@ class MEPCLIProvider:
                     print(f"[CLI Provider] ❌ Download error: {e}")
 
             print(f"[CLI Provider] Upload code enabled: {self.upload_code}")
-            
-            if os.name == "nt":
-                safe_payload = payload.replace('"', '""')
-                cmd = (
-                    "echo Booting Autonomous CLI Agent... & "
-                    "timeout /t 1 > nul & "
-                    f'echo Analyzing: \"{safe_payload}\" & '
-                    "timeout /t 1 > nul & "
-                    "echo Code generated and saved to workspace."
-                )
-            else:
-                safe_payload = shlex.quote(payload)
-                cmd = (
-                    "echo 'Booting Autonomous CLI Agent...' && "
-                    "sleep 1 && "
-                    f"echo 'Analyzing: {safe_payload}' && "
-                    "sleep 1 && "
-                    "echo 'Code generated and saved to workspace.'"
-                )
             agent_cmd = os.getenv("MEP_CLI_AGENT_CMD")
             if agent_cmd:
-                if "{payload}" in agent_cmd:
-                    # Substitute placeholder with quoted payload
-                    cmd = agent_cmd.replace("{payload}", safe_payload)
-                else:
-                    # Append quoted payload to agent command
-                    cmd = f"{agent_cmd} {safe_payload}"
-                # Note: Full fix requires subprocess_exec + arg array instead of shell=True
-                # to prevent injection via agent_cmd path itself.
-            
-            print(f"\n[CLI Agent] Executing in {task_dir}:")
-            print(f"$ {cmd[:100]}...\n")
-            
-            process = await asyncio.create_subprocess_shell(
-                cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=task_dir
-            )
-            
-            stdout, stderr = await process.communicate()
-            
-            output = stdout.decode(errors="replace").strip()
-            if stderr:
-                output += "\n[Errors/Warnings]:\n" + stderr.decode(errors="replace").strip()
-                
-            print(f"[CLI Agent] Finished with exit code {process.returncode}")
+                argv = self._build_agent_argv(agent_cmd, payload)
+                print(f"\n[CLI Agent] Executing in {task_dir}:")
+                print(f"$ {' '.join(shlex.quote(part) for part in argv)[:100]}...\n")
+                process = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=task_dir
+                )
+                stdout, stderr = await process.communicate()
+                output = stdout.decode(errors="replace").strip()
+                if stderr:
+                    output += "\n[Errors/Warnings]:\n" + stderr.decode(errors="replace").strip()
+                print(f"[CLI Agent] Finished with exit code {process.returncode}")
+            else:
+                output = (
+                    "Booting Autonomous CLI Agent...\n"
+                    f"Analyzing: {payload}\n"
+                    "No MEP_CLI_AGENT_CMD configured; simulated execution only."
+                )
+                print("[CLI Agent] No MEP_CLI_AGENT_CMD configured; simulated execution only.")
             code_block = ""
             if self.upload_code:
                 py_candidates = [
@@ -399,7 +396,7 @@ class MEPCLIProvider:
 if __name__ == "__main__":
     print("=" * 60)
     print("MEP Autonomous CLI Provider")
-    print("WARNING: This node executes shell commands. Use sandboxing!")
+    print("Execution is disabled by default. Set MEP_CLI_ALLOW_EXECUTION=true only with sandboxing.")
     print("=" * 60)
     
     key_dir = os.getenv("MEP_KEY_DIR", os.path.join(os.path.expanduser("~"), ".mep"))

--- a/node/sentinel_engineer.py
+++ b/node/sentinel_engineer.py
@@ -16,6 +16,10 @@ DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
 GLM_API_KEY = os.getenv("GLM_API_KEY")
 MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY")
 
+
+def _allow_code_execution() -> bool:
+    return os.getenv("SE_ALLOW_CODE_EXECUTION", "false").lower() in ("1", "true", "yes")
+
 class MultiBrain:
     def __init__(self):
         self.history = [] # Stores {"role": "user/model", "content": "..."} (Normalized)
@@ -96,6 +100,8 @@ class SentinelEngineer:
         self.brain = MultiBrain()
 
     def execute_code(self, code, language="python"):
+        if not _allow_code_execution():
+            return "", "Code execution disabled by default. Set SE_ALLOW_CODE_EXECUTION=true only in a sandboxed environment.", 126
         filename = "temp_script.py" if language == "python" else "temp_script.sh"
         with open(filename, "w") as f:
             f.write(code)

--- a/node/sentinel_engineer_v2.py
+++ b/node/sentinel_engineer_v2.py
@@ -56,6 +56,7 @@ class Config:
     sandbox_dir: str = os.getenv("SE_SANDBOX_DIR", "")  # empty = auto tmpdir
     circuit_breaker_threshold: int = int(os.getenv("SE_CB_THRESHOLD", "3"))
     circuit_breaker_cooldown: int = int(os.getenv("SE_CB_COOLDOWN", "300"))  # seconds
+    allow_code_execution: bool = os.getenv("SE_ALLOW_CODE_EXECUTION", "false").lower() in ("1", "true", "yes")
 
 CONFIG = Config()
 
@@ -358,6 +359,12 @@ class CodeExecutor:
         self._sandbox_base.mkdir(parents=True, exist_ok=True)
 
     def execute(self, code: str, language: str = "python") -> ExecResult:
+        if not CONFIG.allow_code_execution:
+            return ExecResult(
+                "",
+                "Code execution disabled by default. Set SE_ALLOW_CODE_EXECUTION=true only in a sandboxed environment.",
+                126,
+            )
         if language not in self.ALLOWED_LANGUAGES:
             return ExecResult("", f"Unsupported language: {language}", 1)
 

--- a/tests/test_mep_cli_provider_safety.py
+++ b/tests/test_mep_cli_provider_safety.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import tempfile
+import unittest
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "node"))
+
+from mep_cli_provider import MEPCLIProvider  # noqa: E402
+
+
+class TestMEPCLIProviderSafety(unittest.IsolatedAsyncioTestCase):
+    def test_build_agent_argv_keeps_payload_as_single_arg(self):
+        payload = "hello; touch /tmp/pwned && echo bad"
+        argv = MEPCLIProvider._build_agent_argv("python -m local_agent", payload)
+        self.assertEqual(argv[-1], payload)
+        self.assertNotIn(";", argv[:-1])
+
+    def test_build_agent_argv_replaces_payload_placeholder_without_shell(self):
+        payload = "$(touch /tmp/pwned)"
+        argv = MEPCLIProvider._build_agent_argv("agent --task {payload}", payload)
+        self.assertEqual(argv, ["agent", "--task", payload])
+
+    async def test_process_task_skips_executable_task_when_disabled(self):
+        provider = MEPCLIProvider.__new__(MEPCLIProvider)
+        provider.workspace_dir = tempfile.mkdtemp()
+        provider.allow_execution = False
+        provider.upload_code = False
+        provider.max_code_chars = 12000
+        provider.node_id = "node_test"
+
+        calls = []
+
+        async def fake_post(*args, **kwargs):
+            calls.append((args, kwargs))
+            return None
+
+        provider._post_with_retry = fake_post
+        await provider.process_task(
+            {
+                "id": "task_exec_disabled",
+                "payload": "import os\nprint(os.listdir('.'))",
+                "bounty": 1.0,
+                "consumer_id": "node_consumer",
+            }
+        )
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mep_cli_provider_safety.py
+++ b/tests/test_mep_cli_provider_safety.py
@@ -1,10 +1,22 @@
 import os
 import sys
 import tempfile
+import types
 import unittest
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "node"))
+
+# The CLI provider can run standalone with optional websocket/aiohttp runtime
+# dependencies. These unit tests only exercise local safety helpers.
+sys.modules.setdefault(
+    "websockets",
+    types.SimpleNamespace(exceptions=types.SimpleNamespace(ConnectionClosed=Exception), connect=None),
+)
+sys.modules.setdefault(
+    "aiohttp",
+    types.SimpleNamespace(ClientSession=None),
+)
 
 from mep_cli_provider import MEPCLIProvider  # noqa: E402
 

--- a/tests/test_sentinel_engineer_v2.py
+++ b/tests/test_sentinel_engineer_v2.py
@@ -121,7 +121,18 @@ class TestCodeExecutor(unittest.TestCase):
     """Test sandboxed code execution."""
 
     def setUp(self):
+        self.old_allow_code_execution = CONFIG.allow_code_execution
+        CONFIG.allow_code_execution = True
         self.executor = CodeExecutor()
+
+    def tearDown(self):
+        CONFIG.allow_code_execution = self.old_allow_code_execution
+
+    def test_execution_disabled_by_default_guard(self):
+        CONFIG.allow_code_execution = False
+        result = self.executor.execute('print("blocked")', "python")
+        self.assertEqual(result.returncode, 126)
+        self.assertIn("disabled", result.stderr)
 
     def test_python_hello(self):
         result = self.executor.execute('print("hello")', "python")


### PR DESCRIPTION
﻿@Hub-Sentinel please review this production-readiness PR.

## Summary
- Makes SentinelEngineer code execution opt-in via `SE_ALLOW_CODE_EXECUTION=true`; default now returns a blocked execution result instead of running LLM-generated code.
- Applies the same opt-in guard to the legacy `sentinel_engineer.py` path.
- Makes `MEPCLIProvider` refuse non-zero-bounty executable tasks unless `MEP_CLI_ALLOW_EXECUTION=true`.
- Replaces CLI provider shell invocation with argv-based `asyncio.create_subprocess_exec(...)` for `MEP_CLI_AGENT_CMD`, keeping task payload as a single argument.
- Keeps zero-bounty message/DM handling working without enabling execution.

## Review focus
- Verify no remote task can trigger local code/shell execution by default.
- Verify opt-in switches are explicit and named clearly: `SE_ALLOW_CODE_EXECUTION`, `MEP_CLI_ALLOW_EXECUTION`.
- Verify CLI provider no longer uses `create_subprocess_shell` or payload-interpolated shell strings.
- Verify existing sandbox tests only enable execution inside tests.
- Verify zero-bounty message handling still works while execution is disabled.

## Tests
- `python -m py_compile node/sentinel_engineer.py node/sentinel_engineer_v2.py node/mep_cli_provider.py tests/test_sentinel_engineer_v2.py tests/test_mep_cli_provider_safety.py` — passed
- `python -m ruff check node/sentinel_engineer.py node/sentinel_engineer_v2.py node/mep_cli_provider.py tests/test_sentinel_engineer_v2.py tests/test_mep_cli_provider_safety.py` — passed
- `python -m pytest tests/test_sentinel_engineer_v2.py tests/test_mep_cli_provider_safety.py -q` — 28 passed, 1 skipped
- `python -m pytest tests/test_node_runtime.py tests/test_node_client.py -q` — 34 passed
