### PR TITLE
fix(hub): cap task rebroadcasts with configurable retry limit

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -108,6 +108,19 @@ def _ensure_tasks_verifier_type_column(cursor):
         if "verifier_type" not in columns:
             cursor.execute("ALTER TABLE tasks ADD COLUMN verifier_type TEXT")
 
+def _ensure_tasks_rebroadcast_count_column(cursor):
+    if _is_postgres():
+        cursor.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = 'tasks' AND column_name = 'rebroadcast_count'"
+        )
+        if not cursor.fetchone():
+            cursor.execute("ALTER TABLE tasks ADD COLUMN rebroadcast_count INTEGER NOT NULL DEFAULT 0")
+    else:
+        cursor.execute("PRAGMA table_info(tasks)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if "rebroadcast_count" not in columns:
+            cursor.execute("ALTER TABLE tasks ADD COLUMN rebroadcast_count INTEGER NOT NULL DEFAULT 0")
+
 def init_db():
     conn = _get_conn()
     cursor = conn.cursor()
@@ -133,6 +146,7 @@ def init_db():
             payload_uri TEXT,
             result_uri TEXT,
             verifier_type TEXT,
+            rebroadcast_count INTEGER NOT NULL DEFAULT 0,
             created_at REAL NOT NULL,
             updated_at REAL NOT NULL
         )
@@ -140,6 +154,7 @@ def init_db():
     _ensure_tasks_expires_in_seconds_column(cursor)
     _ensure_tasks_envelope_json_column(cursor)
     _ensure_tasks_verifier_type_column(cursor)
+    _ensure_tasks_rebroadcast_count_column(cursor)
     if not _is_postgres():
         try:
             cursor.execute("ALTER TABLE tasks ADD COLUMN payload_uri TEXT")
@@ -1043,12 +1058,12 @@ def requeue_task_if_assigned(task_id: str, updated_at: float) -> bool:
     cursor = conn.cursor()
     if _is_postgres():
         cursor.execute(
-            "UPDATE tasks SET status = 'bidding', provider_id = NULL, updated_at = %s WHERE task_id = %s AND status = 'assigned'",
+            "UPDATE tasks SET status = 'bidding', provider_id = NULL, rebroadcast_count = COALESCE(rebroadcast_count, 0) + 1, updated_at = %s WHERE task_id = %s AND status = 'assigned'",
             (updated_at, task_id)
         )
     else:
         cursor.execute(
-            "UPDATE tasks SET status = 'bidding', provider_id = NULL, updated_at = ? WHERE task_id = ? AND status = 'assigned'",
+            "UPDATE tasks SET status = 'bidding', provider_id = NULL, rebroadcast_count = COALESCE(rebroadcast_count, 0) + 1, updated_at = ? WHERE task_id = ? AND status = 'assigned'",
             (updated_at, task_id)
         )
     updated = cursor.rowcount

--- a/hub/main.py
+++ b/hub/main.py
@@ -164,6 +164,7 @@ TASK_TIMEOUT_DEFAULT_SECONDS = int(os.getenv("MEP_TASK_TIMEOUT_DEFAULT_SECONDS",
 TASK_TIMEOUT_MIN_SECONDS = int(os.getenv("MEP_TASK_TIMEOUT_MIN_SECONDS", "60"))
 TASK_TIMEOUT_MAX_SECONDS = int(os.getenv("MEP_TASK_TIMEOUT_MAX_SECONDS", "86400"))
 SUBMITTED_RESULT_TIMEOUT_SECONDS = int(os.getenv("MEP_SUBMITTED_RESULT_TIMEOUT_SECONDS", "86400"))
+MAX_REBROADCAST_COUNT = int(os.getenv("MEP_MAX_REBROADCAST_COUNT", "3"))
 ASSIGNMENT_SWEEP_INTERVAL_SECONDS = int(os.getenv("MEP_ASSIGNMENT_SWEEP_INTERVAL_SECONDS", "60"))
 MAINTENANCE_SWEEP_INTERVAL_SECONDS = int(os.getenv("MEP_MAINTENANCE_SWEEP_INTERVAL_SECONDS", "60"))
 REGISTRY_RECONCILE_LIMIT = int(os.getenv("MEP_REGISTRY_RECONCILE_LIMIT", "1000"))
@@ -207,6 +208,7 @@ if TASK_TIMEOUT_MIN_SECONDS > TASK_TIMEOUT_MAX_SECONDS:
     TASK_TIMEOUT_MIN_SECONDS, TASK_TIMEOUT_MAX_SECONDS = TASK_TIMEOUT_MAX_SECONDS, TASK_TIMEOUT_MIN_SECONDS
 TASK_TIMEOUT_DEFAULT_SECONDS = max(TASK_TIMEOUT_MIN_SECONDS, min(TASK_TIMEOUT_DEFAULT_SECONDS, TASK_TIMEOUT_MAX_SECONDS))
 SUBMITTED_RESULT_TIMEOUT_SECONDS = max(TASK_TIMEOUT_MIN_SECONDS, min(SUBMITTED_RESULT_TIMEOUT_SECONDS, TASK_TIMEOUT_MAX_SECONDS))
+MAX_REBROADCAST_COUNT = max(0, MAX_REBROADCAST_COUNT)
 
 # ---------------------------------------------------------------------------
 # Node Activity Tracking (for passive degraded detection)
@@ -1409,50 +1411,62 @@ async def _sweep_assigned_timeouts():
         return
     for task in expired_tasks:
         if TIMEOUT_POLICY == "rebroadcast" and not task["target_node"]:
-            if task["bounty"] < 0:
-                refunded = db.refund_escrow(task["task_id"], now)
-                if refunded is not None:
-                    buyer_id = task.get("provider_id") or ""
-                    new_balance = db.get_balance(buyer_id) or 0.0
-                    log_audit("DATA_TIMEOUT_REFUND", buyer_id, refunded, new_balance, task["task_id"])
-            if not db.requeue_task_if_assigned(task["task_id"], now):
+            rebroadcast_count = int(task.get("rebroadcast_count") or 0)
+            if MAX_REBROADCAST_COUNT > 0 and rebroadcast_count >= MAX_REBROADCAST_COUNT:
+                log_event(
+                    "task_rebroadcast_limit",
+                    f"Task {task['task_id'][:8]} reached rebroadcast limit",
+                    task_id=task["task_id"],
+                    consumer_id=task["consumer_id"],
+                    bounty=task["bounty"],
+                    rebroadcast_count=rebroadcast_count,
+                    max_rebroadcast_count=MAX_REBROADCAST_COUNT,
+                )
+            else:
+                if task["bounty"] < 0:
+                    refunded = db.refund_escrow(task["task_id"], now)
+                    if refunded is not None:
+                        buyer_id = task.get("provider_id") or ""
+                        new_balance = db.get_balance(buyer_id) or 0.0
+                        log_audit("DATA_TIMEOUT_REFUND", buyer_id, refunded, new_balance, task["task_id"])
+                if not db.requeue_task_if_assigned(task["task_id"], now):
+                    continue
+                task_data = {
+                    "id": task["task_id"],
+                    "consumer_id": task["consumer_id"],
+                    "payload": task["payload"],
+                    "bounty": task["bounty"],
+                    "status": "bidding",
+                    "target_node": task["target_node"],
+                    "model_requirement": task["model_requirement"],
+                    "verifier_type": task.get("verifier_type"),
+                    "expires_in_seconds": task.get("expires_in_seconds"),
+                    "payload_uri": task.get("payload_uri"),
+                    "secret_data": task.get("result_payload")
+                }
+                async with task_lock:
+                    active_tasks[task["task_id"]] = task_data
+                model_requirement = _normalize_model_requirement(task["model_requirement"])
+                rfc_data = {
+                    "id": task["task_id"],
+                    "consumer_id": task["consumer_id"],
+                    "bounty": task["bounty"],
+                    "model_requirement": model_requirement,
+                    "payload_uri": task.get("payload_uri")
+                }
+                async with node_lock:
+                    broadcast_nodes = list(connected_nodes.items())
+                candidate_nodes = _select_rfc_recipients(task["consumer_id"], model_requirement, broadcast_nodes)
+                for node_id, ws in candidate_nodes:
+                    try:
+                        await ws.send_json({"event": "rfc", "data": rfc_data})
+                    except Exception as exc:
+                        log_event("broadcast_error", f"Failed to send RFC to {node_id}: {exc}", node_id=node_id, task_id=task["task_id"])
+                        async with node_lock:
+                            if connected_nodes.get(node_id) is ws:
+                                del connected_nodes[node_id]
+                log_event("task_requeued_timeout", f"Task {task['task_id'][:8]} requeued after timeout", task_id=task["task_id"], consumer_id=task["consumer_id"], bounty=task["bounty"], rebroadcast_count=rebroadcast_count + 1)
                 continue
-            task_data = {
-                "id": task["task_id"],
-                "consumer_id": task["consumer_id"],
-                "payload": task["payload"],
-                "bounty": task["bounty"],
-                "status": "bidding",
-                "target_node": task["target_node"],
-                "model_requirement": task["model_requirement"],
-                "verifier_type": task.get("verifier_type"),
-                "expires_in_seconds": task.get("expires_in_seconds"),
-                "payload_uri": task.get("payload_uri"),
-                "secret_data": task.get("result_payload")
-            }
-            async with task_lock:
-                active_tasks[task["task_id"]] = task_data
-            model_requirement = _normalize_model_requirement(task["model_requirement"])
-            rfc_data = {
-                "id": task["task_id"],
-                "consumer_id": task["consumer_id"],
-                "bounty": task["bounty"],
-                "model_requirement": model_requirement,
-                "payload_uri": task.get("payload_uri")
-            }
-            async with node_lock:
-                broadcast_nodes = list(connected_nodes.items())
-            candidate_nodes = _select_rfc_recipients(task["consumer_id"], model_requirement, broadcast_nodes)
-            for node_id, ws in candidate_nodes:
-                try:
-                    await ws.send_json({"event": "rfc", "data": rfc_data})
-                except Exception as exc:
-                    log_event("broadcast_error", f"Failed to send RFC to {node_id}: {exc}", node_id=node_id, task_id=task["task_id"])
-                    async with node_lock:
-                        if connected_nodes.get(node_id) is ws:
-                            del connected_nodes[node_id]
-            log_event("task_requeued_timeout", f"Task {task['task_id'][:8]} requeued after timeout", task_id=task["task_id"], consumer_id=task["consumer_id"], bounty=task["bounty"])
-            continue
         if not db.expire_task_if_assigned(task["task_id"], now):
             continue
         if task["bounty"] > 0:

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -1467,6 +1467,63 @@ class TestBiddingTimeout(unittest.TestCase):
         self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before)
         self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before)
 
+    def test_rebroadcast_limit_expires_after_max_rebroadcasts(self):
+        """When TIMEOUT_POLICY=rebroadcast, task should requeue up to MAX_REBROADCAST_COUNT then expire and refund."""
+        old_policy = main.TIMEOUT_POLICY
+        old_max = main.MAX_REBROADCAST_COUNT
+        main.TIMEOUT_POLICY = "rebroadcast"
+        main.MAX_REBROADCAST_COUNT = 2
+        try:
+            consumer_priv, consumer_pub, consumer_id = _make_identity()
+            provider_priv, provider_pub, provider_id = _make_identity()
+            _register(consumer_pub)
+            _register(provider_pub)
+
+            consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+
+            task_payload = json.dumps({"consumer_id": consumer_id, "payload": "rebroadcast me", "bounty": 1.0})
+            headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+            submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+            self.assertEqual(submit.status_code, 200, submit.text)
+            task_id = submit.json()["task_id"]
+
+            bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+            headers = _auth_headers(provider_priv, provider_id, bid_payload)
+            self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+            self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
+
+            import asyncio
+            from main import _sweep_assigned_timeouts
+
+            for i in range(3):
+                old_time = time.time() - 7200
+                conn = db._get_conn()
+                conn.execute("UPDATE tasks SET updated_at = ? WHERE task_id = ?", (old_time, task_id))
+                conn.commit()
+                db._release_conn(conn)
+
+                loop = asyncio.new_event_loop()
+                try:
+                    loop.run_until_complete(_sweep_assigned_timeouts())
+                finally:
+                    loop.close()
+
+                task = db.get_task(task_id)
+                if i < 2:
+                    self.assertEqual(task["status"], "bidding", f"Expected bidding after requeue {i+1}, got {task['status']}")
+                    self.assertEqual(task.get("rebroadcast_count", 0), i + 1)
+                    # Re-bid so next sweep can requeue again
+                    bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+                    headers = _auth_headers(provider_priv, provider_id, bid_payload)
+                    self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+                else:
+                    self.assertEqual(task["status"], "expired", f"Expected expired after hitting limit on iteration {i+1}, got {task['status']}")
+                    self.assertEqual(task.get("rebroadcast_count", 0), 2)
+
+            self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
+        finally:
+            main.TIMEOUT_POLICY = old_policy
+            main.MAX_REBROADCAST_COUNT = old_max
 
 class TestConsumerDefinedTimeout(unittest.TestCase):
     """Per-task consumer timeout should override global default within bounds."""


### PR DESCRIPTION
## Summary
- Adds `rebroadcast_count` column to the `tasks` table (with migration).
- Introduces `MEP_MAX_REBROADCAST_COUNT` env var (default 3) to cap rebroadcast loops.
- When limit reached, task expires and refunds escrow instead of looping forever.
- Includes regression test.

Closes #185

#### Test plan
- [x] Regression test passes
- [x] Full `test_hub_api` suite passes
- [x] `ruff check` clean

Generated with [Devin](https://cli.devin.ai/docs)