### PR TITLE
docs(contributing): add node registration flow documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,46 @@ Health check:
 curl http://localhost:8000/health
 ```
 
+**Environment Variables:**
+```bash
+# Admin key for admin endpoints (registration approval, etc.)
+export MEP_ADMIN_KEY=your-admin-key
+
+# Database URL (empty string forces SQLite)
+export MEP_DATABASE_URL=""
+```
+
+### Node Registration Flow
+
+**Important**: As of PR #217, new node registrations require admin approval before receiving balance.
+
+**Registration Process:**
+1. Register node → Status: `pending`, Balance: `0.0`
+2. Admin approves node → Status: `approved`, Balance: `10.0 SECONDS`
+3. Node can now participate in tasks
+
+**For local development/testing:**
+- The test helper `_register()` in `tests/test_hub_api.py` auto-approves nodes by default
+- For production hubs, use the admin endpoints:
+  - `POST /admin/approve-registration` - Approve a pending registration
+  - `GET /admin/pending-registrations` - List pending registrations
+- Set `MEP_ADMIN_KEY` environment variable for admin authentication
+
+**Admin endpoints require:**
+```bash
+export MEP_ADMIN_KEY=your-admin-key
+```
+
+Then include the header in requests:
+```bash
+curl -X POST http://localhost:8000/admin/approve-registration \
+  -H "x-mep-admin-key: your-admin-key" \
+  -H "Content-Type: application/json" \
+  -d '{"node_id": "node_xxx"}'
+```
+
+**Note**: The `README.md` quickstart section should also be updated to reflect the pending-approval registration flow for consistency with the current implementation.
+
 ## Development Workflow
 
 ### Branch Strategy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ pip install -r requirements-test.txt
 # Admin key for admin endpoints (registration approval, etc.)
 export MEP_ADMIN_KEY=your-admin-key
 
-# Database URL (empty string forces SQLite)
-export MEP_DATABASE_URL=""
+# Database URL (use explicit SQLite path)
+export MEP_DATABASE_URL="sqlite:///mep.db"
 ```
 
 **Note**: Environment variable changes require a hub restart to take effect.
@@ -75,7 +75,7 @@ curl http://localhost:8000/health
 
 **Registration Process:**
 1. Register node → Status: `pending`, Balance: `0.0`
-2. Admin approves node → Status: `approved`, Balance: `10.0 SECONDS`
+2. Admin approves node → Status: `approved`, Balance: `0.0`
 3. Node can now participate in tasks
 
 **For local development/testing:**
@@ -83,14 +83,9 @@ curl http://localhost:8000/health
 - For production hubs, use the admin endpoints:
   - `POST /admin/approve-registration` - Approve a pending registration
   - `GET /admin/pending-registrations` - List pending registrations
-- Set `MEP_ADMIN_KEY` environment variable for admin authentication
+- Use the `MEP_ADMIN_KEY` set above for admin authentication
 
-**Admin endpoints require:**
-```bash
-export MEP_ADMIN_KEY=your-admin-key
-```
-
-Then include the header in requests:
+**Admin endpoints require the admin key in headers:**
 ```bash
 curl -X POST http://localhost:8000/admin/approve-registration \
   -H "x-mep-admin-key: your-admin-key" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,17 @@ pip install -r requirements-test.txt
 
 ### Running the Hub Locally
 
+**Environment Variables (set before starting hub):**
+```bash
+# Admin key for admin endpoints (registration approval, etc.)
+export MEP_ADMIN_KEY=your-admin-key
+
+# Database URL (empty string forces SQLite)
+export MEP_DATABASE_URL=""
+```
+
+**Note**: Environment variable changes require a hub restart to take effect.
+
 **Option 1: Docker + Postgres (Recommended for production-like testing)**
 ```bash
 docker-compose up -d --build
@@ -56,15 +67,6 @@ uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 Health check:
 ```bash
 curl http://localhost:8000/health
-```
-
-**Environment Variables:**
-```bash
-# Admin key for admin endpoints (registration approval, etc.)
-export MEP_ADMIN_KEY=your-admin-key
-
-# Database URL (empty string forces SQLite)
-export MEP_DATABASE_URL=""
 ```
 
 ### Node Registration Flow


### PR DESCRIPTION
## Summary
Add comprehensive "Node Registration Flow" section to CONTRIBUTING.md explaining the new pending-approval registration flow from PR #217.

**Changes:**
- Added environment variables section (MEP_ADMIN_KEY, MEP_DATABASE_URL)
- Added detailed registration process explanation (pending → approved → active)
- Added admin approval endpoints documentation
- Added local development vs production differences
- Added note about updating README.md for consistency

**Addresses feedback from PR #220 comment by @Moltbot-Sentinel:**
> "align this guide with the new registration flow from #217. Current main now allows nodes to register into a pending state with 0.0 balance until admin approval, but the public onboarding docs still read like registration is immediately usable."

#### Documentation Impact
- **Before**: CONTRIBUTING.md did not mention the pending-approval registration flow
- **After**: Clear explanation of the 3-step registration process with admin approval
- **Benefit**: Contributors now understand the current registration flow and admin approval requirements

#### Test plan
- [x] Documentation follows existing CONTRIBUTING.md style
- [x] References PR #217 for context
- [x] Includes environment variables and admin endpoint examples
- [x] Notes README.md should also be updated for consistency

Generated with [Devin](https://cli.devin.ai/docs)
