### PR TITLE
design(finance): add ns migration foundation

### DIFF
--- a/docs/ns-migration/design-lock.md
+++ b/docs/ns-migration/design-lock.md
@@ -1,0 +1,110 @@
+# Financial NS Migration Design Lock
+
+This document locks the implementation direction from issues #223 and #224.
+PR 1 is a foundation PR only: it defines the contract, helper layer, and
+inventory. It does not migrate storage, rewrite endpoints, or remove legacy
+compatibility.
+
+## Locked Decisions
+
+1. **Versioning**
+   - Use path versioning for the new financial API surface: `/v2/...`.
+   - Keep legacy endpoints unchanged during the migration window.
+
+2. **Canonical unit**
+   - V2 financial request/response schemas use integer nanoseconds only.
+   - V2 uses MEP-spec field names wherever practical.
+   - No float-backed financial field is part of the canonical v2 API.
+
+3. **JSON encoding**
+   - V2 `*_ns` values are JSON strings, not JSON numbers.
+   - Encoding rule: values must match `^(0|-?[1-9][0-9]*)$`.
+   - No leading zeros except the single value `"0"`.
+   - `"-0"` is forbidden; use `"0"`.
+   - Client libraries must parse these values as arbitrary-precision integers,
+     not JavaScript `Number`.
+
+4. **Storage model**
+   - Internal financial storage migrates to integer nanoseconds.
+   - Task bounty storage uses signed `bounty_ns` semantics for the first storage
+     migration because current hub behavior relies on positive/zero/negative
+     bounty branching.
+   - Protocol-level unsigned `bounty_ns` plus `payment_direction` / `market`
+     can be layered later as a separate protocol upgrade.
+
+5. **Scope**
+   - In scope: `ledger.balance`, `tasks.bounty`, `escrows.amount`, and
+     registration credit in `approve_registration()`.
+   - Out of scope: timestamp columns such as `created_at`, `updated_at`, and
+     `approved_at`.
+
+6. **Legacy compatibility**
+   - Legacy financial endpoints stay behaviorally compatible during the
+     migration window.
+   - Legacy endpoints must become thin adapters over canonical ns-first
+     helpers/internal logic.
+   - Float translation is permitted only at legacy request/response boundaries.
+
+7. **Deprecation window**
+   - Default target: 3 months after v2 is announced.
+   - The window can be extended if adoption is materially lower than expected
+     near the end of the window.
+
+## Backfill Rules
+
+Do not use `int(float_value * 1_000_000_000)` as migration truth.
+
+Backfill must use:
+
+- `Decimal(str(value))`
+- an explicit rounding policy
+- audit logging for every non-exact legacy row
+
+Cleanup should happen only after mismatches are reviewed.
+
+## PR Sequencing
+
+1. **PR 1:** design-lock artifacts, field registry, endpoint inventory,
+   canonical ns helper layer, v2 schema definitions, and helper tests.
+2. **PR 2:** internal storage/arithmetic migration to integer ns.
+3. **PR 3:** v2 financial endpoints and v2 request handling.
+4. **PR 4:** legacy adapter layer plus regression coverage.
+5. **PR 5:** docs, migration guide, and deprecation notice.
+6. **PR 6:** legacy float-era financial surface removal after the deprecation
+   window closes.
+
+## PR 1 Scope
+
+PR 1 should include:
+
+- financial surface inventory document
+- canonical field registry artifact
+- canonical v2 financial schema definitions
+- canonical ns-first helper functions
+- legacy-boundary conversion helpers clearly marked as adapters
+- tests for ns string encoding and helper behavior
+
+PR 1 should not include:
+
+- full storage migration
+- broad endpoint rewrites
+- final legacy adapter implementation across routes
+- deprecation/removal changes
+- cleanup of old float-era endpoints
+
+## PR 1 Acceptance Criteria
+
+- Every money-bearing endpoint is inventoried or explicitly marked out of scope.
+- V2 schema definitions use ns-only units.
+- V2 schema definitions use MEP-spec names where already defined.
+- Unresolved field names are explicitly proposed and tracked in the field
+  registry.
+- Canonical money helpers establish ns-first internal handling.
+- Legacy compatibility is described as boundary adaptation only, not separate
+  business logic.
+- No new canonical financial schema, internal money helper, or internal
+  arithmetic path introduced in PR 1 may use `float` or `REAL` as the source of
+  truth.
+- Any float-based conversion introduced in PR 1 is explicitly limited to legacy
+  boundary adaptation.
+- PR 1 introduces no broad API behavior change.

--- a/docs/ns-migration/field-registry.md
+++ b/docs/ns-migration/field-registry.md
@@ -1,0 +1,29 @@
+# V2 Financial Field Registry
+
+If a canonical financial field is not listed here, it should not appear in the
+v2 API. For spec gaps, the proposed name, type, example, and likely MEP-spec
+home must be ratified here before implementation merges.
+
+| MEP spec section | Field name | V2 JSON type | Example | Status | Notes |
+|---|---|---|---|---|---|
+| task.economics | `bounty_ns` | string | `"5000000000"` | ratified | Signed internally for storage; v2 request schemas may pair with direction/market. |
+| task.economics | `currency` | string | `"MEP_NS"` | ratified | Canonical currency for v2 financial fields. |
+| task.economics | `payment_direction` | string | `"sender_to_receiver"` | ratified | Existing spec-shaped request concept. |
+| task.economics | `market` | string | `"compute"` | ratified | Existing spec-shaped request concept. |
+| ledger.balance | `balance_ns` | string | `"10000000000"` | proposed | Canonical balance response field. |
+| escrow.amount | `amount_ns` | string | `"5000000000"` | proposed | Canonical escrow and ledger amount field. |
+
+## Encoding Rule
+
+All `*_ns` fields use JSON strings and must match:
+
+```text
+^(0|-?[1-9][0-9]*)$
+```
+
+Additional constraints:
+
+- no leading zeros except `"0"`
+- `"-0"` is forbidden
+- consumers must parse with arbitrary-precision integer support
+- JavaScript clients must not parse these values into `Number`

--- a/docs/ns-migration/field-registry.md
+++ b/docs/ns-migration/field-registry.md
@@ -8,8 +8,8 @@ home must be ratified here before implementation merges.
 |---|---|---|---|---|---|
 | task.economics | `bounty_ns` | string | `"5000000000"` | ratified | Signed internally for storage; v2 request schemas may pair with direction/market. |
 | task.economics | `currency` | string | `"MEP_NS"` | ratified | Canonical currency for v2 financial fields. |
-| task.economics | `payment_direction` | string | `"sender_to_receiver"` | ratified | Existing spec-shaped request concept. |
-| task.economics | `market` | string | `"compute"` | ratified | Existing spec-shaped request concept. |
+| task.economics | `payment_direction` | string | `"sender_to_receiver"` | ratified | Existing spec-shaped request concept, ratified by #223/#224 design-lock consensus. |
+| task.economics | `market` | string | `"compute"` | ratified | Existing spec-shaped request concept, ratified by #223/#224 design-lock consensus. |
 | ledger.balance | `balance_ns` | string | `"10000000000"` | proposed | Canonical balance response field. |
 | escrow.amount | `amount_ns` | string | `"5000000000"` | proposed | Canonical escrow and ledger amount field. |
 

--- a/docs/ns-migration/financial-surface-inventory.md
+++ b/docs/ns-migration/financial-surface-inventory.md
@@ -1,0 +1,46 @@
+# Financial Surface Inventory
+
+This inventory tracks money-bearing request/response surfaces that must be
+covered by the v2 financial API migration. PR 1 does not implement these routes;
+it locks the scope for later PRs.
+
+## Endpoint Inventory
+
+| Legacy surface | Money fields today | V2 target | Status |
+|---|---|---|---|
+| `POST /register` | response `balance` | `POST /v2/register` with `balance_ns` | in scope |
+| `POST /admin/approve-registration` | response `balance`; registration credit writes ledger balance | v2/admin equivalent or documented admin schema using `balance_ns` | in scope |
+| `GET /balance/{node_id}` | response `balance_seconds` | `GET /v2/balance/{node_id}` with `balance_ns` | in scope |
+| `POST /tasks/submit` | request `bounty`, `bounty_ns`, `economics.bounty_seconds`; response task id only; internal escrow/balance writes | `POST /v2/tasks/submit` with `economics.bounty_ns`, `currency`, `payment_direction`, `market` | in scope |
+| `POST /tasks/bid` | response may include task `bounty` through payload/envelope | `POST /v2/tasks/bid` or v2 task assignment response with `bounty_ns` | in scope |
+| `POST /tasks/complete` | response includes settlement output such as `earned` in existing tests/flows | `POST /v2/tasks/complete` with `earned_ns` or registry-approved equivalent | proposed field pending |
+| `POST /tasks/reject` | can trigger refund ledger events | legacy adapter over ns-first rejection/refund logic | in scope |
+| `POST /tasks/verify/accept` | can trigger settlement | v2 verify/accept response with ns settlement fields where exposed | in scope |
+| `POST /tasks/verify/automated` | can trigger settlement | v2 automated verify response with ns settlement fields where exposed | in scope |
+| `GET /tasks/result/{task_id}` | response `bounty` | `GET /v2/tasks/{task_id}/result` with `bounty_ns` | in scope |
+| `GET /v2/tasks?node_id=...&state=...` | not present today; task lists expose economics in related internals | v2 task list with `bounty_ns` | proposed |
+| `GET /ledger/entries` | audit log text may include amount/balance | structured `GET /v2/ledger/{node_id}` or `GET /v2/ledger/entries` with `amount_ns`, `balance_ns` | in scope |
+| `GET /v2/escrows/{task_id}` | not present today; DB exposes escrow amount internally | v2 escrow response with `amount_ns` | proposed |
+| `GET /v2/escrows?node_id=...` | not present today | v2 escrow list with `amount_ns` | proposed |
+| `POST /disputes/open` | eligibility uses positive bounty and escrow status; response no amount | legacy adapter over ns-first dispute eligibility | in scope |
+| `POST /disputes/resolve` | chargeback amount logged via audit | v2/admin response with amount fields only if exposed | in scope |
+
+## Out Of Scope
+
+- Timestamp fields such as `created_at`, `updated_at`, `approved_at`, and
+  dispute timestamps.
+- Arbitrary provider/user `result_payload` content. Only hub-owned financial
+  fields in task/result envelopes are in scope.
+- Reputation `score`, which is non-financial despite using a numeric value.
+
+## Legacy Adapter Rule
+
+Legacy handlers should not own financial business logic after the migration.
+The desired shape is:
+
+```text
+legacy request -> boundary adapter -> ns-first internal logic -> boundary adapter -> legacy response
+v2 request     ->                  ns-first internal logic ->                  v2 response
+```
+
+Legacy float compatibility exists only in the boundary adapters.

--- a/docs/ns-migration/financial-surface-inventory.md
+++ b/docs/ns-migration/financial-surface-inventory.md
@@ -12,7 +12,7 @@ it locks the scope for later PRs.
 | `POST /admin/approve-registration` | response `balance`; registration credit writes ledger balance | v2/admin equivalent or documented admin schema using `balance_ns` | in scope |
 | `GET /balance/{node_id}` | response `balance_seconds` | `GET /v2/balance/{node_id}` with `balance_ns` | in scope |
 | `POST /tasks/submit` | request `bounty`, `bounty_ns`, `economics.bounty_seconds`; response task id only; internal escrow/balance writes | `POST /v2/tasks/submit` with `economics.bounty_ns`, `currency`, `payment_direction`, `market` | in scope |
-| `POST /tasks/bid` | response may include task `bounty` through payload/envelope | `POST /v2/tasks/bid` or v2 task assignment response with `bounty_ns` | in scope |
+| `POST /tasks/bid` | response may include task `bounty` through payload/envelope | `POST /v2/tasks/bid` or v2 task assignment response with `bounty_ns` | proposed; depends on future v2 bidding route design |
 | `POST /tasks/complete` | response includes settlement output such as `earned` in existing tests/flows | `POST /v2/tasks/complete` with `earned_ns` or registry-approved equivalent | proposed field pending |
 | `POST /tasks/reject` | can trigger refund ledger events | legacy adapter over ns-first rejection/refund logic | in scope |
 | `POST /tasks/verify/accept` | can trigger settlement | v2 verify/accept response with ns settlement fields where exposed | in scope |
@@ -29,6 +29,9 @@ it locks the scope for later PRs.
 
 - Timestamp fields such as `created_at`, `updated_at`, `approved_at`, and
   dispute timestamps.
+- Duration fields such as `expires_in_seconds`; these are not financial ledger
+  values and should be revisited separately if v2 later standardizes duration
+  units.
 - Arbitrary provider/user `result_payload` content. Only hub-owned financial
   fields in task/result envelopes are in scope.
 - Reputation `score`, which is non-financial despite using a numeric value.

--- a/hub/nanoseconds.py
+++ b/hub/nanoseconds.py
@@ -1,0 +1,90 @@
+"""Canonical nanosecond helpers for MEP financial values.
+
+This module is intentionally centered on the ns-first model. Float helpers are
+legacy-boundary adapters only; internal money arithmetic should use integer ns.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal, InvalidOperation, ROUND_HALF_EVEN
+from typing import Any
+
+NS_PER_SECOND = 1_000_000_000
+NS_STRING_RE = re.compile(r"^(0|-?[1-9][0-9]*)$")
+
+
+class NanosecondsError(ValueError):
+    """Raised when a financial nanosecond value is malformed."""
+
+
+def _field_label(field_name: str) -> str:
+    return field_name or "amount_ns"
+
+
+def validate_ns_string(value: str, field_name: str = "amount_ns", *, allow_negative: bool = True) -> int:
+    """Validate a canonical v2 ns JSON string and return it as an int.
+
+    Encoding rules:
+    - JSON type is string
+    - value must match ``^(0|-?[1-9][0-9]*)$``
+    - no leading zeroes except exactly "0"
+    - "-0" is forbidden by the regex
+    """
+
+    label = _field_label(field_name)
+    if not isinstance(value, str):
+        raise NanosecondsError(f"{label} must be a decimal string")
+    if not NS_STRING_RE.fullmatch(value):
+        raise NanosecondsError(f"{label} must be a canonical integer string")
+    parsed = int(value)
+    if parsed < 0 and not allow_negative:
+        raise NanosecondsError(f"{label} must be non-negative")
+    return parsed
+
+
+def format_ns_string(value: int, field_name: str = "amount_ns") -> str:
+    """Format an internal integer ns value as a canonical v2 JSON string."""
+
+    return str(assert_ns_amount(value, field_name))
+
+
+def assert_ns_amount(value: Any, field_name: str = "amount_ns") -> int:
+    """Assert that a value is an integer nanosecond amount for internal use."""
+
+    label = _field_label(field_name)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise NanosecondsError(f"{label} must be an integer nanosecond amount")
+    return value
+
+
+def legacy_seconds_to_ns(seconds: float | int | str | Decimal, field_name: str = "amount") -> int:
+    """Convert a legacy SECONDS value to integer ns at the legacy boundary.
+
+    This helper is not migration truth for existing database rows. Backfills
+    should call their own audit path using Decimal(str(value)) and report every
+    non-exact legacy value before cleanup.
+    """
+
+    label = _field_label(field_name)
+    try:
+        decimal_seconds = Decimal(str(seconds))
+    except (InvalidOperation, ValueError) as exc:
+        raise NanosecondsError(f"{label} must be convertible to Decimal seconds") from exc
+
+    ns_value = decimal_seconds * Decimal(NS_PER_SECOND)
+    integral = ns_value.to_integral_value(rounding=ROUND_HALF_EVEN)
+    return int(integral)
+
+
+def ns_to_legacy_seconds(ns: int) -> float:
+    """Convert integer ns to a legacy float SECONDS response value."""
+
+    return float(Decimal(assert_ns_amount(ns)) / Decimal(NS_PER_SECOND))
+
+
+def ns_to_seconds_decimal_string(ns: int) -> str:
+    """Render integer ns as a human-readable decimal SECONDS string."""
+
+    seconds = Decimal(assert_ns_amount(ns)) / Decimal(NS_PER_SECOND)
+    return format(seconds, "f")

--- a/hub/nanoseconds.py
+++ b/hub/nanoseconds.py
@@ -7,7 +7,7 @@ legacy-boundary adapters only; internal money arithmetic should use integer ns.
 from __future__ import annotations
 
 import re
-from decimal import Decimal, InvalidOperation, ROUND_HALF_EVEN
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 NS_PER_SECOND = 1_000_000_000
@@ -73,7 +73,9 @@ def legacy_seconds_to_ns(seconds: float | int | str | Decimal, field_name: str =
         raise NanosecondsError(f"{label} must be convertible to Decimal seconds") from exc
 
     ns_value = decimal_seconds * Decimal(NS_PER_SECOND)
-    integral = ns_value.to_integral_value(rounding=ROUND_HALF_EVEN)
+    integral = ns_value.to_integral_value()
+    if ns_value != integral:
+        raise NanosecondsError(f"{label} must be exactly representable in nanoseconds")
     return int(integral)
 
 

--- a/hub/v2_models.py
+++ b/hub/v2_models.py
@@ -12,14 +12,16 @@ from nanoseconds import validate_ns_string
 
 
 Currency = Literal["MEP_NS"]
+Market = Literal["chat", "compute", "data"]
 NsString = str
+PaymentDirection = Literal["sender_to_receiver", "receiver_to_sender", "none"]
 
 
 class V2TaskEconomics(BaseModel):
     bounty_ns: NsString = Field(..., description="Signed bounty in MEP nanoseconds")
     currency: Currency = "MEP_NS"
-    payment_direction: Optional[str] = None
-    market: Optional[str] = None
+    payment_direction: Optional[PaymentDirection] = None
+    market: Optional[Market] = None
 
     @field_validator("bounty_ns")
     @classmethod

--- a/hub/v2_models.py
+++ b/hub/v2_models.py
@@ -1,0 +1,131 @@
+"""V2 financial API schema definitions.
+
+These schemas are design-lock artifacts for the ns-only financial API surface.
+They are not wired to live routes in PR 1.
+"""
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+from nanoseconds import validate_ns_string
+
+
+Currency = Literal["MEP_NS"]
+NsString = str
+
+
+class V2TaskEconomics(BaseModel):
+    bounty_ns: NsString = Field(..., description="Signed bounty in MEP nanoseconds")
+    currency: Currency = "MEP_NS"
+    payment_direction: Optional[str] = None
+    market: Optional[str] = None
+
+    @field_validator("bounty_ns")
+    @classmethod
+    def _validate_bounty_ns(cls, value: str) -> str:
+        validate_ns_string(value, "bounty_ns")
+        return value
+
+
+class V2BalanceResponse(BaseModel):
+    node_id: str
+    balance_ns: NsString
+    currency: Currency = "MEP_NS"
+
+    @field_validator("balance_ns")
+    @classmethod
+    def _validate_balance_ns(cls, value: str) -> str:
+        validate_ns_string(value, "balance_ns", allow_negative=False)
+        return value
+
+
+class V2RegistrationResponse(BaseModel):
+    status: str
+    node_id: str
+    balance_ns: NsString
+    currency: Currency = "MEP_NS"
+    hub_url: Optional[str] = None
+    ws_url: Optional[str] = None
+
+    @field_validator("balance_ns")
+    @classmethod
+    def _validate_balance_ns(cls, value: str) -> str:
+        validate_ns_string(value, "balance_ns", allow_negative=False)
+        return value
+
+
+class V2TaskSubmitRequest(BaseModel):
+    consumer_id: Optional[str] = None
+    source: Optional[Dict[str, Any]] = None
+    intent: Optional[Dict[str, Any]] = None
+    task: Optional[Dict[str, Any]] = None
+    economics: V2TaskEconomics
+    payload: Optional[str] = None
+    target_node: Optional[str] = None
+    routing: Optional[Dict[str, Any]] = None
+    verifier: Optional[Dict[str, Any]] = None
+    expires_in_seconds: Optional[int] = Field(default=None, ge=1)
+    secret_data: Optional[str] = None
+    payload_uri: Optional[str] = None
+
+
+class V2TaskResponse(BaseModel):
+    task_id: str
+    consumer_id: str
+    provider_id: Optional[str] = None
+    status: str
+    bounty_ns: NsString
+    currency: Currency = "MEP_NS"
+    result_uri: Optional[str] = None
+
+    @field_validator("bounty_ns")
+    @classmethod
+    def _validate_bounty_ns(cls, value: str) -> str:
+        validate_ns_string(value, "bounty_ns")
+        return value
+
+
+class V2EscrowResponse(BaseModel):
+    task_id: str
+    consumer_id: str
+    provider_id: Optional[str] = None
+    amount_ns: NsString
+    currency: Currency = "MEP_NS"
+    status: str
+
+    @field_validator("amount_ns")
+    @classmethod
+    def _validate_amount_ns(cls, value: str) -> str:
+        validate_ns_string(value, "amount_ns", allow_negative=False)
+        return value
+
+
+class V2LedgerEntryResponse(BaseModel):
+    node_id: str
+    amount_ns: NsString
+    balance_ns: Optional[NsString] = None
+    currency: Currency = "MEP_NS"
+    kind: str
+    reference_id: Optional[str] = None
+
+    @field_validator("amount_ns")
+    @classmethod
+    def _validate_amount_ns(cls, value: str) -> str:
+        validate_ns_string(value, "amount_ns")
+        return value
+
+    @field_validator("balance_ns")
+    @classmethod
+    def _validate_balance_ns(cls, value: Optional[str]) -> Optional[str]:
+        if value is not None:
+            validate_ns_string(value, "balance_ns", allow_negative=False)
+        return value
+
+
+class V2EscrowListResponse(BaseModel):
+    escrows: List[V2EscrowResponse]
+
+
+class V2TaskListResponse(BaseModel):
+    tasks: List[V2TaskResponse]

--- a/tests/test_nanoseconds.py
+++ b/tests/test_nanoseconds.py
@@ -1,0 +1,59 @@
+import pytest
+
+from nanoseconds import (
+    NanosecondsError,
+    format_ns_string,
+    legacy_seconds_to_ns,
+    ns_to_legacy_seconds,
+    ns_to_seconds_decimal_string,
+    validate_ns_string,
+)
+from v2_models import V2BalanceResponse, V2TaskEconomics
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("0", 0),
+        ("1", 1),
+        ("5000000000", 5_000_000_000),
+        ("-5000000000", -5_000_000_000),
+    ],
+)
+def test_validate_ns_string_accepts_canonical_values(value, expected):
+    assert validate_ns_string(value, "bounty_ns") == expected
+
+
+@pytest.mark.parametrize("value", ["", "01", "-0", "1.0", 1, None, "+1"])
+def test_validate_ns_string_rejects_non_canonical_values(value):
+    with pytest.raises(NanosecondsError):
+        validate_ns_string(value, "bounty_ns")
+
+
+def test_validate_ns_string_can_require_non_negative():
+    with pytest.raises(NanosecondsError):
+        validate_ns_string("-1", "balance_ns", allow_negative=False)
+
+
+def test_format_ns_string_rejects_float_source_of_truth():
+    assert format_ns_string(5_000_000_000, "bounty_ns") == "5000000000"
+    with pytest.raises(NanosecondsError):
+        format_ns_string(5.0, "bounty_ns")
+
+
+def test_legacy_seconds_adapters_are_boundary_only():
+    assert legacy_seconds_to_ns(5.0) == 5_000_000_000
+    assert legacy_seconds_to_ns("0.001") == 1_000_000
+    assert ns_to_legacy_seconds(1_000_000) == 0.001
+    assert ns_to_seconds_decimal_string(1_000_000) == "0.001"
+
+
+def test_v2_schema_models_validate_ns_strings():
+    balance = V2BalanceResponse(node_id="node_abc", balance_ns="10000000000")
+    assert balance.balance_ns == "10000000000"
+
+    economics = V2TaskEconomics(bounty_ns="-500000000", market="data")
+    assert economics.currency == "MEP_NS"
+
+    with pytest.raises(ValueError):
+        V2BalanceResponse(node_id="node_abc", balance_ns="01")

--- a/tests/test_nanoseconds.py
+++ b/tests/test_nanoseconds.py
@@ -48,6 +48,11 @@ def test_legacy_seconds_adapters_are_boundary_only():
     assert ns_to_seconds_decimal_string(1_000_000) == "0.001"
 
 
+def test_legacy_seconds_to_ns_rejects_non_exact_precision():
+    with pytest.raises(NanosecondsError):
+        legacy_seconds_to_ns("0.0000000015")
+
+
 def test_v2_schema_models_validate_ns_strings():
     balance = V2BalanceResponse(node_id="node_abc", balance_ns="10000000000")
     assert balance.balance_ns == "10000000000"
@@ -57,3 +62,11 @@ def test_v2_schema_models_validate_ns_strings():
 
     with pytest.raises(ValueError):
         V2BalanceResponse(node_id="node_abc", balance_ns="01")
+
+
+def test_v2_task_economics_rejects_unknown_market_and_payment_direction():
+    with pytest.raises(ValueError):
+        V2TaskEconomics(bounty_ns="1", market="foo")
+
+    with pytest.raises(ValueError):
+        V2TaskEconomics(bounty_ns="1", payment_direction="foo")


### PR DESCRIPTION
## Summary
PR 1 foundation for the v2 financial API migration tracked in #224 and designed in #223.

This PR intentionally avoids live endpoint migration, storage changes, and legacy behavior changes. It adds:
- `docs/ns-migration/design-lock.md` with the locked migration decisions and PR sequencing
- `docs/ns-migration/field-registry.md` with canonical v2 field names, types, examples, and status
- `docs/ns-migration/financial-surface-inventory.md` with money-bearing endpoint/schema inventory
- `hub/nanoseconds.py` with canonical ns-first validation/format helpers and legacy-boundary adapters
- `hub/v2_models.py` with v2 ns-only financial schema definitions
- `tests/test_nanoseconds.py` covering canonical `*_ns` string encoding and schema validation

## Design Lock Highlights
- `/v2/...` path versioning
- v2 financial fields are ns-only
- `*_ns` values are decimal strings matching `^(0|-?[1-9][0-9]*)$`
- legacy routes remain compatible during the migration window
- legacy float compatibility is boundary adaptation only
- no storage migration or endpoint rewrite in PR 1

## Test plan
- [x] `python -m pytest tests/test_nanoseconds.py -v`
- [x] `python -m pytest tests/test_hub_api.py tests/test_nanoseconds.py -q` (70 passed)
- [x] `python -m py_compile hub/nanoseconds.py hub/v2_models.py`
- [x] `python -m ruff check hub/ tests/test_nanoseconds.py`

Generated with [Devin](https://cli.devin.ai/docs)
