### PR TITLE
feat(bridge): add GitHub to MEP first-slice bridge

### DIFF
--- a/bridge/__init__.py
+++ b/bridge/__init__.py
@@ -1,0 +1,3 @@
+from .github_to_mep import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1,0 +1,1066 @@
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import sqlite3
+import time
+import uuid
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import requests
+from fastapi import FastAPI, Header, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from clients.shared.identity import MEPIdentity
+from node.task_envelope import build_task_envelope
+
+
+SUPPORTED_GITHUB_EVENTS = {"issue_comment", "pull_request", "pull_request_review_comment"}
+DEFAULT_TRIGGER_VERBS = {
+    "review": "code.review.request",
+    "analyze": "code.review.request",
+    "check": "code.review.request",
+    "comment": "code.review.comment",
+    "approve": "code.review.approve",
+    "triage": "issue.triage.request",
+}
+DEFAULT_ALLOWED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _split_csv(raw: str) -> list[str]:
+    return [item.strip() for item in raw.split(",") if item and item.strip()]
+
+
+def _base64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _base64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+@dataclass(slots=True)
+class BridgeConfig:
+    hub_url: str
+    key_path: str
+    sqlite_path: str
+    webhook_secret: str
+    target_node_id: str
+    target_alias: str
+    trigger_aliases: list[str]
+    public_base_url: str
+    status_secret: str
+    status_token_lifetime_seconds: int
+    dedup_ttl_hours: int
+    coalesce_window_seconds: float
+    coalesce_max_buffer_size: int
+    allowed_repos: set[str]
+    maintainer_only: bool
+    allowed_associations: set[str]
+    bridge_source_alias: str
+    telegram_bot_token: Optional[str]
+    telegram_chat_id: Optional[str]
+    compact_telegram_updates: bool
+
+    @classmethod
+    def from_env(cls) -> "BridgeConfig":
+        target_alias = os.getenv("MEP_BRIDGE_TARGET_ALIAS", "Hub Sentinel").strip() or "Hub Sentinel"
+        trigger_aliases = _split_csv(os.getenv("MEP_BRIDGE_TRIGGER_ALIASES", target_alias))
+        if not trigger_aliases:
+            trigger_aliases = [target_alias]
+        allowed_repos = set(_split_csv(os.getenv("GITHUB_ALLOWED_REPOS", "")))
+        allowed_associations = set(
+            item.upper() for item in _split_csv(os.getenv("MEP_BRIDGE_ALLOWED_ASSOCIATIONS", "OWNER,MEMBER,COLLABORATOR"))
+        ) or set(DEFAULT_ALLOWED_ASSOCIATIONS)
+        return cls(
+            hub_url=os.getenv("MEP_HUB_URL", "").rstrip("/"),
+            key_path=os.getenv(
+                "MEP_BRIDGE_KEY_PATH",
+                os.path.join(os.path.dirname(os.path.abspath(__file__)), "bridge_identity.pem"),
+            ),
+            sqlite_path=os.getenv(
+                "MEP_BRIDGE_SQLITE_PATH",
+                os.path.join(os.path.dirname(os.path.abspath(__file__)), "github_bridge.db"),
+            ),
+            webhook_secret=os.getenv("GITHUB_WEBHOOK_SECRET", ""),
+            target_node_id=os.getenv("MEP_BRIDGE_TARGET_NODE_ID", "").strip(),
+            target_alias=target_alias,
+            trigger_aliases=trigger_aliases,
+            public_base_url=os.getenv("MEP_BRIDGE_PUBLIC_BASE_URL", "http://localhost:8787").rstrip("/"),
+            status_secret=os.getenv("MEP_BRIDGE_STATUS_SECRET", ""),
+            status_token_lifetime_seconds=max(
+                60, int(os.getenv("MEP_BRIDGE_STATUS_TOKEN_LIFETIME_SECONDS", "1800"))
+            ),
+            dedup_ttl_hours=max(1, int(os.getenv("MEP_BRIDGE_DEDUP_TTL_HOURS", "72"))),
+            coalesce_window_seconds=max(
+                0.0, float(os.getenv("MEP_BRIDGE_COALESCE_WINDOW_SECONDS", "10"))
+            ),
+            coalesce_max_buffer_size=max(
+                1, int(os.getenv("MEP_BRIDGE_COALESCE_MAX_BUFFER_SIZE", "50"))
+            ),
+            allowed_repos=allowed_repos,
+            maintainer_only=_env_bool("MEP_BRIDGE_MAINTAINER_ONLY", True),
+            allowed_associations=allowed_associations,
+            bridge_source_alias=os.getenv("MEP_BRIDGE_SOURCE_ALIAS", "GitHub Bridge").strip() or "GitHub Bridge",
+            telegram_bot_token=(os.getenv("TELEGRAM_BOT_TOKEN") or "").strip() or None,
+            telegram_chat_id=(os.getenv("TELEGRAM_CHAT_ID") or "").strip() or None,
+            compact_telegram_updates=_env_bool("MEP_BRIDGE_TELEGRAM_COMPACT", True),
+        )
+
+
+@dataclass(slots=True)
+class NormalizedGitHubEvent:
+    delivery_id: str
+    source_event: str
+    source_action: str
+    repo_full_name: str
+    entity_type: str
+    number: int
+    title: str
+    url: str
+    actor_login: str
+    author_association: str
+    context_id: str
+    imperative_verb: str
+    intent_type: str
+    instructions: str
+    raw_trigger_text: str
+    event_sequence: int = 0
+    bridge_id: str = ""
+    coalesced_delivery_ids: list[str] = field(default_factory=list)
+    coalesced_actions: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class PendingContext:
+    context_id: str
+    bridge_id: str
+    event: NormalizedGitHubEvent
+    first_seen: float
+    flush_task: Optional[asyncio.Task] = None
+
+
+class BridgeStatusUpdate(BaseModel):
+    bridge_id: str
+    status: str = Field(..., min_length=1, max_length=64)
+    context_id: Optional[str] = None
+    target_node_id: Optional[str] = None
+    task_id: Optional[str] = None
+    action: Optional[str] = None
+    timestamp_ms: Optional[int] = None
+    detail: Optional[str] = None
+
+
+class BridgeStore:
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        os.makedirs(os.path.dirname(os.path.abspath(db_path)), exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bridge_deliveries (
+                delivery_id TEXT PRIMARY KEY,
+                bridge_id TEXT NOT NULL,
+                context_id TEXT NOT NULL,
+                source_event TEXT NOT NULL,
+                source_action TEXT NOT NULL,
+                repo_full_name TEXT NOT NULL,
+                issue_number INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                received_at REAL NOT NULL,
+                raw_event TEXT
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bridge_executions (
+                bridge_id TEXT PRIMARY KEY,
+                context_id TEXT NOT NULL,
+                repo_full_name TEXT NOT NULL,
+                issue_number INTEGER NOT NULL,
+                entity_type TEXT NOT NULL,
+                target_node_id TEXT NOT NULL,
+                imperative_verb TEXT NOT NULL,
+                intent_type TEXT NOT NULL,
+                event_sequence INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                task_id TEXT,
+                action TEXT,
+                telegram_message_id TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bridge_context_sequences (
+                context_id TEXT PRIMARY KEY,
+                last_sequence INTEGER NOT NULL
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_bridge_deliveries_context_received
+            ON bridge_deliveries (context_id, received_at)
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def cleanup_expired_deliveries(self, ttl_hours: int) -> None:
+        cutoff = time.time() - max(1, ttl_hours) * 3600.0
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM bridge_deliveries WHERE received_at < ?", (cutoff,))
+        conn.commit()
+        conn.close()
+
+    def delivery_exists(self, delivery_id: str) -> bool:
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute("SELECT 1 FROM bridge_deliveries WHERE delivery_id = ?", (delivery_id,))
+        exists = cursor.fetchone() is not None
+        conn.close()
+        return exists
+
+    def _next_event_sequence(self, context_id: str) -> int:
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT last_sequence FROM bridge_context_sequences WHERE context_id = ?",
+            (context_id,),
+        )
+        row = cursor.fetchone()
+        next_sequence = int(row["last_sequence"]) + 1 if row else 1
+        cursor.execute(
+            """
+            INSERT INTO bridge_context_sequences (context_id, last_sequence)
+            VALUES (?, ?)
+            ON CONFLICT(context_id) DO UPDATE SET last_sequence = excluded.last_sequence
+            """,
+            (context_id, next_sequence),
+        )
+        conn.commit()
+        conn.close()
+        return next_sequence
+
+    def create_execution(self, event: NormalizedGitHubEvent, bridge_id: str, target_node_id: str) -> int:
+        now = time.time()
+        event_sequence = self._next_event_sequence(event.context_id)
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO bridge_executions (
+                bridge_id, context_id, repo_full_name, issue_number, entity_type,
+                target_node_id, imperative_verb, intent_type, event_sequence,
+                status, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                bridge_id,
+                event.context_id,
+                event.repo_full_name,
+                event.number,
+                event.entity_type,
+                target_node_id,
+                event.imperative_verb,
+                event.intent_type,
+                event_sequence,
+                "buffered",
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+        conn.close()
+        return event_sequence
+
+    def record_delivery(
+        self,
+        *,
+        delivery_id: str,
+        bridge_id: str,
+        context_id: str,
+        source_event: str,
+        source_action: str,
+        repo_full_name: str,
+        issue_number: int,
+        status: str,
+        raw_event: dict[str, Any],
+    ) -> None:
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO bridge_deliveries (
+                delivery_id, bridge_id, context_id, source_event, source_action,
+                repo_full_name, issue_number, status, received_at, raw_event
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                delivery_id,
+                bridge_id,
+                context_id,
+                source_event,
+                source_action,
+                repo_full_name,
+                issue_number,
+                status,
+                time.time(),
+                json.dumps(raw_event),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+    def update_execution(
+        self,
+        bridge_id: str,
+        *,
+        status: Optional[str] = None,
+        task_id: Optional[str] = None,
+        action: Optional[str] = None,
+        telegram_message_id: Optional[str] = None,
+    ) -> None:
+        assignments = []
+        params: list[Any] = []
+        if status is not None:
+            assignments.append("status = ?")
+            params.append(status)
+        if task_id is not None:
+            assignments.append("task_id = ?")
+            params.append(task_id)
+        if action is not None:
+            assignments.append("action = ?")
+            params.append(action)
+        if telegram_message_id is not None:
+            assignments.append("telegram_message_id = ?")
+            params.append(str(telegram_message_id))
+        assignments.append("updated_at = ?")
+        params.append(time.time())
+        params.append(bridge_id)
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            f"UPDATE bridge_executions SET {', '.join(assignments)} WHERE bridge_id = ?",
+            params,
+        )
+        conn.commit()
+        conn.close()
+
+    def get_execution(self, bridge_id: str) -> Optional[dict[str, Any]]:
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM bridge_executions WHERE bridge_id = ?", (bridge_id,))
+        row = cursor.fetchone()
+        conn.close()
+        return dict(row) if row else None
+
+
+class DefaultMEPSubmissionClient:
+    def __init__(self, config: BridgeConfig):
+        self.config = config
+        self.identity = MEPIdentity(config.key_path)
+        self.node_id = self.identity.node_id
+        self.session = requests.Session()
+        self._registered = False
+
+    def ensure_registered(self) -> None:
+        if self._registered:
+            return
+        response = self.session.post(
+            f"{self.config.hub_url}/register",
+            json={"pubkey": self.identity.pub_pem, "alias": self.config.bridge_source_alias},
+            timeout=10,
+        )
+        response.raise_for_status()
+        self._registered = True
+
+    def submit_structured_dm(self, envelope: dict[str, Any], target_node_id: str, intent_type: str) -> dict[str, Any]:
+        self.ensure_registered()
+        outer_task = build_task_envelope(
+            self.node_id,
+            json.dumps(envelope),
+            0.0,
+            intent_type=intent_type,
+            target_node=target_node_id,
+        )
+        payload_str = json.dumps(outer_task)
+        headers = self.identity.get_auth_headers(payload_str)
+        headers["Content-Type"] = "application/json"
+        response = self.session.post(
+            f"{self.config.hub_url}/tasks/submit",
+            data=payload_str,
+            headers=headers,
+            timeout=20,
+        )
+        return {"status_code": response.status_code, "json": response.json()}
+
+
+class TelegramNotifier:
+    def __init__(self, config: BridgeConfig):
+        self.config = config
+        self.session = requests.Session()
+
+    def send_or_edit(self, text: str, message_id: Optional[str] = None) -> Optional[str]:
+        if not self.config.telegram_bot_token or not self.config.telegram_chat_id:
+            return message_id
+        base = f"https://api.telegram.org/bot{self.config.telegram_bot_token}"
+        if self.config.compact_telegram_updates and message_id:
+            response = self.session.post(
+                f"{base}/editMessageText",
+                json={
+                    "chat_id": self.config.telegram_chat_id,
+                    "message_id": int(message_id),
+                    "text": text,
+                    "disable_web_page_preview": True,
+                },
+                timeout=10,
+            )
+            response.raise_for_status()
+            return str(message_id)
+        response = self.session.post(
+            f"{base}/sendMessage",
+            json={
+                "chat_id": self.config.telegram_chat_id,
+                "text": text,
+                "disable_web_page_preview": True,
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        result = payload.get("result") if isinstance(payload, dict) else None
+        if isinstance(result, dict) and result.get("message_id") is not None:
+            return str(result["message_id"])
+        return message_id
+
+
+class GitHubToMEPBridgeService:
+    def __init__(
+        self,
+        config: BridgeConfig,
+        *,
+        store: Optional[BridgeStore] = None,
+        submission_client: Optional[Any] = None,
+        notifier: Optional[Any] = None,
+    ):
+        self.config = config
+        self.store = store or BridgeStore(config.sqlite_path)
+        self.submission_client = submission_client or DefaultMEPSubmissionClient(config)
+        self.notifier = notifier or TelegramNotifier(config)
+        self._pending_lock = asyncio.Lock()
+        self._pending_by_context: dict[str, PendingContext] = {}
+
+    def _require_runtime_config(self) -> None:
+        missing = []
+        if not self.config.webhook_secret:
+            missing.append("GITHUB_WEBHOOK_SECRET")
+        if not self.config.hub_url:
+            missing.append("MEP_HUB_URL")
+        if not self.config.target_node_id:
+            missing.append("MEP_BRIDGE_TARGET_NODE_ID")
+        if not self.config.status_secret:
+            missing.append("MEP_BRIDGE_STATUS_SECRET")
+        if missing:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Bridge configuration missing: {', '.join(missing)}",
+            )
+
+    def verify_github_signature(self, body: bytes, signature_header: Optional[str]) -> None:
+        self._require_runtime_config()
+        if not signature_header or not signature_header.startswith("sha256="):
+            raise HTTPException(status_code=401, detail="Missing GitHub signature")
+        expected = hmac.new(
+            self.config.webhook_secret.encode("utf-8"),
+            body,
+            hashlib.sha256,
+        ).hexdigest()
+        provided = signature_header.split("=", 1)[1].strip()
+        if not hmac.compare_digest(expected, provided):
+            raise HTTPException(status_code=401, detail="Invalid GitHub signature")
+
+    async def handle_github_webhook(
+        self,
+        *,
+        delivery_id: str,
+        github_event: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        self._require_runtime_config()
+        if github_event not in SUPPORTED_GITHUB_EVENTS:
+            return {"status": "ignored", "reason": f"unsupported_event:{github_event}"}
+        self.store.cleanup_expired_deliveries(self.config.dedup_ttl_hours)
+        if self.store.delivery_exists(delivery_id):
+            return {"status": "duplicate", "delivery_id": delivery_id}
+        normalized = self._normalize_github_event(delivery_id, github_event, payload)
+        if normalized is None:
+            return {"status": "ignored", "delivery_id": delivery_id, "reason": "non_actionable"}
+        result = await self._buffer_event(normalized, payload)
+        result["delivery_id"] = delivery_id
+        return result
+
+    async def _buffer_event(self, event: NormalizedGitHubEvent, raw_event: dict[str, Any]) -> dict[str, Any]:
+        flush_context_id: Optional[str] = None
+        async with self._pending_lock:
+            pending = self._pending_by_context.get(event.context_id)
+            if pending is not None:
+                pending.event = self._merge_events(pending.event, event)
+                self.store.record_delivery(
+                    delivery_id=event.delivery_id,
+                    bridge_id=pending.bridge_id,
+                    context_id=pending.context_id,
+                    source_event=event.source_event,
+                    source_action=event.source_action,
+                    repo_full_name=event.repo_full_name,
+                    issue_number=event.number,
+                    status="buffered",
+                    raw_event=raw_event,
+                )
+                return {
+                    "status": "buffered",
+                    "bridge_id": pending.bridge_id,
+                    "context_id": pending.context_id,
+                    "coalesced": True,
+                }
+
+            bridge_id = f"br-{secrets.token_hex(8)}"
+            event_sequence = self.store.create_execution(event, bridge_id, self.config.target_node_id)
+            event.bridge_id = bridge_id
+            event.event_sequence = event_sequence
+            if not event.coalesced_delivery_ids:
+                event.coalesced_delivery_ids = [event.delivery_id]
+            if not event.coalesced_actions:
+                event.coalesced_actions = [event.source_action]
+            self.store.record_delivery(
+                delivery_id=event.delivery_id,
+                bridge_id=bridge_id,
+                context_id=event.context_id,
+                source_event=event.source_event,
+                source_action=event.source_action,
+                repo_full_name=event.repo_full_name,
+                issue_number=event.number,
+                status="buffered",
+                raw_event=raw_event,
+            )
+            pending = PendingContext(
+                context_id=event.context_id,
+                bridge_id=bridge_id,
+                event=event,
+                first_seen=time.time(),
+            )
+            pending.flush_task = asyncio.create_task(self._flush_after_delay(event.context_id))
+            self._pending_by_context[event.context_id] = pending
+
+            if len(self._pending_by_context) > self.config.coalesce_max_buffer_size:
+                oldest = min(self._pending_by_context.values(), key=lambda item: item.first_seen)
+                if oldest.context_id != event.context_id:
+                    flush_context_id = oldest.context_id
+
+        if flush_context_id:
+            await self._flush_context(flush_context_id)
+        return {
+            "status": "buffered",
+            "bridge_id": bridge_id,
+            "context_id": event.context_id,
+            "coalesced": False,
+            "event_sequence": event.event_sequence,
+        }
+
+    def _merge_events(
+        self,
+        existing: NormalizedGitHubEvent,
+        incoming: NormalizedGitHubEvent,
+    ) -> NormalizedGitHubEvent:
+        existing.source_action = incoming.source_action or existing.source_action
+        existing.actor_login = incoming.actor_login or existing.actor_login
+        existing.author_association = incoming.author_association or existing.author_association
+        existing.imperative_verb = incoming.imperative_verb or existing.imperative_verb
+        existing.intent_type = incoming.intent_type or existing.intent_type
+        existing.instructions = incoming.instructions or existing.instructions
+        existing.raw_trigger_text = incoming.raw_trigger_text or existing.raw_trigger_text
+        if incoming.delivery_id not in existing.coalesced_delivery_ids:
+            existing.coalesced_delivery_ids.append(incoming.delivery_id)
+        if incoming.source_action and incoming.source_action not in existing.coalesced_actions:
+            existing.coalesced_actions.append(incoming.source_action)
+        return existing
+
+    async def _flush_after_delay(self, context_id: str) -> None:
+        try:
+            await asyncio.sleep(self.config.coalesce_window_seconds)
+            await self._flush_context(context_id)
+        except asyncio.CancelledError:
+            return
+
+    async def _flush_context(self, context_id: str) -> None:
+        async with self._pending_lock:
+            pending = self._pending_by_context.pop(context_id, None)
+        if pending is None:
+            return
+        if pending.flush_task and pending.flush_task is not asyncio.current_task():
+            pending.flush_task.cancel()
+
+        self.store.update_execution(pending.bridge_id, status="submitting")
+        envelope = self._build_interbot_envelope(pending.event)
+        try:
+            response = await asyncio.to_thread(
+                self.submission_client.submit_structured_dm,
+                envelope,
+                self.config.target_node_id,
+                pending.event.intent_type,
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.store.update_execution(pending.bridge_id, status="submit_failed", action="error")
+            await self._notify_status(
+                pending.bridge_id,
+                self._render_status_text(pending.event, "submit_failed", detail=str(exc)),
+            )
+            return
+
+        status_code = int(response.get("status_code") or 500)
+        payload = response.get("json") if isinstance(response, dict) else None
+        if status_code >= 400 or not isinstance(payload, dict):
+            detail = json.dumps(payload) if payload is not None else f"http_{status_code}"
+            self.store.update_execution(pending.bridge_id, status="submit_failed", action="error")
+            await self._notify_status(
+                pending.bridge_id,
+                self._render_status_text(pending.event, "submit_failed", detail=detail),
+            )
+            return
+
+        task_id = payload.get("task_id")
+        execution_status = str(payload.get("status") or "submitted")
+        self.store.update_execution(
+            pending.bridge_id,
+            status=execution_status,
+            task_id=str(task_id) if task_id else None,
+        )
+        await self._notify_status(
+            pending.bridge_id,
+            self._render_status_text(
+                pending.event,
+                execution_status,
+                task_id=str(task_id) if task_id else None,
+            ),
+        )
+
+    async def _notify_status(self, bridge_id: str, text: str) -> None:
+        execution = self.store.get_execution(bridge_id)
+        message_id = execution.get("telegram_message_id") if execution else None
+        new_message_id = await asyncio.to_thread(self.notifier.send_or_edit, text, message_id)
+        if new_message_id and new_message_id != message_id:
+            self.store.update_execution(bridge_id, telegram_message_id=str(new_message_id))
+
+    def _normalize_github_event(
+        self,
+        delivery_id: str,
+        github_event: str,
+        payload: dict[str, Any],
+    ) -> Optional[NormalizedGitHubEvent]:
+        repository = payload.get("repository")
+        if not isinstance(repository, dict):
+            return None
+        repo_full_name = str(repository.get("full_name") or "").strip()
+        if not repo_full_name:
+            return None
+        if self.config.allowed_repos and repo_full_name not in self.config.allowed_repos:
+            return None
+
+        action = str(payload.get("action") or "").strip() or "unknown"
+        entity_type = "pr"
+        subject = payload.get("pull_request")
+        issue = payload.get("issue")
+        if not isinstance(subject, dict) and isinstance(issue, dict):
+            subject = issue
+            entity_type = "pr" if isinstance(issue.get("pull_request"), dict) else "issue"
+        elif not isinstance(subject, dict):
+            return None
+
+        number = payload.get("number", subject.get("number"))
+        if not isinstance(number, int):
+            return None
+        title = str(subject.get("title") or f"{repo_full_name}#{number}")
+        url = str(
+            subject.get("html_url")
+            or (payload.get("comment") or {}).get("html_url")
+            or f"https://github.com/{repo_full_name}"
+        )
+
+        comment = payload.get("comment") if isinstance(payload.get("comment"), dict) else None
+        trigger_text = ""
+        author_association = ""
+        if comment is not None:
+            trigger_text = str(comment.get("body") or "")
+            author_association = str(comment.get("author_association") or "")
+        if not trigger_text:
+            trigger_text = str(subject.get("body") or "")
+        if not author_association:
+            author_association = str(subject.get("author_association") or "")
+        actor_login = str((payload.get("sender") or {}).get("login") or "unknown")
+
+        if self.config.maintainer_only:
+            if author_association.upper() not in self.config.allowed_associations:
+                return None
+
+        trigger = self._extract_trigger(trigger_text)
+        if trigger is None:
+            return None
+        verb, intent_type = trigger
+
+        owner, repo_name = repo_full_name.split("/", 1)
+        context_id = f"github-{owner}-{repo_name}-{entity_type}-{number}"
+        instructions = self._build_instructions(
+            repo_full_name=repo_full_name,
+            entity_type=entity_type,
+            number=number,
+            title=title,
+            url=url,
+            actor_login=actor_login,
+            action=action,
+            imperative_verb=verb,
+            trigger_text=trigger_text,
+        )
+        return NormalizedGitHubEvent(
+            delivery_id=delivery_id,
+            source_event=github_event,
+            source_action=action,
+            repo_full_name=repo_full_name,
+            entity_type=entity_type,
+            number=number,
+            title=title,
+            url=url,
+            actor_login=actor_login,
+            author_association=author_association.upper(),
+            context_id=context_id,
+            imperative_verb=verb,
+            intent_type=intent_type,
+            instructions=instructions,
+            raw_trigger_text=trigger_text.strip(),
+            coalesced_delivery_ids=[delivery_id],
+            coalesced_actions=[action],
+        )
+
+    def _extract_trigger(self, text: str) -> Optional[tuple[str, str]]:
+        if not isinstance(text, str) or not text.strip():
+            return None
+        for alias in self.config.trigger_aliases:
+            pattern = re.compile(
+                rf"@{re.escape(alias)}\b(?:\s+|[,:]\s*)(?P<verb>[a-z][a-z_-]*)",
+                re.IGNORECASE,
+            )
+            match = pattern.search(text)
+            if not match:
+                continue
+            verb = match.group("verb").strip().lower()
+            intent_type = DEFAULT_TRIGGER_VERBS.get(verb)
+            if intent_type:
+                return verb, intent_type
+        return None
+
+    def _build_instructions(
+        self,
+        *,
+        repo_full_name: str,
+        entity_type: str,
+        number: int,
+        title: str,
+        url: str,
+        actor_login: str,
+        action: str,
+        imperative_verb: str,
+        trigger_text: str,
+    ) -> str:
+        clipped_trigger = trigger_text.strip()
+        if len(clipped_trigger) > 1200:
+            clipped_trigger = clipped_trigger[:1200].rstrip() + "..."
+        kind = "pull request" if entity_type == "pr" else "issue"
+        return (
+            f"GitHub {kind} automation request.\n"
+            f"Repository: {repo_full_name}\n"
+            f"{kind.title()} number: {number}\n"
+            f"Title: {title}\n"
+            f"URL: {url}\n"
+            f"Actor: @{actor_login}\n"
+            f"Webhook action: {action}\n"
+            f"Requested verb: {imperative_verb}\n"
+            "Instructions:\n"
+            f"{clipped_trigger}"
+        )
+
+    def _build_interbot_envelope(self, event: NormalizedGitHubEvent) -> dict[str, Any]:
+        timestamp_ms = int(time.time() * 1000)
+        status_endpoint = f"{self.config.public_base_url}/bridge/status"
+        status_token = self._generate_status_token(event.bridge_id, self.config.target_node_id)
+        return {
+            "spec_version": "mep.interbot.v1",
+            "message_id": str(uuid.uuid4()),
+            "trace_id": event.bridge_id,
+            "timestamp_ms": timestamp_ms,
+            "source": {
+                "node_id": self.submission_client.node_id,
+                "alias": self.config.bridge_source_alias,
+            },
+            "target": {
+                "node_id": self.config.target_node_id,
+                "alias": self.config.target_alias,
+            },
+            "conversation": {
+                "context_id": event.context_id,
+                "turn_type": "chat_turn",
+                "turn_index": event.event_sequence,
+            },
+            "intent": {
+                "type": event.intent_type,
+                "priority": "high",
+            },
+            "task": {
+                "title": f"GitHub {event.entity_type.upper()} {event.repo_full_name}#{event.number}",
+                "instructions": event.instructions,
+                "expected_output": {"result_type": "text"},
+                "inputs": {
+                    "bridge_metadata": {
+                        "source_type": "github",
+                        "delivery_id": event.delivery_id,
+                        "bridge_id": event.bridge_id,
+                        "status_endpoint": status_endpoint,
+                        "status_token": status_token,
+                        "event_sequence": event.event_sequence,
+                        "coalesced_delivery_ids": list(event.coalesced_delivery_ids),
+                    },
+                    "github": {
+                        "repo_full_name": event.repo_full_name,
+                        "entity_type": event.entity_type,
+                        "number": event.number,
+                        "url": event.url,
+                        "actor_login": event.actor_login,
+                        "author_association": event.author_association,
+                        "source_event": event.source_event,
+                        "source_action": event.source_action,
+                        "trigger_verb": event.imperative_verb,
+                        "coalesced_actions": list(event.coalesced_actions),
+                    },
+                },
+            },
+            "economics": {
+                "bounty_ns": 0,
+                "currency": "MEP_NS",
+                "market": "chat",
+                "payment_direction": "none",
+            },
+            "delivery": {
+                "reply_mode": "new_dm",
+                "settlement_mode": "task_result",
+            },
+        }
+
+    def _generate_status_token(self, bridge_id: str, target_node_id: str) -> str:
+        exp = int(time.time()) + self.config.status_token_lifetime_seconds
+        claims = {"bridge_id": bridge_id, "target_node_id": target_node_id, "exp": exp}
+        payload = json.dumps(claims, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        signature = hmac.new(
+            self.config.status_secret.encode("utf-8"),
+            payload,
+            hashlib.sha256,
+        ).digest()
+        return f"{_base64url_encode(payload)}.{_base64url_encode(signature)}"
+
+    def _verify_status_token(self, token: str) -> dict[str, Any]:
+        if not token or "." not in token:
+            raise HTTPException(status_code=401, detail="Missing bridge status token")
+        payload_part, sig_part = token.split(".", 1)
+        payload = _base64url_decode(payload_part)
+        provided_sig = _base64url_decode(sig_part)
+        expected_sig = hmac.new(
+            self.config.status_secret.encode("utf-8"),
+            payload,
+            hashlib.sha256,
+        ).digest()
+        if not hmac.compare_digest(expected_sig, provided_sig):
+            raise HTTPException(status_code=401, detail="Invalid bridge status token")
+        claims = json.loads(payload.decode("utf-8"))
+        if int(claims.get("exp") or 0) < int(time.time()):
+            raise HTTPException(status_code=401, detail="Expired bridge status token")
+        return claims
+
+    async def handle_status_callback(self, update: BridgeStatusUpdate, token: str) -> dict[str, Any]:
+        self._require_runtime_config()
+        claims = self._verify_status_token(token)
+        execution = self.store.get_execution(update.bridge_id)
+        if execution is None:
+            raise HTTPException(status_code=404, detail="Unknown bridge_id")
+        if claims.get("bridge_id") != update.bridge_id:
+            raise HTTPException(status_code=403, detail="bridge_id mismatch")
+        expected_target = claims.get("target_node_id")
+        if expected_target and update.target_node_id and expected_target != update.target_node_id:
+            raise HTTPException(status_code=403, detail="target_node_id mismatch")
+        self.store.update_execution(
+            update.bridge_id,
+            status=update.status,
+            task_id=update.task_id,
+            action=update.action,
+        )
+        refreshed = self.store.get_execution(update.bridge_id)
+        event = NormalizedGitHubEvent(
+            delivery_id="",
+            source_event="",
+            source_action="",
+            repo_full_name=str(refreshed["repo_full_name"]),
+            entity_type=str(refreshed["entity_type"]),
+            number=int(refreshed["issue_number"]),
+            title="",
+            url="",
+            actor_login="",
+            author_association="",
+            context_id=str(refreshed["context_id"]),
+            imperative_verb=str(refreshed["imperative_verb"]),
+            intent_type=str(refreshed["intent_type"]),
+            instructions="",
+            raw_trigger_text="",
+            event_sequence=int(refreshed["event_sequence"]),
+            bridge_id=update.bridge_id,
+        )
+        await self._notify_status(
+            update.bridge_id,
+            self._render_status_text(
+                event,
+                update.status,
+                task_id=update.task_id or refreshed.get("task_id"),
+                action=update.action,
+                detail=update.detail,
+            ),
+        )
+        return {"status": "ok", "bridge_id": update.bridge_id}
+
+    def _render_status_text(
+        self,
+        event: NormalizedGitHubEvent,
+        status: str,
+        *,
+        task_id: Optional[str] = None,
+        action: Optional[str] = None,
+        detail: Optional[str] = None,
+    ) -> str:
+        kind = "PR" if event.entity_type == "pr" else "Issue"
+        lines = [
+            f"{kind} {event.repo_full_name}#{event.number}",
+            f"verb: {event.imperative_verb}",
+            f"status: {status}",
+            f"target: {self.config.target_alias} ({self.config.target_node_id})",
+            f"bridge_id: {event.bridge_id}",
+            f"context_id: {event.context_id}",
+        ]
+        if task_id:
+            lines.append(f"task_id: {task_id}")
+        if action:
+            lines.append(f"action: {action}")
+        if detail:
+            lines.append(f"detail: {detail[:300]}")
+        return "\n".join(lines)
+
+    async def shutdown(self) -> None:
+        async with self._pending_lock:
+            pendings = list(self._pending_by_context.values())
+            self._pending_by_context.clear()
+        for pending in pendings:
+            if pending.flush_task:
+                pending.flush_task.cancel()
+
+
+def create_app(
+    *,
+    config: Optional[BridgeConfig] = None,
+    service: Optional[GitHubToMEPBridgeService] = None,
+) -> FastAPI:
+    bridge_config = config or BridgeConfig.from_env()
+    bridge_service = service or GitHubToMEPBridgeService(bridge_config)
+
+    @asynccontextmanager
+    async def lifespan(_: FastAPI):
+        try:
+            yield
+        finally:
+            await bridge_service.shutdown()
+
+    app = FastAPI(
+        title="GitHub To MEP Bridge",
+        description="GitHub webhook bridge that emits actionable MEP DM tasks",
+        version="0.1.0",
+        lifespan=lifespan,
+    )
+    app.state.bridge_service = bridge_service
+
+    @app.get("/health")
+    async def health() -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "bridge": "github_to_mep",
+            "target_node_id": bridge_service.config.target_node_id,
+            "coalesce_window_seconds": bridge_service.config.coalesce_window_seconds,
+        }
+
+    @app.post("/github/webhook")
+    async def github_webhook(
+        request: Request,
+        x_github_event: str = Header(...),
+        x_github_delivery: str = Header(...),
+        x_hub_signature_256: Optional[str] = Header(default=None),
+    ) -> dict[str, Any]:
+        body = await request.body()
+        bridge_service.verify_github_signature(body, x_hub_signature_256)
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid JSON payload: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="GitHub webhook payload must be an object")
+        return await bridge_service.handle_github_webhook(
+            delivery_id=x_github_delivery,
+            github_event=x_github_event,
+            payload=payload,
+        )
+
+    @app.post("/bridge/status")
+    async def bridge_status(
+        update: BridgeStatusUpdate,
+        authorization: Optional[str] = Header(default=None),
+        x_bridge_status_token: Optional[str] = Header(default=None),
+    ) -> dict[str, Any]:
+        token = x_bridge_status_token
+        if not token and authorization and authorization.lower().startswith("bearer "):
+            token = authorization.split(" ", 1)[1].strip()
+        return await bridge_service.handle_status_callback(update, token or "")
+
+    return app
+
+
+app = create_app()

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -31,6 +31,7 @@ DEFAULT_TRIGGER_VERBS = {
     "triage": "issue.triage.request",
 }
 DEFAULT_ALLOWED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+BRIDGE_OUTPUT_MARKER = "<!-- mep-bridge:output"
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -71,6 +72,8 @@ class BridgeConfig:
     allowed_repos: set[str]
     maintainer_only: bool
     allowed_associations: set[str]
+    human_only_triggers: bool
+    trusted_bot_logins: set[str]
     bridge_source_alias: str
     telegram_bot_token: Optional[str]
     telegram_chat_id: Optional[str]
@@ -86,6 +89,9 @@ class BridgeConfig:
         allowed_associations = set(
             item.upper() for item in _split_csv(os.getenv("MEP_BRIDGE_ALLOWED_ASSOCIATIONS", "OWNER,MEMBER,COLLABORATOR"))
         ) or set(DEFAULT_ALLOWED_ASSOCIATIONS)
+        trusted_bot_logins = set(
+            item.lower() for item in _split_csv(os.getenv("MEP_BRIDGE_TRUSTED_BOT_LOGINS", ""))
+        )
         return cls(
             hub_url=os.getenv("MEP_HUB_URL", "").rstrip("/"),
             key_path=os.getenv(
@@ -115,6 +121,8 @@ class BridgeConfig:
             allowed_repos=allowed_repos,
             maintainer_only=_env_bool("MEP_BRIDGE_MAINTAINER_ONLY", True),
             allowed_associations=allowed_associations,
+            human_only_triggers=_env_bool("MEP_BRIDGE_HUMAN_ONLY_TRIGGERS", True),
+            trusted_bot_logins=trusted_bot_logins,
             bridge_source_alias=os.getenv("MEP_BRIDGE_SOURCE_ALIAS", "GitHub Bridge").strip() or "GitHub Bridge",
             telegram_bot_token=(os.getenv("TELEGRAM_BOT_TOKEN") or "").strip() or None,
             telegram_chat_id=(os.getenv("TELEGRAM_CHAT_ID") or "").strip() or None,
@@ -726,7 +734,17 @@ class GitHubToMEPBridgeService:
             trigger_text = str(subject.get("body") or "")
         if not author_association:
             author_association = str(subject.get("author_association") or "")
-        actor_login = str((payload.get("sender") or {}).get("login") or "unknown")
+        sender = payload.get("sender") if isinstance(payload.get("sender"), dict) else {}
+        actor_login = str(sender.get("login") or "unknown")
+        actor_type = str(sender.get("type") or "")
+
+        if self._contains_bridge_output_marker(trigger_text):
+            return None
+
+        if self._is_bot_sender(actor_login, actor_type):
+            actor_login_key = actor_login.strip().lower()
+            if self.config.human_only_triggers and actor_login_key not in self.config.trusted_bot_logins:
+                return None
 
         if self.config.maintainer_only:
             if author_association.upper() not in self.config.allowed_associations:
@@ -786,6 +804,14 @@ class GitHubToMEPBridgeService:
             if intent_type:
                 return verb, intent_type
         return None
+
+    def _contains_bridge_output_marker(self, text: str) -> bool:
+        return isinstance(text, str) and BRIDGE_OUTPUT_MARKER in text.lower()
+
+    def _is_bot_sender(self, actor_login: str, actor_type: str) -> bool:
+        login = actor_login.strip().lower()
+        sender_type = actor_type.strip().lower()
+        return sender_type == "bot" or login.endswith("[bot]")
 
     def _build_instructions(
         self,

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -24,7 +24,7 @@ from node.task_envelope import build_task_envelope
 SUPPORTED_GITHUB_EVENTS = {"issue_comment", "pull_request", "pull_request_review_comment"}
 DEFAULT_TRIGGER_VERBS = {
     "review": "code.review.request",
-    "analyze": "code.review.request",
+    "analyze": "analysis.request",
     "check": "code.review.request",
     "comment": "code.review.comment",
     "approve": "code.review.approve",

--- a/docs/external-bridge/GITHUB_TO_MEP_TELEGRAM_FIRST_SLICE.md
+++ b/docs/external-bridge/GITHUB_TO_MEP_TELEGRAM_FIRST_SLICE.md
@@ -1,0 +1,926 @@
+# GitHub To MEP Bridge - First Slice
+
+## Status
+
+Draft.
+
+This document defines the first practical external-platform bridge for MEP:
+
+- inbound source: GitHub webhooks
+- execution plane: MEP structured DM and targeted `new_task`
+- live continuation: existing DM-to-call bridge when enabled
+- visible operator surface: Telegram status messages
+
+The goal is to solve the current Hub Sentinel failure mode:
+
+- GitHub events already arrive
+- Telegram notifications already show up
+- but the event is not converted into an actionable MEP conversation
+
+This slice fixes that gap without redesigning the whole system.
+
+## Goal
+
+Ship a reusable bridge that lets a bot owner deploy one component and get this behavior:
+
+1. GitHub PR or Issue webhook reaches the bridge.
+2. The bridge validates and normalizes the event.
+3. The bridge submits a targeted `mep.interbot.v1` DM or `new_task` into MEP Hub.
+4. The target bot, such as `Hub Sentinel`, receives an actionable event.
+5. The target bot can stay in structured DM mode or upgrade into live `call.*`.
+6. Telegram shows status updates for visibility and operator trust.
+
+## Why This First Slice
+
+This is the right first slice because:
+
+- GitHub is already the real event source in the current workflow.
+- Telegram is already the visible operator surface.
+- MEP already has the core building blocks:
+  - targeted `new_task`
+  - structured `mep.interbot.v1` DM
+  - DM queue / offline delivery
+  - optional live `call.*` bridge
+- the missing piece is the external platform adapter layer
+
+This slice should not try to solve every external platform at once.
+
+## Non-Goals
+
+This first slice does not include:
+
+- full multi-platform support in one PR
+- a new UI product
+- replacing all existing Telegram adapter behavior
+- persistent storage of every live frame
+- arbitrary bot discovery beyond explicit routing config
+- automatic support for every GitHub event type
+
+## Product Outcome
+
+After this slice:
+
+- GitHub mention-driven review requests can trigger autonomous MEP workflows
+- Telegram remains the human-visible status surface
+- the same bridge pattern can later be reused for Discord or other IM systems
+
+## Core Principle
+
+Telegram is not the execution trigger.
+
+Telegram is the visibility and status surface.
+
+MEP is the execution plane.
+
+So the correct flow is:
+
+`GitHub webhook -> bridge -> MEP task/DM -> bot runtime -> optional call.* -> GitHub action/result -> Telegram status`
+
+Not:
+
+`GitHub webhook -> Telegram only`
+
+## Architecture
+
+### Components
+
+The first slice introduces one new layer:
+
+- **External Bridge**
+  - validates GitHub webhook signature
+  - normalizes GitHub event into internal bridge event
+  - resolves target node / bot
+  - builds `mep.interbot.v1` payload
+  - submits targeted task to MEP Hub
+  - emits Telegram status updates
+
+Existing components remain:
+
+- **MEP Hub**
+  - receives targeted task submission
+  - routes `new_task` to online target
+  - queues DM if target is offline
+  - preserves auditability
+
+- **Target Bot Runtime**
+  - receives `new_task`
+  - processes structured DM
+  - may upgrade to `call.*` if policy allows
+  - returns result through existing workflow
+
+- **Telegram**
+  - receives status updates:
+    - event received
+    - review started
+    - review completed
+    - failed / fallback / manual approval required
+
+### High-Level Flow
+
+1. GitHub sends webhook to the bridge endpoint.
+2. Bridge validates signature and event type.
+3. Bridge extracts repo, PR/Issue number, actor, mention target, URLs, and action details.
+4. Bridge decides whether the event is actionable.
+5. Bridge resolves target bot node.
+6. Bridge builds a structured MEP message with stable `context_id`.
+7. Bridge submits targeted task to MEP Hub.
+8. MEP Hub routes it to the target bot as `new_task`.
+9. Target bot processes the message.
+10. If enabled, runtime upgrades to `call.invite` / `call.frame`.
+11. Telegram receives visible status messages throughout.
+
+## First-Slice Event Scope
+
+### Supported GitHub Events
+
+Start with:
+
+- `pull_request`
+- `issue_comment`
+- `pull_request_review_comment`
+- optionally `issues`
+
+### First-Slice Actionable Cases
+
+Only treat an event as actionable when at least one rule matches:
+
+- PR body contains an actionable bot invocation
+- Issue body contains an actionable bot invocation
+- comment contains an actionable bot invocation
+- repo-specific rule says all PR open/sync events should trigger the bot
+
+### Example Actionable Triggers
+
+- `@Hub-Sentinel review this PR`
+- `@Hub-Sentinel please analyze this issue`
+- repo-level rule: all PR open events go to `Hub Sentinel`
+
+### Trigger Grammar
+
+Simple mention matching is not strong enough for autonomous action.
+
+Examples of weak signals:
+
+- typoed alias
+- ambiguous multi-bot mention
+- sarcastic or negative mention
+- informational mention with no requested action
+
+Recommended first-slice rule:
+
+- parse `@<bot-alias> <imperative verb> ...` as the minimum actionable unit
+- non-imperative mentions may generate notification-only behavior, but should not auto-trigger execution
+
+Examples:
+
+- `@Hub-Sentinel review this PR`
+- `@Hub-Sentinel analyze this issue`
+- `@Hub-Sentinel approve`
+- `@Hub-Sentinel request changes`
+
+Recommended first-slice verb mapping:
+
+- `review` -> `code.review.request`
+- `analyze` -> `analysis.request`
+- `approve` -> `code.review.request` with requested outcome hint
+- `request changes` -> `code.review.request` with requested outcome hint
+
+If a repo-level policy triggers all PR open/sync events automatically, that policy should be explicit in routing configuration rather than inferred from free text.
+
+## Normalized Bridge Event
+
+Every inbound GitHub webhook should be converted into an internal normalized shape before MEP submission.
+
+Example:
+
+```json
+{
+  "source_type": "github",
+  "event_name": "pull_request",
+  "delivery_id": "uuid-from-github",
+  "bridge_id": "br-abc123",
+  "repo_full_name": "owner/repo",
+  "installation_id": null,
+  "action": "opened",
+  "actor": "octocat",
+  "target_alias": "Hub Sentinel",
+  "target_node_id": "node_123",
+  "context_id": "github-owner-repo-pr-226",
+  "thread_key": "owner/repo#226",
+  "event_sequence": 17,
+  "kind": "pull_request",
+  "number": 226,
+  "title": "Add live DM bridge",
+  "html_url": "https://github.com/owner/repo/pull/226",
+  "body_excerpt": "@Hub-Sentinel please review this PR",
+  "actionable": true
+}
+```
+
+This normalized event is the contract between GitHub parsing and MEP submission.
+
+## Correlation Model
+
+The bridge must carry three different identities through the workflow:
+
+- `delivery_id`
+  - GitHub delivery identity
+  - used for webhook replay protection and dedup at ingress
+- `context_id`
+  - MEP conversation identity
+  - used to keep the DM thread and optional live call on one durable thread
+- `bridge_id`
+  - bridge-owned workflow identity
+  - used to correlate one bridge request from webhook ingress to runtime result
+- `event_sequence`
+  - bridge-visible event ordering value for a stable GitHub thread
+  - used to distinguish fresh PR updates from older or superseded ones
+
+Recommended rule:
+
+- the bridge generates a fresh `bridge_id` for each accepted actionable bridge request
+- the bridge persists it before submitting to MEP
+- the runtime echoes it back in bridge status callbacks
+
+Preferred status authentication model:
+
+- pass `status_endpoint` plus a short-lived signed `status_token` in `bridge_metadata`
+- avoid hardcoding bridge callback URLs inside the runtime
+- avoid long-lived plaintext secrets per execution unless there is no better transport option
+- recommended first-slice token format: HMAC-SHA256 signed token with claims `{bridge_id, target_node_id, exp}`
+- recommended first-slice token lifetime: expected bridge execution time plus grace, approximately 30 minutes by default
+
+This separation matters because:
+
+- multiple GitHub deliveries may relate to the same PR thread over time
+- one durable `context_id` may have several bridge executions
+- the bridge still needs one stable key to link `review requested` to `review completed`
+- a stable thread may still need an execution-local ordering hint
+
+## MEP Payload Shape
+
+The bridge should submit a targeted `mep.interbot.v1` message to the bot.
+
+Recommended intent:
+
+- `code.review.request` for PR review
+- `analysis.request` for issues
+- `coordination.request` for operational follow-up
+
+Example payload:
+
+```json
+{
+  "spec_version": "mep.interbot.v1",
+  "message_id": "uuid",
+  "trace_id": "uuid",
+  "timestamp_ms": 1760000000000,
+  "source": {
+    "node_id": "bridge-github"
+  },
+  "target": {
+    "node_id": "node_123"
+  },
+  "conversation": {
+    "context_id": "github-owner-repo-pr-226",
+    "turn_type": "review_request"
+  },
+  "intent": {
+    "type": "code.review.request",
+    "priority": "high"
+  },
+  "task": {
+    "instructions": "Review PR #226 and decide whether to comment, request changes, or approve.",
+    "inputs": {
+      "github_event": {
+        "repo_full_name": "owner/repo",
+        "kind": "pull_request",
+        "number": 226,
+        "action": "opened",
+        "title": "Add live DM bridge",
+        "html_url": "https://github.com/owner/repo/pull/226",
+        "actor": "octocat",
+        "body_excerpt": "@Hub-Sentinel please review this PR"
+      },
+      "bridge_metadata": {
+        "bridge_id": "br-abc123",
+        "source_type": "github",
+        "delivery_id": "uuid-from-github",
+        "source_event": "pull_request",
+        "source_action": "opened",
+        "status_endpoint": "https://bridge.example.com/bridge/status",
+        "status_token": "signed-short-lived-token"
+      }
+    },
+    "expected_output": {
+      "result_type": "text"
+    }
+  },
+  "economics": {
+    "bounty_ns": 0,
+    "currency": "MEP_NS"
+  },
+  "delivery": {
+    "reply_mode": "new_dm",
+    "settlement_mode": "task_result"
+  }
+}
+```
+
+## Context Identity
+
+Every GitHub object must map to a stable MEP thread root.
+
+Recommended rules:
+
+- PR: `github-<owner>-<repo>-pr-<number>`
+- Issue: `github-<owner>-<repo>-issue-<number>`
+
+Recommended companion fields:
+
+- `event_sequence`
+  - monotonic per `context_id` from bridge persistence
+- or `review_epoch`
+  - a bridge-defined integer that increases when a materially new review-worthy event arrives
+
+This matters because:
+
+- DM thread identity must remain stable
+- later `call.*` upgrade needs the same `context_id`
+- Telegram status updates should refer to the same context
+- later comment or review events should continue the same thread
+
+`context_id` is not a replacement for `bridge_id`.
+
+Use:
+
+- `context_id` for the durable conversation thread
+- `bridge_id` for one bridge workflow execution
+- `event_sequence` for ordering and supersession checks within the same thread
+
+This allows the runtime or bridge to distinguish:
+
+- same PR thread, newer commit push
+- same PR thread, older stale queued review
+- same PR thread, follow-up comment on the current review state
+
+## Bridge Status Contract
+
+To close the loop, the runtime must be able to report bridge-visible status back to the bridge.
+
+Recommended endpoint:
+
+`POST /bridge/status`
+
+### Required Request Fields
+
+```json
+{
+  "bridge_id": "br-abc123",
+  "context_id": "github-WUAIBING-MEP-pr-226",
+  "target_node_id": "node_123",
+  "task_id": "task_456",
+  "status": "completed",
+  "action": "approved",
+  "timestamp_ms": 1760000000000
+}
+```
+
+### Recommended Additional Fields
+
+```json
+{
+  "delivery_id": "uuid-from-github",
+  "event_sequence": 17,
+  "result_summary": "Approved after automated review.",
+  "github_result": {
+    "comment_posted": true,
+    "review_submitted": true,
+    "review_decision": "approve"
+  },
+  "error": null
+}
+```
+
+### Status Semantics
+
+Recommended `status` values:
+
+- `accepted`
+- `queued`
+- `started`
+- `completed`
+- `manual_approval_required`
+- `failed`
+
+Recommended `action` values:
+
+- `review_requested`
+- `commented`
+- `approved`
+- `changes_requested`
+- `analysis_completed`
+- `no_action`
+
+### Why This Endpoint Exists
+
+Without `bridge_id`, bridge status calls are anonymous and the bridge cannot reliably determine which bridge execution they belong to.
+
+With `bridge_id`, the bridge can:
+
+- link `review completed` to `review requested`
+- update Telegram status accurately
+- persist a bridge execution timeline
+- deduplicate repeated status calls
+- diagnose partial or failed workflows
+
+### Authentication And Idempotency
+
+`POST /bridge/status` must be authenticated.
+
+Recommended first-slice approach:
+
+- the bridge includes `status_endpoint` and `status_token` in inbound `bridge_metadata`
+- the runtime echoes the token in the callback
+- the bridge verifies token validity, expiry, and target binding
+- use an HMAC-SHA256 signing key controlled by the bridge for first-slice token verification
+
+Recommended idempotency approach:
+
+- key status writes by `bridge_id` plus status phase
+- or by `bridge_id` plus a dedicated status event ID
+- repeated callback delivery must be safe and non-destructive
+
+## Routing Model
+
+The bridge should support explicit routing config.
+
+### First-Slice Routing Inputs
+
+- default target node ID
+- default target alias
+- optional repo-specific target override
+- optional event-type-specific override
+
+### Example
+
+```json
+{
+  "default_target_alias": "Hub Sentinel",
+  "default_target_node_id": "node_123",
+  "repo_rules": {
+    "WUAIBING/MEP": {
+      "target_alias": "Hub Sentinel",
+      "target_node_id": "node_123",
+      "pull_request": {
+        "trigger_mode": "mention_or_open"
+      },
+      "issues": {
+        "trigger_mode": "mention_only"
+      }
+    }
+  }
+}
+```
+
+### Trigger Policy Suggestions
+
+Recommended first-slice policy knobs:
+
+- `mention_only`
+- `imperative_mention_only`
+- `mention_or_open`
+- `maintainer_only`
+
+For production use, prefer `imperative_mention_only` or a repo-explicit automation policy over raw mention matching.
+
+## Actor Authorization
+
+The bridge should define who is allowed to trigger autonomous behavior.
+
+Recommended options:
+
+- allow all repo commenters
+- allow maintainers only
+- allowlist explicit GitHub usernames or teams
+
+For the first slice, a repo-level `maintainer_only` option is strongly recommended for sensitive repositories.
+
+## Telegram Role In First Slice
+
+Telegram remains important, but not as the execution trigger.
+
+### Telegram Should Show
+
+- GitHub event received
+- target bot selected
+- task submitted to MEP
+- target bot online / queued
+- review started
+- review completed
+- fallback or failure reason
+
+### Example Messages
+
+- `GitHub event received: PR #226 in WUAIBING/MEP`
+- `Hub Sentinel review task submitted: context=github-WUAIBING-MEP-pr-226`
+- `Hub Sentinel review started for PR #226`
+- `Hub Sentinel completed review for PR #226`
+- `Hub Sentinel requires manual approval for PR #226`
+
+This keeps Telegram useful while making MEP the real action engine.
+
+### Message Volume Policy
+
+Sending a new Telegram message for every phase is easy to implement but noisy.
+
+Recommended first-slice default:
+
+- create one status message per bridge execution
+- edit that message as status progresses
+
+Example lifecycle:
+
+- `PR #226 review status: received`
+- edit to `PR #226 review status: started`
+- edit to `PR #226 review status: completed`
+
+Recommended modes:
+
+- `compact`
+  - editable progress message
+- `verbose`
+  - separate messages for each transition, useful during rollout and debugging
+
+## Deployment Model
+
+### Recommended Form
+
+Use a standalone bridge worker or isolated bridge module.
+
+This is preferred because it is:
+
+- easier to deploy
+- easier to test
+- easier for other bot owners to reuse
+- easier to extend to Discord later
+
+### Runtime Requirements
+
+The bot or bot owner already knows:
+
+- target node ID
+- bot token
+- GitHub PAT or App credentials
+- GitHub webhook secret
+- MEP Hub URL
+
+That is enough for the first slice.
+
+## Bot Owner Deployment Guide
+
+### Required Environment Variables
+
+Example:
+
+```env
+MEP_HUB_URL=https://mep-hub.example.com
+MEP_WS_URL=wss://mep-hub.example.com
+MEP_BRIDGE_SOURCE_NODE_ID=bridge-github
+MEP_TARGET_NODE_ID=node_123
+MEP_TARGET_ALIAS=Hub Sentinel
+MEP_BRIDGE_STATUS_SECRET=replace-me
+MEP_BRIDGE_DEDUP_TTL_HOURS=72
+MEP_BRIDGE_COALESCE_WINDOW_SECONDS=10
+MEP_BRIDGE_COALESCE_MAX_BUFFER_SIZE=50
+MEP_BRIDGE_STALE_DM_SOFT_TTL_SECONDS=7200
+MEP_BRIDGE_STALE_DM_HARD_TTL_SECONDS=86400
+
+GITHUB_WEBHOOK_SECRET=replace-me
+GITHUB_PAT=replace-me
+GITHUB_ALLOWED_REPOS=WUAIBING/MEP
+
+TELEGRAM_BOT_TOKEN=replace-me
+TELEGRAM_CHAT_ID=replace-me
+
+MEP_LIVE_CALL_ENABLED=true
+MEP_DM_TO_CALL_BRIDGE_ENABLED=true
+MEP_CALL_AUTO_ACCEPT=true
+```
+
+### Bot Owner Steps
+
+1. Deploy or update the MEP Hub.
+2. Ensure the target bot runtime is online.
+3. Set the bridge environment variables.
+4. Start the bridge service.
+5. Confirm the bridge can reach MEP Hub.
+6. Confirm the target node ID is correct.
+7. Confirm Telegram notification works.
+8. Trigger a GitHub test webhook.
+9. Verify that the event becomes a targeted MEP task, not just a Telegram notification.
+
+## GitHub Webhook Setup Guide
+
+### Repository Owner Steps
+
+1. Open the GitHub repository.
+2. Go to `Settings -> Webhooks`.
+3. Click `Add webhook`.
+4. Set the payload URL to the bridge endpoint.
+5. Set content type to `application/json`.
+6. Set the shared secret to the configured `GITHUB_WEBHOOK_SECRET`.
+7. Select events:
+   - `Pull requests`
+   - `Issue comments`
+   - `Pull request review comments`
+   - optionally `Issues`
+8. Save the webhook.
+9. Use GitHub's redelivery test to confirm the bridge returns success.
+
+### Validation Expectations
+
+The bridge must:
+
+- reject invalid signatures
+- reject unsupported repos if allowlisted
+- return clear non-2xx errors for invalid requests
+- return 2xx only when the event is accepted and processed or intentionally ignored
+
+### Replay Protection
+
+Replay protection must be persisted, not in-memory only.
+
+Recommended rule:
+
+- persist `delivery_id -> bridge_id, timestamp, status`
+- retain for at least 72 hours
+- survive bridge restarts
+
+This prevents duplicate GitHub redelivery from causing duplicate reviews.
+
+### Event Coalescence
+
+GitHub frequently emits multiple related events for the same PR within seconds.
+
+Recommended first-slice rule:
+
+- buffer events by `context_id` for 5-10 seconds
+- deduplicate or merge rapid-fire events
+- submit one consolidated actionable task where possible
+- cap the coalescence buffer to a bounded size and flush oldest buffered contexts when the cap is exceeded
+
+Example burst:
+
+- PR opened
+- synchronize after force-push
+- issue comment mention
+- review comment mention
+
+These should not necessarily produce four independent autonomous reviews.
+
+## Execution Behavior
+
+### Online Target
+
+If the target bot is online:
+
+- bridge submits targeted task
+- hub routes `new_task`
+- runtime processes task immediately
+- runtime may upgrade to `call.*`
+
+The bridge should not trust registry presence alone as proof that delivery succeeded.
+
+If the target appears online but live delivery cannot be confirmed, the bridge must treat the node as a possible ghost node and fall back to queue-safe behavior where appropriate.
+
+### Offline Target
+
+If the target bot is offline:
+
+- bridge still submits targeted task
+- hub queues the zero-bounty DM
+- Telegram status says queued, not failed
+- bot processes it when it reconnects
+
+This gives voicemail semantics instead of dropping the event.
+
+### Staleness Policy For Queued DMs
+
+Queued autonomous work must not execute indefinitely without freshness checks.
+
+Recommended first-slice policy:
+
+- if the queued item is older than 2 hours and the PR or Issue is already closed or merged, auto-skip and notify Telegram
+- if the queued item is older than 24 hours, do not auto-process; notify the operator and require a fresh trigger or explicit policy override
+
+This prevents a reconnecting bot from acting on stale review requests.
+
+## Failure Handling
+
+### Signature Failure
+
+- reject request
+- do not submit to MEP
+- optionally log local warning only
+
+### Unsupported Event
+
+- accept but ignore
+- optional Telegram debug message in verbose mode only
+
+### MEP Submission Failure
+
+- report Telegram failure
+- include repo, number, and reason
+- keep enough metadata for retry
+- preserve `bridge_id` for later retry or operator diagnosis
+
+### Replay Or Duplicate Delivery
+
+- detect duplicate `delivery_id`
+- return the persisted bridge outcome when safe
+- never create a second autonomous review for the same deduplicated delivery unless policy explicitly replays it
+
+### Target Not Routed
+
+- report configuration error
+- do not silently drop the event
+
+### Bot Requires Human Approval
+
+- send Telegram status
+- preserve `context_id`
+- preserve `bridge_id`
+- do not lose thread identity
+
+### Bridge Status Failure
+
+- reject unauthenticated status requests
+- reject requests without `bridge_id`
+- accept idempotent retried status updates for the same `bridge_id`
+- report correlation failures explicitly instead of silently dropping them
+
+### Ghost Node Delivery Failure
+
+- if a node appears online but the bridge cannot confirm live routing or the hub falls back, preserve queue-safe semantics
+- record the incident as ghost-node or stale-registration behavior for diagnosis
+
+## Observability
+
+The bridge must log:
+
+- webhook received
+- signature verified
+- event normalized
+- actionable decision
+- coalescence decision
+- target resolved
+- MEP submission result
+- Telegram notification result
+- bridge status callback received
+- final workflow outcome if known
+
+Recommended structured fields:
+
+- `source_type`
+- `delivery_id`
+- `bridge_id`
+- `event_sequence`
+- `repo_full_name`
+- `kind`
+- `number`
+- `context_id`
+- `target_node_id`
+- `actionable`
+- `submission_status`
+
+## Security
+
+### Required
+
+- verify GitHub webhook signature
+- authenticate `POST /bridge/status`
+- allowlist repositories where needed
+- do not trust mention text alone without repo policy
+- bind status tokens to bridge execution or trusted bot identity with expiry
+- keep PAT and webhook secret out of logs
+- send only sanitized excerpts to Telegram
+
+### Recommended
+
+- use GitHub App auth later instead of broad PAT
+- add replay protection keyed by GitHub delivery ID
+- make bridge status updates idempotent by `bridge_id` plus status phase or status event ID
+- prefer persisted replay protection with at least 72h retention
+- add trigger actor permission checks for sensitive repos
+- add rate limits per repo
+
+## Implementation Shape
+
+### First PR Scope
+
+Build:
+
+- GitHub webhook endpoint or bridge worker receiver
+- event normalizer
+- target resolver
+- MEP structured DM builder
+- bridge correlation store keyed by `bridge_id`
+- persisted replay-protection store keyed by `delivery_id`
+- coalescence buffer keyed by `context_id`
+- coalescence max-buffer guard to prevent unbounded buffered contexts under burst load
+- targeted submission to hub
+- authenticated `/bridge/status` endpoint
+- Telegram status notifier
+- focused tests
+- deployment docs
+
+Do not build yet:
+
+- Discord adapter
+- Slack adapter
+- full bidirectional IM reply system
+- large UI/dashboard
+
+## File Targets
+
+Suggested first-slice targets:
+
+- `docs/external-bridge/GITHUB_TO_MEP_TELEGRAM_FIRST_SLICE.md`
+- `hub/main.py` or new bridge module entrypoint
+- new bridge normalization module
+- new bridge config module
+- new bridge Telegram notifier module
+- focused tests under `tests/`
+
+If a standalone worker is preferred, use a dedicated module path rather than hardwiring all bridge logic into the hub.
+
+## Acceptance Criteria
+
+This slice is successful when:
+
+1. a GitHub mention event is accepted and verified
+2. the bridge resolves the correct target node
+3. the bridge submits a targeted `mep.interbot.v1` task to MEP Hub
+4. the target bot receives the event as `new_task`
+5. Telegram shows visible status updates
+6. the existing runtime can optionally upgrade the thread into `call.*`
+7. offline targets are queued instead of silently dropped
+8. bridge status updates correlate back to the original request with `bridge_id`
+9. stale queued work is skipped or escalated according to policy
+10. rapid-fire webhook bursts are coalesced into safe actionable work
+11. failures are explicit and diagnosable
+
+## Minimal Test Plan
+
+Add focused tests for:
+
+- valid webhook signature -> event accepted
+- invalid webhook signature -> rejected
+- PR mention -> actionable structured DM submitted
+- non-actionable event -> ignored cleanly
+- non-imperative mention -> notify-only or ignored according to policy
+- target online -> `new_task` delivered
+- target offline -> queued DM behavior
+- ghost node appears online but cannot receive -> queue-safe handling
+- queued DM older than soft TTL and closed PR -> auto-skip
+- queued DM older than hard TTL -> operator-visible escalation
+- rapid webhook burst on same PR -> coalesced submission
+- Telegram status notification emitted
+- stable `context_id` for repeated events on same PR
+- increasing `event_sequence` for same thread
+- `bridge_id` present in inbound DM payload
+- authenticated `POST /bridge/status` accepted and correlated
+- duplicate status update handled idempotently
+- duplicate `delivery_id` handled from persisted dedup state
+
+## Numeric Safety Note
+
+This first slice uses `bounty_ns = 0` with `currency = "MEP_NS"` for targeted bridge-triggered DM by default.
+
+If future bridge policy introduces computed bounty values, use precise decimal handling rather than raw binary float arithmetic.
+
+Recommended pattern:
+
+- parse external numeric input as decimal-safe strings
+- convert using `Decimal(str(value))`
+- convert to integer nanoseconds at the final protocol boundary
+
+## Recommended Next PR Title
+
+```text
+feat(bridge): add GitHub-to-MEP bridge with Telegram status updates
+```
+
+## Final Note
+
+The correct first product slice is not "GitHub to Telegram only".
+
+The correct first slice is:
+
+- GitHub as the external source
+- MEP as the action engine
+- Telegram as the status surface
+
+That keeps the architecture clean, makes Hub Sentinel actually autonomous, and creates a reusable bridge pattern for future IM platforms.

--- a/docs/external-bridge/GITHUB_TO_MEP_TELEGRAM_FIRST_SLICE.md
+++ b/docs/external-bridge/GITHUB_TO_MEP_TELEGRAM_FIRST_SLICE.md
@@ -72,6 +72,10 @@ Telegram is the visibility and status surface.
 
 MEP is the execution plane.
 
+The bridge webhook endpoint is the canonical production ingress for GitHub.
+
+Any older hub-side GitHub webhook path should be treated as a temporary stopgap used to prove WS notification flow, not as the long-term integration boundary.
+
 So the correct flow is:
 
 `GitHub webhook -> bridge -> MEP task/DM -> bot runtime -> optional call.* -> GitHub action/result -> Telegram status`
@@ -644,6 +648,12 @@ MEP_CALL_AUTO_ACCEPT=true
    - optionally `Issues`
 8. Save the webhook.
 9. Use GitHub's redelivery test to confirm the bridge returns success.
+
+### Production Routing Note
+
+- production-correct target: `${MEP_BRIDGE_PUBLIC_BASE_URL}/github/webhook`
+- do not use a legacy hub-side GitHub webhook path as the long-term integration target once the bridge is deployed
+- if a hub-side path still exists in an older deployment, treat it as compatibility or migration-only behavior and move GitHub to the bridge endpoint after rollout
 
 ### Validation Expectations
 

--- a/docs/external-bridge/GITHUB_TO_MEP_TELEGRAM_FIRST_SLICE.md
+++ b/docs/external-bridge/GITHUB_TO_MEP_TELEGRAM_FIRST_SLICE.md
@@ -175,15 +175,21 @@ Examples:
 
 - `@Hub-Sentinel review this PR`
 - `@Hub-Sentinel analyze this issue`
+- `@Hub-Sentinel check this PR`
+- `@Hub-Sentinel comment on this PR`
 - `@Hub-Sentinel approve`
-- `@Hub-Sentinel request changes`
+- `@Hub-Sentinel triage this issue`
 
 Recommended first-slice verb mapping:
 
 - `review` -> `code.review.request`
 - `analyze` -> `analysis.request`
+- `check` -> `code.review.request`
+- `comment` -> `code.review.comment`
 - `approve` -> `code.review.request` with requested outcome hint
-- `request changes` -> `code.review.request` with requested outcome hint
+- `triage` -> `issue.triage.request`
+
+For this first implementation, keep imperative verbs single-word. Phrases such as `request changes` remain a follow-up extension unless the parser is explicitly widened.
 
 If a repo-level policy triggers all PR open/sync events automatically, that policy should be explicit in routing configuration rather than inferred from free text.
 
@@ -593,6 +599,7 @@ MEP_BRIDGE_STATUS_SECRET=replace-me
 MEP_BRIDGE_DEDUP_TTL_HOURS=72
 MEP_BRIDGE_COALESCE_WINDOW_SECONDS=10
 MEP_BRIDGE_COALESCE_MAX_BUFFER_SIZE=50
+# reserved follow-up config: documented staleness policy is approved, but bridge-side enforcement is not implemented in this PR
 MEP_BRIDGE_STALE_DM_SOFT_TTL_SECONDS=7200
 MEP_BRIDGE_STALE_DM_HARD_TTL_SECONDS=86400
 
@@ -627,7 +634,7 @@ MEP_CALL_AUTO_ACCEPT=true
 1. Open the GitHub repository.
 2. Go to `Settings -> Webhooks`.
 3. Click `Add webhook`.
-4. Set the payload URL to the bridge endpoint.
+4. Set the payload URL to `${MEP_BRIDGE_PUBLIC_BASE_URL}/github/webhook`.
 5. Set content type to `application/json`.
 6. Set the shared secret to the configured `GITHUB_WEBHOOK_SECRET`.
 7. Select events:
@@ -715,6 +722,8 @@ Recommended first-slice policy:
 - if the queued item is older than 24 hours, do not auto-process; notify the operator and require a fresh trigger or explicit policy override
 
 This prevents a reconnecting bot from acting on stale review requests.
+
+Note: this policy is part of the approved design, but the current PR implements the bridge-side core only. TTL enforcement remains a follow-up change on top of the shipped bridge persistence and status plumbing.
 
 ## Failure Handling
 

--- a/docs/external-bridge/README.md
+++ b/docs/external-bridge/README.md
@@ -1,0 +1,203 @@
+# GitHub-to-MEP Bridge
+
+This bridge connects GitHub webhooks to MEP Hub so a target bot can receive actionable MEP tasks for PR and issue workflows.
+
+This README is the operator-facing deployment guide for the first GitHub-to-MEP bridge slice.
+
+## Production Routing
+
+The canonical production webhook target is:
+
+`{MEP_BRIDGE_PUBLIC_BASE_URL}/github/webhook`
+
+Example:
+
+`https://bridge.example.com/github/webhook`
+
+Do not use an older hub-side GitHub webhook path as the long-term target after the bridge is deployed. That older path may still exist in some environments as a stopgap, but the bridge endpoint is the production-correct ingress.
+
+## What This Bridge Does
+
+- verifies GitHub webhook signatures
+- filters allowed repositories
+- parses explicit bot-trigger phrases
+- normalizes GitHub events into bridge-owned correlation state
+- creates targeted `mep.interbot.v1` DM tasks for MEP Hub
+- supports delivery dedup and same-thread coalescence
+- emits Telegram status updates
+- accepts authenticated `/bridge/status` callbacks from runtime follow-up work
+
+## Current First-Slice Scope
+
+Supported inbound GitHub events:
+
+- `pull_request`
+- `issue_comment`
+- `pull_request_review_comment`
+
+Current actionable trigger verbs:
+
+- `review` -> `code.review.request`
+- `analyze` -> `analysis.request`
+- `check` -> `code.review.request`
+- `comment` -> `code.review.comment`
+- `approve` -> `code.review.approve`
+- `triage` -> `issue.triage.request`
+
+Examples:
+
+- `@Hub-Sentinel review this PR`
+- `@Hub-Sentinel analyze this issue`
+- `@Hub-Sentinel check this PR`
+- `@Hub-Sentinel comment on this PR`
+- `@Hub-Sentinel approve`
+- `@Hub-Sentinel triage this issue`
+
+Current parser limitation:
+
+- first-slice imperative verbs are single-word only
+- phrases like `request changes` are not yet implemented as parser-native actionable commands
+
+## Quick Start
+
+1. Set the required environment variables.
+2. Start the bridge service.
+3. Configure the GitHub webhook to point to the bridge endpoint.
+4. Trigger a GitHub test event with a valid bot invocation.
+5. Verify the bridge creates a targeted MEP task and emits Telegram status.
+
+## Environment Variables
+
+### Required
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| `MEP_HUB_URL` | `https://mep-hub.example.com` | MEP Hub base URL used for task submission |
+| `MEP_BRIDGE_TARGET_NODE_ID` | `node_b2f19654a37c` | Target bot node ID |
+| `MEP_BRIDGE_TARGET_ALIAS` | `Hub Sentinel` | Human-readable target alias |
+| `MEP_BRIDGE_PUBLIC_BASE_URL` | `https://bridge.example.com` | Public base URL for webhook ingress and status callback generation |
+| `MEP_BRIDGE_STATUS_SECRET` | `replace-me` | HMAC signing key for short-lived status tokens |
+| `GITHUB_WEBHOOK_SECRET` | `replace-me` | Shared secret used for GitHub HMAC verification |
+
+### Commonly Used
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| `GITHUB_ALLOWED_REPOS` | `WUAIBING/MEP` | Comma-separated allowlist of `owner/repo` |
+| `TELEGRAM_BOT_TOKEN` | `replace-me` | Telegram bot token for status messages |
+| `TELEGRAM_CHAT_ID` | `123456789` | Telegram chat ID for status messages |
+| `MEP_BRIDGE_TRIGGER_ALIASES` | `Hub-Sentinel` | Comma-separated aliases matched in GitHub text |
+| `MEP_BRIDGE_SOURCE_ALIAS` | `GitHub Bridge` | Alias used when the bridge registers with MEP Hub |
+| `MEP_BRIDGE_KEY_PATH` | `./bridge/bridge_identity.pem` | Bridge signing key path used for MEP auth |
+| `MEP_BRIDGE_SQLITE_PATH` | `./bridge/github_bridge.db` | SQLite persistence path for dedup and correlation |
+
+### Optional Tuning
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MEP_BRIDGE_DEDUP_TTL_HOURS` | `72` | How long to remember seen GitHub deliveries |
+| `MEP_BRIDGE_COALESCE_WINDOW_SECONDS` | `10` | Buffer window for same-context GitHub bursts |
+| `MEP_BRIDGE_COALESCE_MAX_BUFFER_SIZE` | `50` | Max buffered contexts before oldest is flushed |
+| `MEP_BRIDGE_MAINTAINER_ONLY` | `true` | Restrict actionable triggers to maintainer-like associations |
+| `MEP_BRIDGE_ALLOWED_ASSOCIATIONS` | `OWNER,MEMBER,COLLABORATOR` | Allowed GitHub author associations when maintainer-only is enabled |
+| `MEP_BRIDGE_STATUS_TOKEN_LIFETIME_SECONDS` | `1800` | Lifetime for signed `/bridge/status` tokens |
+| `MEP_BRIDGE_TELEGRAM_COMPACT` | `true` | Edit a compact Telegram status message instead of emitting many messages |
+
+Documented but not yet enforced in this first bridge-side implementation:
+
+- `MEP_BRIDGE_STALE_DM_SOFT_TTL_SECONDS`
+- `MEP_BRIDGE_STALE_DM_HARD_TTL_SECONDS`
+
+These remain approved design follow-up settings, not active runtime behavior in this slice.
+
+## Starting The Bridge
+
+The bridge is implemented as a Python module under `bridge/`.
+
+Run it with your preferred ASGI server, for example:
+
+```bash
+uvicorn bridge.github_to_mep:app --host 0.0.0.0 --port 8787
+```
+
+If you deploy behind a reverse proxy, set `MEP_BRIDGE_PUBLIC_BASE_URL` to the externally reachable HTTPS URL.
+
+## GitHub Webhook Setup
+
+1. Open the GitHub repository.
+2. Go to `Settings -> Webhooks`.
+3. Click `Add webhook`.
+4. Set **Payload URL** to:
+
+   `${MEP_BRIDGE_PUBLIC_BASE_URL}/github/webhook`
+
+   Example:
+
+   `https://bridge.example.com/github/webhook`
+
+5. Set **Content type** to `application/json`.
+6. Set **Secret** to the same value as `GITHUB_WEBHOOK_SECRET`.
+7. Select individual events:
+   - `Pull requests`
+   - `Issue comments`
+   - `Pull request review comments`
+   - optionally `Issues`
+8. Save the webhook.
+9. Use GitHub redelivery to confirm the bridge returns success.
+
+## How The Flow Works
+
+```text
+GitHub webhook
+-> bridge /github/webhook
+-> signature verification + normalization
+-> bridge correlation state (delivery_id, bridge_id, context_id)
+-> targeted MEP DM/new_task via hub
+-> target bot runtime
+-> Telegram status updates
+-> optional runtime callback to /bridge/status
+```
+
+## Runtime Contract
+
+The bridge creates structured DM tasks that include:
+
+- `bridge_id`
+- `delivery_id`
+- `context_id`
+- `status_endpoint`
+- `status_token`
+- GitHub context fields under `task.inputs.github`
+
+Runtime-side completion callback is a follow-up integration step. The bridge endpoint is already implemented:
+
+- `POST /bridge/status`
+
+Status tokens are short-lived HMAC-SHA256 signed tokens with claims:
+
+- `bridge_id`
+- `target_node_id`
+- `exp`
+
+## Testing
+
+Run the focused bridge tests:
+
+```bash
+python -m pytest tests/test_github_bridge.py -q
+```
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| Webhook returns `401` | `GITHUB_WEBHOOK_SECRET` must match GitHub webhook secret |
+| Webhook is ignored | repo may not be in `GITHUB_ALLOWED_REPOS`, or trigger text is non-actionable |
+| No Telegram status | verify `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` |
+| Bot does not act | verify `MEP_BRIDGE_TARGET_NODE_ID` is correct and the target bot is online |
+| Duplicate reviews | verify bridge SQLite path is writable and dedup TTL is configured |
+| Too many same-thread events | verify coalescence settings and inspect buffered GitHub actions |
+
+## Related Docs
+
+- [GITHUB_TO_MEP_TELEGRAM_FIRST_SLICE.md](./GITHUB_TO_MEP_TELEGRAM_FIRST_SLICE.md)

--- a/docs/external-bridge/README.md
+++ b/docs/external-bridge/README.md
@@ -24,6 +24,7 @@ Do not use an older hub-side GitHub webhook path as the long-term target after t
 - normalizes GitHub events into bridge-owned correlation state
 - creates targeted `mep.interbot.v1` DM tasks for MEP Hub
 - supports delivery dedup and same-thread coalescence
+- ignores bot-authored GitHub trigger comments by default to prevent bot-to-bot ping-pong loops
 - emits Telegram status updates
 - accepts authenticated `/bridge/status` callbacks from runtime follow-up work
 
@@ -57,6 +58,7 @@ Current parser limitation:
 
 - first-slice imperative verbs are single-word only
 - phrases like `request changes` are not yet implemented as parser-native actionable commands
+- bot-authored GitHub comments are output-only by default unless their login is explicitly trusted
 
 ## Quick Start
 
@@ -100,6 +102,8 @@ Current parser limitation:
 | `MEP_BRIDGE_COALESCE_MAX_BUFFER_SIZE` | `50` | Max buffered contexts before oldest is flushed |
 | `MEP_BRIDGE_MAINTAINER_ONLY` | `true` | Restrict actionable triggers to maintainer-like associations |
 | `MEP_BRIDGE_ALLOWED_ASSOCIATIONS` | `OWNER,MEMBER,COLLABORATOR` | Allowed GitHub author associations when maintainer-only is enabled |
+| `MEP_BRIDGE_HUMAN_ONLY_TRIGGERS` | `true` | Ignore bot-authored trigger comments unless explicitly trusted |
+| `MEP_BRIDGE_TRUSTED_BOT_LOGINS` | `` | Comma-separated bot logins allowed to trigger automation |
 | `MEP_BRIDGE_STATUS_TOKEN_LIFETIME_SECONDS` | `1800` | Lifetime for signed `/bridge/status` tokens |
 | `MEP_BRIDGE_TELEGRAM_COMPACT` | `true` | Edit a compact Telegram status message instead of emitting many messages |
 
@@ -179,6 +183,8 @@ Status tokens are short-lived HMAC-SHA256 signed tokens with claims:
 - `target_node_id`
 - `exp`
 
+Bridge-generated GitHub output comments should be marked with hidden provenance such as `<!-- mep-bridge:output ... -->`. The bridge suppresses trigger processing for comments containing that marker so bot result messages do not recursively reopen automation.
+
 ## Testing
 
 Run the focused bridge tests:
@@ -197,6 +203,7 @@ python -m pytest tests/test_github_bridge.py -q
 | Bot does not act | verify `MEP_BRIDGE_TARGET_NODE_ID` is correct and the target bot is online |
 | Duplicate reviews | verify bridge SQLite path is writable and dedup TTL is configured |
 | Too many same-thread events | verify coalescence settings and inspect buffered GitHub actions |
+| Bots retrigger each other | keep `MEP_BRIDGE_HUMAN_ONLY_TRIGGERS=true` and do not allowlist result-posting bot accounts |
 
 ## Related Docs
 

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -64,7 +64,7 @@ def _build_config(tmp_dir: str) -> BridgeConfig:
         status_secret="status-secret",
         status_token_lifetime_seconds=1800,
         dedup_ttl_hours=72,
-        coalesce_window_seconds=0.02,
+        coalesce_window_seconds=60.0,
         coalesce_max_buffer_size=50,
         allowed_repos={"WUAIBING/MEP"},
         maintainer_only=True,

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -176,6 +176,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(len(self.submission.calls), 1)
         bridge_metadata = self.submission.calls[0]["envelope"]["task"]["inputs"]["bridge_metadata"]
         self.assertEqual(set(bridge_metadata["coalesced_delivery_ids"]), {"delivery-a", "delivery-b"})
+        self.assertEqual(self.submission.calls[0]["intent_type"], "analysis.request")
         github_inputs = self.submission.calls[0]["envelope"]["task"]["inputs"]["github"]
         self.assertEqual(github_inputs["source_action"], "edited")
 

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1,0 +1,227 @@
+import hashlib
+import hmac
+import json
+import os
+import sys
+import tempfile
+import time
+import asyncio
+import unittest
+
+from fastapi.testclient import TestClient
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+
+from bridge.github_to_mep import BridgeConfig, BridgeStore, GitHubToMEPBridgeService, create_app  # noqa: E402
+
+
+class _FakeSubmissionClient:
+    def __init__(self):
+        self.node_id = "node_bridge"
+        self.calls = []
+
+    def submit_structured_dm(self, envelope, target_node_id, intent_type):
+        self.calls.append(
+            {
+                "envelope": envelope,
+                "target_node_id": target_node_id,
+                "intent_type": intent_type,
+            }
+        )
+        return {
+            "status_code": 200,
+            "json": {
+                "status": "queued",
+                "task_id": f"task-{len(self.calls)}",
+            },
+        }
+
+
+class _FakeNotifier:
+    def __init__(self):
+        self.calls = []
+
+    def send_or_edit(self, text, message_id=None):
+        if message_id is None:
+            next_id = str(len(self.calls) + 100)
+        else:
+            next_id = str(message_id)
+        self.calls.append({"text": text, "message_id": next_id, "editing": message_id is not None})
+        return next_id
+
+
+def _build_config(tmp_dir: str) -> BridgeConfig:
+    return BridgeConfig(
+        hub_url="http://hub.example.test",
+        key_path=os.path.join(tmp_dir, "bridge_identity.pem"),
+        sqlite_path=os.path.join(tmp_dir, "bridge.sqlite3"),
+        webhook_secret="github-secret",
+        target_node_id="node_target",
+        target_alias="Hub Sentinel",
+        trigger_aliases=["Hub-Sentinel"],
+        public_base_url="http://bridge.example.test",
+        status_secret="status-secret",
+        status_token_lifetime_seconds=1800,
+        dedup_ttl_hours=72,
+        coalesce_window_seconds=0.02,
+        coalesce_max_buffer_size=50,
+        allowed_repos={"WUAIBING/MEP"},
+        maintainer_only=True,
+        allowed_associations={"OWNER", "MEMBER", "COLLABORATOR"},
+        bridge_source_alias="GitHub Bridge",
+        telegram_bot_token=None,
+        telegram_chat_id=None,
+        compact_telegram_updates=True,
+    )
+
+
+def _sign_payload(secret: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _issue_comment_payload(comment_body: str, *, action: str = "created", delivery_number: int = 226) -> dict:
+    return {
+        "action": action,
+        "repository": {"full_name": "WUAIBING/MEP"},
+        "issue": {
+            "number": delivery_number,
+            "title": "Bridge automation",
+            "html_url": f"https://github.com/WUAIBING/MEP/pull/{delivery_number}",
+            "pull_request": {"url": f"https://api.github.com/repos/WUAIBING/MEP/pulls/{delivery_number}"},
+            "author_association": "MEMBER",
+        },
+        "comment": {
+            "body": comment_body,
+            "html_url": f"https://github.com/WUAIBING/MEP/pull/{delivery_number}#discussion_r1",
+            "author_association": "MEMBER",
+        },
+        "sender": {"login": "alice"},
+    }
+
+
+class TestGitHubToMEPBridge(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix="mep_bridge_")
+        self.config = _build_config(self.tmp_dir)
+        self.store = BridgeStore(self.config.sqlite_path)
+        self.submission = _FakeSubmissionClient()
+        self.notifier = _FakeNotifier()
+        self.service = GitHubToMEPBridgeService(
+            self.config,
+            store=self.store,
+            submission_client=self.submission,
+            notifier=self.notifier,
+        )
+        self.client = TestClient(create_app(config=self.config, service=self.service))
+
+    def tearDown(self):
+        self.client.close()
+
+    def _post_webhook(self, payload: dict, *, delivery_id: str, event_name: str = "issue_comment"):
+        body = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "X-GitHub-Event": event_name,
+            "X-GitHub-Delivery": delivery_id,
+            "X-Hub-Signature-256": _sign_payload(self.config.webhook_secret, body),
+        }
+        return self.client.post("/github/webhook", content=body, headers=headers)
+
+    def _flush_context(self, context_id: str) -> None:
+        asyncio.run(self.service._flush_context(context_id))
+
+    def test_actionable_webhook_submits_structured_dm_after_coalescence(self):
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR"),
+            delivery_id="delivery-1",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()["status"], "buffered")
+        self._flush_context(response.json()["context_id"])
+
+        self.assertEqual(len(self.submission.calls), 1)
+        call = self.submission.calls[0]
+        envelope = call["envelope"]
+        self.assertEqual(call["target_node_id"], "node_target")
+        self.assertEqual(call["intent_type"], "code.review.request")
+        self.assertEqual(envelope["economics"]["bounty_ns"], 0)
+        self.assertEqual(envelope["economics"]["currency"], "MEP_NS")
+        bridge_metadata = envelope["task"]["inputs"]["bridge_metadata"]
+        self.assertEqual(bridge_metadata["source_type"], "github")
+        self.assertEqual(bridge_metadata["coalesced_delivery_ids"], ["delivery-1"])
+        self.assertIn("/bridge/status", bridge_metadata["status_endpoint"])
+        self.assertTrue(bridge_metadata["status_token"])
+
+    def test_duplicate_delivery_is_deduplicated(self):
+        payload = _issue_comment_payload("@Hub-Sentinel review this PR")
+        first = self._post_webhook(payload, delivery_id="delivery-dup")
+        second = self._post_webhook(payload, delivery_id="delivery-dup")
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(second.json()["status"], "duplicate")
+
+    def test_same_context_bursts_are_coalesced_into_one_submission(self):
+        payload_one = _issue_comment_payload("@Hub-Sentinel review this PR", action="created")
+        payload_two = _issue_comment_payload("@Hub-Sentinel analyze this PR", action="edited")
+
+        first = self._post_webhook(payload_one, delivery_id="delivery-a")
+        second = self._post_webhook(payload_two, delivery_id="delivery-b")
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self._flush_context(first.json()["context_id"])
+
+        self.assertEqual(len(self.submission.calls), 1)
+        bridge_metadata = self.submission.calls[0]["envelope"]["task"]["inputs"]["bridge_metadata"]
+        self.assertEqual(set(bridge_metadata["coalesced_delivery_ids"]), {"delivery-a", "delivery-b"})
+        github_inputs = self.submission.calls[0]["envelope"]["task"]["inputs"]["github"]
+        self.assertEqual(github_inputs["source_action"], "edited")
+
+    def test_status_callback_requires_valid_token_and_updates_existing_message(self):
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel approve this PR"),
+            delivery_id="delivery-status",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        self.assertEqual(len(self.submission.calls), 1)
+        initial_message = self.notifier.calls[-1]
+        self.assertFalse(initial_message["editing"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-1",
+                "action": "approved",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+
+        self.assertEqual(len(self.notifier.calls), 2)
+        final_message = self.notifier.calls[-1]
+        self.assertTrue(final_message["editing"])
+        self.assertIn("status: completed", final_message["text"])
+        self.assertIn("action: approved", final_message["text"])
+
+    def test_non_maintainer_trigger_is_ignored_when_policy_enabled(self):
+        payload = _issue_comment_payload("@Hub-Sentinel review this PR")
+        payload["comment"]["author_association"] = "CONTRIBUTOR"
+        payload["issue"]["author_association"] = "CONTRIBUTOR"
+        response = self._post_webhook(payload, delivery_id="delivery-policy")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ignored")
+        time.sleep(0.05)
+        self.assertEqual(len(self.submission.calls), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -69,6 +69,8 @@ def _build_config(tmp_dir: str) -> BridgeConfig:
         allowed_repos={"WUAIBING/MEP"},
         maintainer_only=True,
         allowed_associations={"OWNER", "MEMBER", "COLLABORATOR"},
+        human_only_triggers=True,
+        trusted_bot_logins=set(),
         bridge_source_alias="GitHub Bridge",
         telegram_bot_token=None,
         telegram_chat_id=None,
@@ -81,7 +83,14 @@ def _sign_payload(secret: str, body: bytes) -> str:
     return f"sha256={digest}"
 
 
-def _issue_comment_payload(comment_body: str, *, action: str = "created", delivery_number: int = 226) -> dict:
+def _issue_comment_payload(
+    comment_body: str,
+    *,
+    action: str = "created",
+    delivery_number: int = 226,
+    sender_login: str = "alice",
+    sender_type: str = "User",
+) -> dict:
     return {
         "action": action,
         "repository": {"full_name": "WUAIBING/MEP"},
@@ -97,7 +106,7 @@ def _issue_comment_payload(comment_body: str, *, action: str = "created", delive
             "html_url": f"https://github.com/WUAIBING/MEP/pull/{delivery_number}#discussion_r1",
             "author_association": "MEMBER",
         },
-        "sender": {"login": "alice"},
+        "sender": {"login": sender_login, "type": sender_type},
     }
 
 
@@ -218,6 +227,43 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         payload["comment"]["author_association"] = "CONTRIBUTOR"
         payload["issue"]["author_association"] = "CONTRIBUTOR"
         response = self._post_webhook(payload, delivery_id="delivery-policy")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ignored")
+        time.sleep(0.05)
+        self.assertEqual(len(self.submission.calls), 0)
+
+    def test_bot_sender_is_ignored_by_default_to_prevent_ping_pong_loops(self):
+        payload = _issue_comment_payload(
+            "@Hub-Sentinel review this PR",
+            sender_login="hub-sentinel[bot]",
+            sender_type="Bot",
+        )
+        response = self._post_webhook(payload, delivery_id="delivery-bot")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ignored")
+        time.sleep(0.05)
+        self.assertEqual(len(self.submission.calls), 0)
+
+    def test_trusted_bot_sender_can_trigger_when_explicitly_allowlisted(self):
+        self.config.trusted_bot_logins = {"hub-sentinel[bot]"}
+        payload = _issue_comment_payload(
+            "@Hub-Sentinel review this PR",
+            sender_login="hub-sentinel[bot]",
+            sender_type="Bot",
+        )
+        response = self._post_webhook(payload, delivery_id="delivery-trusted-bot")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "buffered")
+        self._flush_context(response.json()["context_id"])
+        self.assertEqual(len(self.submission.calls), 1)
+
+    def test_bridge_output_marker_is_ignored_even_if_trigger_text_is_present(self):
+        payload = _issue_comment_payload(
+            "<!-- mep-bridge:output bridge_id=br-123 -->\n@Hub-Sentinel review this PR",
+            sender_login="hub-sentinel[bot]",
+            sender_type="Bot",
+        )
+        response = self._post_webhook(payload, delivery_id="delivery-output-marker")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "ignored")
         time.sleep(0.05)


### PR DESCRIPTION
## Summary
- add a standalone GitHub -> MEP bridge service for the first slice
- emit structured `mep.interbot.v1` DM tasks with `bridge_id`, `event_sequence`, `status_endpoint`, and signed `status_token`
- add SQLite-backed delivery dedup, coalescence, maintainer gating, and Telegram status update support
- document the approved first-slice design and add focused bridge tests

## Validation
- `python -m pytest tests/test_github_bridge.py -q`

## Notes
- this PR intentionally excludes unrelated local changes such as `clients/shared/stdio_adapter.py`
- this is the bridge-side implementation; runtime-side `/bridge/status` callback emission remains a follow-up step