### PR TITLE
feat(finance): add v2 financial API endpoints

### DIFF
--- a/hub/main.py
+++ b/hub/main.py
@@ -41,6 +41,19 @@ from models import (
     BrainstormSessionPost,
 )
 
+from v2_models import (
+    V2BalanceResponse,
+    V2RegistrationResponse,
+    V2TaskSubmitRequest,
+    V2TaskResponse,
+    V2EscrowResponse,
+    V2EscrowListResponse,
+    V2LedgerEntryResponse,
+    V2TaskListResponse,
+)
+
+from nanoseconds import legacy_seconds_to_ns, ns_to_legacy_seconds
+
 app = FastAPI(title="MEP Hub", description="The Time Exchange Clearinghouse", version="0.1.2", docs_url="/docs", redoc_url="/redoc")
 
 # In-memory storage for active tasks
@@ -1674,6 +1687,37 @@ async def register_node(node: NodeRegistration, request: Request):
 
     return {"status": status, "node_id": node_id, "balance": balance, "hub_url": hub_url, "ws_url": ws_url}
 
+@app.post("/v2/register")
+async def register_node_v2(node: NodeRegistration, request: Request):
+    client_host = _request_client_ip(request)
+    if not _is_allowed_ip(client_host):
+        raise HTTPException(status_code=403, detail="Client IP not allowed")
+    _apply_rate_limit(f"{client_host or 'unknown'}:/register")
+    validated_pubkey = _validate_registration_pubkey(node.pubkey)
+    # Registration derives the Node ID from the validated Ed25519 public key PEM
+    node_id = auth.derive_node_id(validated_pubkey)
+    result = db.register_node(node_id, validated_pubkey)
+    if node.alias or node.x25519_public_key:
+        db.upsert_registry(node_id, node.alias, [], [], {}, "offline", time.time(), node.x25519_public_key)
+
+    status = result["status"]
+    balance = result["balance"]
+    if status == "registered":
+        log_event("node_registered", f"Node {node_id} already registered with balance {balance}", node_id=node_id, balance=balance)
+    else:
+        log_event("node_pending", f"Node {node_id} registration pending approval", node_id=node_id)
+
+    hub_url, ws_url = get_hub_urls(request)
+    balance_ns = legacy_seconds_to_ns(balance, "balance")
+
+    return V2RegistrationResponse(
+        status=status,
+        node_id=node_id,
+        balance_ns=str(balance_ns),
+        hub_url=hub_url,
+        ws_url=ws_url
+    )
+
 @app.post("/admin/approve-registration")
 async def approve_registration(payload: dict, x_mep_admin_key: Optional[str] = Header(default=None)):
     _require_admin(x_mep_admin_key)
@@ -2103,6 +2147,14 @@ async def get_balance(node_id: str):
         raise HTTPException(status_code=404, detail="Node not found")
     return {"node_id": node_id, "balance_seconds": balance}
 
+@app.get("/v2/balance/{node_id}")
+async def get_balance_v2(node_id: str):
+    balance = db.get_balance(node_id)
+    if balance is None:
+        raise HTTPException(status_code=404, detail="Node not found")
+    balance_ns = legacy_seconds_to_ns(balance, "balance")
+    return V2BalanceResponse(node_id=node_id, balance_ns=str(balance_ns))
+
 @app.post("/tasks/submit")
 async def submit_task(
     task: TaskCreate,
@@ -2297,6 +2349,35 @@ async def submit_task(
     if x_mep_idempotency_key:
         db.set_idempotency(authenticated_node, "/tasks/submit", x_mep_idempotency_key, response_payload, 200, time.time())
     return response_payload
+
+@app.post("/v2/tasks/submit")
+async def submit_task_v2(
+    task: V2TaskSubmitRequest,
+    authenticated_node: str = Depends(verify_request),
+    x_mep_idempotency_key: Optional[str] = Header(default=None)
+):
+    # Convert v2 economics to legacy format for internal processing
+    bounty_ns = int(task.economics.bounty_ns)
+    bounty = ns_to_legacy_seconds(bounty_ns, "bounty_ns")
+    
+    # Build legacy TaskCreate from v2 request
+    legacy_task = TaskCreate(
+        consumer_id=task.consumer_id,
+        source=task.source,
+        intent=task.intent,
+        task=task.task,
+        economics={"bounty_seconds": bounty},
+        payload=task.payload,
+        target_node=task.target_node,
+        routing=task.routing,
+        verifier=task.verifier,
+        expires_in_seconds=task.expires_in_seconds,
+        secret_data=task.secret_data,
+        payload_uri=task.payload_uri
+    )
+    
+    # Call the internal task submission logic
+    return await submit_task(legacy_task, authenticated_node, x_mep_idempotency_key)
 
 @app.post("/tasks/cancel")
 async def cancel_task(
@@ -2693,6 +2774,24 @@ async def get_task_result(task_id: str, authenticated_node: str = Depends(verify
         "result_uri": task.get("result_uri")
     }
 
+@app.get("/v2/tasks/{task_id}/result")
+async def get_task_result_v2(task_id: str, authenticated_node: str = Depends(verify_request)):
+    task = db.get_task(task_id)
+    if not task or task["status"] != "completed":
+        raise HTTPException(status_code=404, detail="Task not found or not completed")
+    if authenticated_node not in (task["consumer_id"], task["provider_id"]):
+        raise HTTPException(status_code=403, detail="Not authorized to view this result")
+    
+    bounty_ns = legacy_seconds_to_ns(task["bounty"], "bounty_ns")
+    
+    return V2TaskResponse(
+        task_id=task["task_id"],
+        consumer_id=task["consumer_id"],
+        provider_id=task["provider_id"],
+        bounty_ns=str(bounty_ns),
+        result_uri=task.get("result_uri")
+    )
+
 @app.post("/disputes/open")
 async def open_dispute(payload: DisputeOpen, authenticated_node: str = Depends(verify_request)):
     task = db.get_task(payload.task_id)
@@ -3060,6 +3159,93 @@ async def ledger_entries(limit: int = 50, authenticated_node: str = Depends(veri
     safe_limit = max(1, min(limit, 200))
     entries = _read_audit_entries_for_node(authenticated_node, safe_limit)
     return {"node_id": authenticated_node, "entries": entries, "count": len(entries)}
+
+@app.get("/v2/ledger/{node_id}")
+async def ledger_entries_v2(node_id: str, limit: int = 50, authenticated_node: str = Depends(verify_request)):
+    if authenticated_node != node_id:
+        raise HTTPException(status_code=403, detail="Not authorized to view this ledger")
+    
+    safe_limit = max(1, min(limit, 200))
+    entries = _read_audit_entries_for_node(node_id, safe_limit)
+    
+    # Parse audit entries and convert to structured v2 format
+    v2_entries = []
+    for entry in entries:
+        # Parse audit log format: "TIMESTAMP | Node: node_id | Action: action | Amount: amount | Balance: balance"
+        try:
+            parts = [part.strip() for part in entry.split("|")]
+            entry_dict = {}
+            for part in parts:
+                if ":" in part:
+                    key, value = part.split(":", 1)
+                    entry_dict[key.strip().lower()] = value.strip()
+            
+            # Convert financial values to ns
+            amount_ns = None
+            balance_ns = None
+            if "amount" in entry_dict:
+                try:
+                    amount = float(entry_dict["amount"])
+                    amount_ns = legacy_seconds_to_ns(amount, "amount")
+                except (ValueError, KeyError):
+                    pass
+            if "balance" in entry_dict:
+                try:
+                    balance = float(entry_dict["balance"])
+                    balance_ns = legacy_seconds_to_ns(balance, "balance")
+                except (ValueError, KeyError):
+                    pass
+            
+            v2_entries.append(V2LedgerEntryResponse(
+                node_id=node_id,
+                amount_ns=str(amount_ns) if amount_ns is not None else None,
+                balance_ns=str(balance_ns) if balance_ns is not None else None,
+                kind=entry_dict.get("action", "unknown"),
+                reference_id=entry_dict.get("reference")
+            ))
+        except Exception:
+            # Skip malformed entries
+            continue
+    
+    return V2LedgerEntryResponse(
+        node_id=node_id,
+        entries=v2_entries[:safe_limit]
+    )
+
+@app.get("/v2/escrows/{task_id}")
+async def get_escrow_v2(task_id: str, authenticated_node: str = Depends(verify_request)):
+    escrow = db.get_escrow(task_id)
+    if not escrow:
+        raise HTTPException(status_code=404, detail="Escrow not found")
+    if authenticated_node not in (escrow["consumer_id"], escrow.get("provider_id")):
+        raise HTTPException(status_code=403, detail="Not authorized to view this escrow")
+    
+    amount_ns = legacy_seconds_to_ns(escrow["amount"], "amount")
+    
+    return V2EscrowResponse(
+        task_id=task_id,
+        consumer_id=escrow["consumer_id"],
+        provider_id=escrow.get("provider_id"),
+        amount_ns=str(amount_ns),
+        status=escrow["status"]
+    )
+
+@app.get("/v2/escrows")
+async def list_escrows_v2(authenticated_node: str = Depends(verify_request)):
+    escrows = db.get_escrows_by_node(authenticated_node)
+    
+    v2_escrows = []
+    for escrow in escrows:
+        amount_ns = legacy_seconds_to_ns(escrow["amount"], "amount")
+        v2_escrows.append(V2EscrowResponse(
+            task_id=escrow["task_id"],
+            consumer_id=escrow["consumer_id"],
+            provider_id=escrow.get("provider_id"),
+            amount_ns=str(amount_ns),
+            status=escrow["status"]
+        ))
+    
+    return V2EscrowListResponse(escrows=v2_escrows)
 
 @app.get("/events/recent")
 async def recent_events(limit: int = 50, x_mep_admin_key: Optional[str] = Header(default=None)):

--- a/hub/main.py
+++ b/hub/main.py
@@ -49,7 +49,7 @@ from v2_models import (
     V2EscrowResponse,
     V2EscrowListResponse,
     V2LedgerEntryResponse,
-    V2TaskListResponse,
+    V2LedgerListResponse,
 )
 
 from nanoseconds import legacy_seconds_to_ns, ns_to_legacy_seconds
@@ -2358,7 +2358,7 @@ async def submit_task_v2(
 ):
     # Convert v2 economics to legacy format for internal processing
     bounty_ns = int(task.economics.bounty_ns)
-    bounty = ns_to_legacy_seconds(bounty_ns, "bounty_ns")
+    bounty = ns_to_legacy_seconds(bounty_ns)
     
     # Build legacy TaskCreate from v2 request
     legacy_task = TaskCreate(
@@ -2788,6 +2788,7 @@ async def get_task_result_v2(task_id: str, authenticated_node: str = Depends(ver
         task_id=task["task_id"],
         consumer_id=task["consumer_id"],
         provider_id=task["provider_id"],
+        status=task["status"],
         bounty_ns=str(bounty_ns),
         result_uri=task.get("result_uri")
     )
@@ -3207,7 +3208,7 @@ async def ledger_entries_v2(node_id: str, limit: int = 50, authenticated_node: s
             # Skip malformed entries
             continue
     
-    return V2LedgerEntryResponse(
+    return V2LedgerListResponse(
         node_id=node_id,
         entries=v2_entries[:safe_limit]
     )

--- a/hub/v2_models.py
+++ b/hub/v2_models.py
@@ -125,6 +125,11 @@ class V2LedgerEntryResponse(BaseModel):
         return value
 
 
+class V2LedgerListResponse(BaseModel):
+    node_id: str
+    entries: List[V2LedgerEntryResponse]
+
+
 class V2EscrowListResponse(BaseModel):
     escrows: List[V2EscrowResponse]
 

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -161,6 +161,90 @@ class TestBalance(unittest.TestCase):
         self.assertEqual(resp.status_code, 404)
 
 
+class TestV2Endpoints(unittest.TestCase):
+
+    def setUp(self):
+        main.rate_limits.clear()
+
+    def test_v2_submit_converts_ns_bounty_and_returns_task_id(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "What is 2+2?",
+            "economics": {
+                "bounty_ns": "1000000000",
+                "currency": "MEP_NS",
+            },
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        resp = client.post("/v2/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"V2 submit failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["status"], "success")
+        self.assertIn("task_id", data)
+        self.assertEqual(db.get_task(data["task_id"])["bounty"], 1.0)
+
+    def test_v2_task_result_includes_status_and_bounty_ns(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "What is 2+2?",
+            "economics": {
+                "bounty_ns": "1000000000",
+                "currency": "MEP_NS",
+            },
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/v2/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(submit.status_code, 200, submit.text)
+        task_id = submit.json()["task_id"]
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+        bid = client.post("/tasks/bid", content=bid_payload, headers=headers)
+        self.assertEqual(bid.status_code, 200, bid.text)
+
+        complete_payload = json.dumps({
+            "task_id": task_id,
+            "provider_id": provider_id,
+            "result_payload": "4",
+        })
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        complete = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(complete.status_code, 200, complete.text)
+
+        headers = _auth_headers(consumer_priv, consumer_id, "")
+        result = client.get(f"/v2/tasks/{task_id}/result", headers=headers)
+        self.assertEqual(result.status_code, 200, result.text)
+        data = result.json()
+        self.assertEqual(data["status"], "completed")
+        self.assertEqual(data["bounty_ns"], "1000000000")
+        self.assertEqual(data["consumer_id"], consumer_id)
+        self.assertEqual(data["provider_id"], provider_id)
+
+    def test_v2_ledger_returns_entry_list_wrapper(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+
+        headers = _auth_headers(consumer_priv, consumer_id, "")
+        resp = client.get(f"/v2/ledger/{consumer_id}", headers=headers)
+
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        self.assertEqual(data["node_id"], consumer_id)
+        self.assertIn("entries", data)
+        self.assertGreaterEqual(len(data["entries"]), 1)
+        self.assertEqual(data["entries"][0]["node_id"], consumer_id)
+        self.assertIn("amount_ns", data["entries"][0])
+
+
 class TestTaskLifecycle(unittest.TestCase):
     """Full happy-path: register consumer + provider, submit, bid, complete."""
 

--- a/tests/test_v2_endpoints.py
+++ b/tests/test_v2_endpoints.py
@@ -1,9 +1,10 @@
 """Tests for v2 financial API endpoints."""
 
-import pytest
 import os
 import sys
 import tempfile
+
+import pytest
 
 # Point hub DB at a temp file so tests don't pollute anything
 _test_db = os.path.join(tempfile.gettempdir(), "mep_test_v2_hub.db")
@@ -13,18 +14,15 @@ os.environ.setdefault("MEP_ADMIN_KEY", "test-admin-key")
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "hub"))
 
-from hub.v2_models import (
+from hub.v2_models import (  # noqa: E402
     V2BalanceResponse,
-    V2RegistrationResponse,
     V2TaskEconomics,
     V2TaskResponse,
     V2EscrowResponse,
     V2LedgerEntryResponse,
-    V2EscrowListResponse,
-    V2TaskListResponse,
+    V2LedgerListResponse,
 )
-from hub.nanoseconds import validate_ns_string, legacy_seconds_to_ns, ns_to_legacy_seconds
-import pytest
+from hub.nanoseconds import validate_ns_string, legacy_seconds_to_ns, ns_to_legacy_seconds  # noqa: E402
 
 class TestV2Models:
     """Test v2 model validation and ns string encoding."""
@@ -86,6 +84,35 @@ class TestV2Models:
         assert entry.amount_ns == "10000000000"
         assert entry.balance_ns == "90000000000"
         assert entry.currency == "MEP_NS"
+
+    def test_v2_task_response_valid(self):
+        """Test V2TaskResponse validates completed task payloads."""
+        response = V2TaskResponse(
+            task_id="task-123",
+            consumer_id="consumer-1",
+            provider_id="provider-1",
+            status="completed",
+            bounty_ns="50000000000",
+            result_uri="https://example.com/result.json",
+        )
+        assert response.status == "completed"
+        assert response.bounty_ns == "50000000000"
+
+    def test_v2_ledger_list_response_valid(self):
+        """Test V2LedgerListResponse wraps multiple ledger entries."""
+        response = V2LedgerListResponse(
+            node_id="node-1",
+            entries=[
+                V2LedgerEntryResponse(
+                    node_id="node-1",
+                    amount_ns="-1000000000",
+                    balance_ns="9000000000",
+                    kind="ESCROW",
+                )
+            ],
+        )
+        assert response.node_id == "node-1"
+        assert len(response.entries) == 1
 
 class TestNsStringValidation:
     """Test ns string validation logic."""

--- a/tests/test_v2_endpoints.py
+++ b/tests/test_v2_endpoints.py
@@ -1,0 +1,169 @@
+"""Tests for v2 financial API endpoints."""
+
+import pytest
+import os
+import sys
+import tempfile
+
+# Point hub DB at a temp file so tests don't pollute anything
+_test_db = os.path.join(tempfile.gettempdir(), "mep_test_v2_hub.db")
+os.environ["MEP_SQLITE_PATH"] = _test_db
+os.environ.setdefault("MEP_DATABASE_URL", "")  # force SQLite
+os.environ.setdefault("MEP_ADMIN_KEY", "test-admin-key")
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "hub"))
+
+from hub.v2_models import (
+    V2BalanceResponse,
+    V2RegistrationResponse,
+    V2TaskEconomics,
+    V2TaskResponse,
+    V2EscrowResponse,
+    V2LedgerEntryResponse,
+    V2EscrowListResponse,
+    V2TaskListResponse,
+)
+from hub.nanoseconds import validate_ns_string, legacy_seconds_to_ns, ns_to_legacy_seconds
+import pytest
+
+class TestV2Models:
+    """Test v2 model validation and ns string encoding."""
+    
+    def test_v2_balance_response_valid(self):
+        """Test V2BalanceResponse accepts valid ns string."""
+        response = V2BalanceResponse(
+            node_id="test-node",
+            balance_ns="100000000000"
+        )
+        assert response.node_id == "test-node"
+        assert response.balance_ns == "100000000000"
+        assert response.currency == "MEP_NS"
+    
+    def test_v2_balance_response_invalid_negative(self):
+        """Test V2BalanceResponse rejects negative balance."""
+        with pytest.raises(ValueError):
+            V2BalanceResponse(
+                node_id="test-node",
+                balance_ns="-100000000000"
+            )
+    
+    def test_v2_task_economics_valid(self):
+        """Test V2TaskEconomics accepts valid ns string."""
+        economics = V2TaskEconomics(
+            bounty_ns="50000000000",
+            currency="MEP_NS"
+        )
+        assert economics.bounty_ns == "50000000000"
+        assert economics.currency == "MEP_NS"
+    
+    def test_v2_task_economics_signed_bounty(self):
+        """Test V2TaskEconomics accepts signed bounty."""
+        economics = V2TaskEconomics(
+            bounty_ns="-50000000000",
+            currency="MEP_NS"
+        )
+        assert economics.bounty_ns == "-50000000000"
+    
+    def test_v2_escrow_response_valid(self):
+        """Test V2EscrowResponse accepts valid ns string."""
+        escrow = V2EscrowResponse(
+            task_id="task-123",
+            consumer_id="consumer-1",
+            amount_ns="30000000000",
+            status="held"
+        )
+        assert escrow.amount_ns == "30000000000"
+        assert escrow.currency == "MEP_NS"
+    
+    def test_v2_ledger_entry_response_valid(self):
+        """Test V2LedgerEntryResponse accepts valid ns string."""
+        entry = V2LedgerEntryResponse(
+            node_id="node-1",
+            amount_ns="10000000000",
+            balance_ns="90000000000",
+            kind="ESCROW"
+        )
+        assert entry.amount_ns == "10000000000"
+        assert entry.balance_ns == "90000000000"
+        assert entry.currency == "MEP_NS"
+
+class TestNsStringValidation:
+    """Test ns string validation logic."""
+    
+    def test_validate_ns_string_valid_positive(self):
+        """Test validate_ns_string accepts valid positive ns string."""
+        result = validate_ns_string("100000000000", "test_field")
+        assert result == 100000000000
+        assert isinstance(result, int)
+    
+    def test_validate_ns_string_valid_zero(self):
+        """Test validate_ns_string accepts zero."""
+        result = validate_ns_string("0", "test_field")
+        assert result == 0
+        assert isinstance(result, int)
+    
+    def test_validate_ns_string_valid_negative(self):
+        """Test validate_ns_string accepts negative when allowed."""
+        result = validate_ns_string("-100000000000", "test_field", allow_negative=True)
+        assert result == -100000000000
+        assert isinstance(result, int)
+    
+    def test_validate_ns_string_invalid_negative(self):
+        """Test validate_ns_string rejects negative when not allowed."""
+        with pytest.raises(ValueError):
+            validate_ns_string("-100000000000", "test_field", allow_negative=False)
+    
+    def test_validate_ns_string_invalid_leading_zero(self):
+        """Test validate_ns_string rejects leading zeros."""
+        with pytest.raises(ValueError):
+            validate_ns_string("010000000000", "test_field")
+    
+    def test_validate_ns_string_invalid_negative_zero(self):
+        """Test validate_ns_string rejects -0."""
+        with pytest.raises(ValueError):
+            validate_ns_string("-0", "test_field")
+    
+    def test_validate_ns_string_invalid_float(self):
+        """Test validate_ns_string rejects float format."""
+        with pytest.raises(ValueError):
+            validate_ns_string("100.5", "test_field")
+
+class TestNsConversion:
+    """Test legacy seconds to ns conversion."""
+    
+    def test_legacy_seconds_to_ns_positive(self):
+        """Test converting positive seconds to ns."""
+        result = legacy_seconds_to_ns(100.0, "test_field")
+        assert result == 100000000000
+    
+    def test_legacy_seconds_to_ns_zero(self):
+        """Test converting zero to ns."""
+        result = legacy_seconds_to_ns(0.0, "test_field")
+        assert result == 0
+    
+    def test_legacy_seconds_to_ns_negative(self):
+        """Test converting negative seconds to ns."""
+        result = legacy_seconds_to_ns(-50.0, "test_field")
+        assert result == -50000000000
+    
+    def test_ns_to_legacy_seconds_positive(self):
+        """Test converting positive ns to seconds."""
+        result = ns_to_legacy_seconds(100000000000)
+        assert result == 100.0
+    
+    def test_ns_to_legacy_seconds_zero(self):
+        """Test converting zero ns to seconds."""
+        result = ns_to_legacy_seconds(0)
+        assert result == 0.0
+    
+    def test_ns_to_legacy_seconds_negative(self):
+        """Test converting negative ns to seconds."""
+        result = ns_to_legacy_seconds(-50000000000)
+        assert result == -50.0
+    
+    def test_roundtrip_conversion(self):
+        """Test that seconds -> ns -> seconds roundtrip is accurate."""
+        original = 123.456
+        ns = legacy_seconds_to_ns(original, "test_field")
+        back = ns_to_legacy_seconds(ns)
+        assert abs(back - original) < 0.001  # Allow small floating point differences


### PR DESCRIPTION
Implements PR 3 of the ns financial migration: v2 financial endpoints that use integer nanoseconds as the canonical unit.