### PR TITLE
fix(bridge): surface pending registration state

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -60,6 +60,7 @@ class BridgeConfig:
     key_path: str
     sqlite_path: str
     webhook_secret: str
+    github_token: Optional[str]
     target_node_id: str
     target_alias: str
     trigger_aliases: list[str]
@@ -103,6 +104,7 @@ class BridgeConfig:
                 os.path.join(os.path.dirname(os.path.abspath(__file__)), "github_bridge.db"),
             ),
             webhook_secret=os.getenv("GITHUB_WEBHOOK_SECRET", ""),
+            github_token=(os.getenv("GITHUB_TOKEN") or os.getenv("GITHUB_API_TOKEN") or "").strip() or None,
             target_node_id=os.getenv("MEP_BRIDGE_TARGET_NODE_ID", "").strip(),
             target_alias=target_alias,
             trigger_aliases=trigger_aliases,
@@ -500,11 +502,13 @@ class GitHubToMEPBridgeService:
         store: Optional[BridgeStore] = None,
         submission_client: Optional[Any] = None,
         notifier: Optional[Any] = None,
+        github_session: Optional[Any] = None,
     ):
         self.config = config
         self.store = store or BridgeStore(config.sqlite_path)
         self.submission_client = submission_client or DefaultMEPSubmissionClient(config)
         self.notifier = notifier or TelegramNotifier(config)
+        self.github_session = github_session or requests.Session()
         self._pending_lock = asyncio.Lock()
         self._pending_by_context: dict[str, PendingContext] = {}
 
@@ -957,6 +961,78 @@ class GitHubToMEPBridgeService:
             raise HTTPException(status_code=401, detail="Expired bridge status token")
         return claims
 
+    def _resolve_github_writeback_action(
+        self,
+        execution: dict[str, Any],
+        update: BridgeStatusUpdate,
+    ) -> str:
+        explicit_action = str(update.action or "").strip().lower()
+        if explicit_action:
+            return explicit_action
+        intent_type = str(execution.get("intent_type") or "").strip().lower()
+        imperative_verb = str(execution.get("imperative_verb") or "").strip().lower()
+        if intent_type == "code.review.approve" or imperative_verb == "approve":
+            return "approved"
+        if intent_type == "code.review.request" or imperative_verb in {"review", "check"}:
+            return "reviewed"
+        if intent_type == "code.review.comment" or imperative_verb == "comment":
+            return "commented"
+        if intent_type in {"analysis.request", "issue.triage.request"} or imperative_verb in {"analyze", "triage"}:
+            return "commented"
+        return "commented"
+
+    def _render_github_writeback_body(self, bridge_id: str, action: str, detail: Optional[str]) -> str:
+        detail_text = (detail or "").strip() or f"{self.config.target_alias} completed the requested action."
+        marker = f"{BRIDGE_OUTPUT_MARKER} bridge_id={bridge_id} action={action} -->"
+        return f"{detail_text}\n\n{marker}"
+
+    def _post_github_comment(self, repo_full_name: str, number: int, body: str) -> None:
+        if not self.config.github_token:
+            raise HTTPException(status_code=500, detail="Bridge configuration missing: GITHUB_TOKEN")
+        response = self.github_session.post(
+            f"https://api.github.com/repos/{repo_full_name}/issues/{number}/comments",
+            json={"body": body},
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.config.github_token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=20,
+        )
+        response.raise_for_status()
+
+    def _submit_github_review(self, repo_full_name: str, number: int, event: str, body: str) -> None:
+        if not self.config.github_token:
+            raise HTTPException(status_code=500, detail="Bridge configuration missing: GITHUB_TOKEN")
+        response = self.github_session.post(
+            f"https://api.github.com/repos/{repo_full_name}/pulls/{number}/reviews",
+            json={"event": event, "body": body},
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.config.github_token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=20,
+        )
+        response.raise_for_status()
+
+    def _write_back_to_github(self, execution: dict[str, Any], update: BridgeStatusUpdate) -> str:
+        repo_full_name = str(execution.get("repo_full_name") or "")
+        number = int(execution.get("issue_number") or 0)
+        entity_type = str(execution.get("entity_type") or "").strip().lower()
+        action = self._resolve_github_writeback_action(execution, update)
+        body = self._render_github_writeback_body(str(execution.get("bridge_id") or update.bridge_id), action, update.detail)
+        review_events = {
+            "approved": "APPROVE",
+            "reviewed": "COMMENT",
+            "changes_requested": "REQUEST_CHANGES",
+        }
+        if entity_type == "pr" and action in review_events:
+            self._submit_github_review(repo_full_name, number, review_events[action], body)
+            return action
+        self._post_github_comment(repo_full_name, number, body)
+        return "commented"
+
     async def handle_status_callback(self, update: BridgeStatusUpdate, token: str) -> dict[str, Any]:
         self._require_runtime_config()
         claims = self._verify_status_token(token)
@@ -975,6 +1051,14 @@ class GitHubToMEPBridgeService:
             action=update.action,
         )
         refreshed = self.store.get_execution(update.bridge_id)
+        resolved_action = update.action
+        if refreshed is None:
+            raise HTTPException(status_code=404, detail="Unknown bridge_id")
+        if str(update.status).strip().lower() == "completed":
+            resolved_action = self._write_back_to_github(refreshed, update)
+            if resolved_action != update.action:
+                self.store.update_execution(update.bridge_id, action=resolved_action)
+                refreshed = self.store.get_execution(update.bridge_id) or refreshed
         event = NormalizedGitHubEvent(
             delivery_id="",
             source_event="",
@@ -1000,7 +1084,7 @@ class GitHubToMEPBridgeService:
                 event,
                 update.status,
                 task_id=update.task_id or refreshed.get("task_id"),
-                action=update.action,
+                action=resolved_action,
                 detail=update.detail,
             ),
         )

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -173,6 +173,16 @@ class BridgeStatusUpdate(BaseModel):
     detail: Optional[str] = None
 
 
+class BridgeRegistrationPendingApprovalError(RuntimeError):
+    def __init__(self, node_id: str):
+        super().__init__(
+            "Bridge node "
+            f"{node_id} is pending admin approval on the hub. "
+            "Approve the registration before using the bridge."
+        )
+        self.node_id = node_id
+
+
 class BridgeStore:
     def __init__(self, db_path: str):
         self.db_path = db_path
@@ -411,6 +421,15 @@ class DefaultMEPSubmissionClient:
             timeout=10,
         )
         response.raise_for_status()
+        payload: dict[str, Any] = {}
+        try:
+            decoded = response.json()
+        except ValueError:
+            decoded = None
+        if isinstance(decoded, dict):
+            payload = decoded
+        if str(payload.get("status") or "").strip().lower() == "pending":
+            raise BridgeRegistrationPendingApprovalError(self.node_id)
         self._registered = True
 
     def submit_structured_dm(self, envelope: dict[str, Any], target_node_id: str, intent_type: str) -> dict[str, Any]:

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -358,6 +358,83 @@ class RuntimeNode:
         headers["Content-Type"] = "application/json"
         return headers
 
+    @staticmethod
+    def _bridge_metadata(interbot_message: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+        if not isinstance(interbot_message, dict):
+            return None
+        task = interbot_message.get("task")
+        if not isinstance(task, dict):
+            return None
+        inputs = task.get("inputs")
+        if not isinstance(inputs, dict):
+            return None
+        bridge_metadata = inputs.get("bridge_metadata")
+        if not isinstance(bridge_metadata, dict):
+            return None
+        if str(bridge_metadata.get("source_type") or "").strip().lower() != "github":
+            return None
+        required = ("bridge_id", "status_endpoint", "status_token")
+        if not all(isinstance(bridge_metadata.get(name), str) and str(bridge_metadata.get(name)).strip() for name in required):
+            return None
+        return bridge_metadata
+
+    @staticmethod
+    def _bridge_status_action(interbot_message: Optional[dict[str, Any]]) -> Optional[str]:
+        if not isinstance(interbot_message, dict):
+            return None
+        intent = interbot_message.get("intent")
+        intent_type = intent.get("type") if isinstance(intent, dict) else None
+        if intent_type == "code.review.approve":
+            return "approved"
+        if intent_type == "code.review.request":
+            return "reviewed"
+        if intent_type == "code.review.comment":
+            return "commented"
+        if intent_type in {"analysis.request", "issue.triage.request"}:
+            return "commented"
+        return None
+
+    def _report_bridge_status(
+        self,
+        interbot_message: Optional[dict[str, Any]],
+        *,
+        task_id: str,
+        status: str,
+        detail: Optional[str],
+    ) -> None:
+        bridge_metadata = self._bridge_metadata(interbot_message)
+        if bridge_metadata is None:
+            return
+        conversation = interbot_message.get("conversation") if isinstance(interbot_message, dict) else None
+        payload: dict[str, Any] = {
+            "bridge_id": bridge_metadata["bridge_id"],
+            "status": status,
+            "target_node_id": self.node_id,
+            "task_id": task_id,
+            "timestamp_ms": int(time.time() * 1000),
+        }
+        if isinstance(conversation, dict) and isinstance(conversation.get("context_id"), str):
+            payload["context_id"] = conversation["context_id"]
+        action = self._bridge_status_action(interbot_message)
+        if action:
+            payload["action"] = action
+        if detail:
+            payload["detail"] = detail[:60000]
+        code, _body, raw = _safe_request(
+            "POST",
+            bridge_metadata["status_endpoint"],
+            json_body=payload,
+            headers={"Authorization": f"Bearer {bridge_metadata['status_token']}"},
+            timeout=20.0,
+        )
+        if code == 200:
+            print(f"[mep run] bridge status reported task={task_id[:8]} bridge_id={bridge_metadata['bridge_id']}")
+        else:
+            print(
+                f"[mep run] bridge status failed task={task_id[:8]} "
+                f"bridge_id={bridge_metadata['bridge_id']} status={code} detail={raw}"
+            )
+
     def register(self, alias: Optional[str]) -> tuple[bool, str]:
         payload = {
             "pubkey": self.identity.pub_pem,
@@ -877,6 +954,12 @@ class RuntimeNode:
         if self._bridge_eligible_interbot_message(task_data, interbot_message):
             bridged = await self._attempt_live_call_bridge(task_data, interbot_message, result)
             if bridged:
+                self._report_bridge_status(
+                    interbot_message,
+                    task_id=task_id,
+                    status="completed",
+                    detail=result,
+                )
                 return
         dm_response = await self._submit_safe_structured_dm_reply(
             result,
@@ -885,8 +968,20 @@ class RuntimeNode:
         )
         if dm_response is not None:
             self.complete(task_id, self._dm_fallback_settlement(task_id, dm_response))
+            self._report_bridge_status(
+                interbot_message,
+                task_id=task_id,
+                status="completed",
+                detail=result,
+            )
             return
         self.complete(task_id, result)
+        self._report_bridge_status(
+            interbot_message,
+            task_id=task_id,
+            status="completed",
+            detail=result,
+        )
 
     def _ws_uri(self) -> str:
         ts = str(int(time.time()))

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -72,15 +72,18 @@ class _FakeResponse:
 
 
 class _FakeRequestsSession:
-    def __init__(self, responses):
-        self.responses = list(responses)
+    def __init__(self, responses=None, *, default_response=None):
+        self.responses = list(responses or [])
+        self.default_response = default_response
         self.posts = []
 
     def post(self, url, **kwargs):
         self.posts.append({"url": url, **kwargs})
-        if not self.responses:
+        if self.responses:
+            return self.responses.pop(0)
+        if self.default_response is None:
             raise AssertionError("No fake responses remaining")
-        return self.responses.pop(0)
+        return self.default_response
 
 
 def _build_config(tmp_dir: str) -> BridgeConfig:
@@ -89,6 +92,7 @@ def _build_config(tmp_dir: str) -> BridgeConfig:
         key_path=os.path.join(tmp_dir, "bridge_identity.pem"),
         sqlite_path=os.path.join(tmp_dir, "bridge.sqlite3"),
         webhook_secret="github-secret",
+        github_token="github-token",
         target_node_id="node_target",
         target_alias="Hub Sentinel",
         trigger_aliases=["Hub-Sentinel"],
@@ -149,11 +153,13 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.store = BridgeStore(self.config.sqlite_path)
         self.submission = _FakeSubmissionClient()
         self.notifier = _FakeNotifier()
+        self.github_session = _FakeRequestsSession(default_response=_FakeResponse({}))
         self.service = GitHubToMEPBridgeService(
             self.config,
             store=self.store,
             submission_client=self.submission,
             notifier=self.notifier,
+            github_session=self.github_session,
         )
         self.client = TestClient(create_app(config=self.config, service=self.service))
 
@@ -253,6 +259,36 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertTrue(final_message["editing"])
         self.assertIn("status: completed", final_message["text"])
         self.assertIn("action: approved", final_message["text"])
+        self.assertEqual(len(self.github_session.posts), 1)
+        self.assertTrue(self.github_session.posts[0]["url"].endswith("/repos/WUAIBING/MEP/pulls/226/reviews"))
+        self.assertEqual(self.github_session.posts[0]["json"]["event"], "APPROVE")
+        self.assertIn("<!-- mep-bridge:output", self.github_session.posts[0]["json"]["body"])
+
+    def test_status_callback_posts_issue_comment_for_analysis_completion(self):
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel analyze this PR", delivery_number=227),
+            delivery_id="delivery-analysis",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-2",
+                "detail": "Analysis complete.",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 1)
+        self.assertTrue(self.github_session.posts[0]["url"].endswith("/repos/WUAIBING/MEP/issues/227/comments"))
+        self.assertEqual(self.github_session.posts[0]["json"]["body"].splitlines()[0], "Analysis complete.")
 
     def test_non_maintainer_trigger_is_ignored_when_policy_enabled(self):
         payload = _issue_comment_payload("@Hub-Sentinel review this PR")

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -13,7 +13,14 @@ from fastapi.testclient import TestClient
 ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, ROOT)
 
-from bridge.github_to_mep import BridgeConfig, BridgeStore, GitHubToMEPBridgeService, create_app  # noqa: E402
+from bridge.github_to_mep import (  # noqa: E402
+    BridgeConfig,
+    BridgeRegistrationPendingApprovalError,
+    BridgeStore,
+    DefaultMEPSubmissionClient,
+    GitHubToMEPBridgeService,
+    create_app,
+)
 
 
 class _FakeSubmissionClient:
@@ -49,6 +56,31 @@ class _FakeNotifier:
             next_id = str(message_id)
         self.calls.append({"text": text, "message_id": next_id, "editing": message_id is not None})
         return next_id
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, *, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"http_{self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _FakeRequestsSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.posts = []
+
+    def post(self, url, **kwargs):
+        self.posts.append({"url": url, **kwargs})
+        if not self.responses:
+            raise AssertionError("No fake responses remaining")
+        return self.responses.pop(0)
 
 
 def _build_config(tmp_dir: str) -> BridgeConfig:
@@ -268,6 +300,27 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(response.json()["status"], "ignored")
         time.sleep(0.05)
         self.assertEqual(len(self.submission.calls), 0)
+
+    def test_pending_registration_raises_clear_operator_error(self):
+        client = DefaultMEPSubmissionClient(self.config)
+        client.session = _FakeRequestsSession(
+            [
+                _FakeResponse(
+                    {
+                        "status": "pending",
+                        "node_id": client.node_id,
+                    }
+                )
+            ]
+        )
+
+        with self.assertRaises(BridgeRegistrationPendingApprovalError) as ctx:
+            client.ensure_registered()
+
+        self.assertIn(client.node_id, str(ctx.exception))
+        self.assertIn("pending admin approval", str(ctx.exception))
+        self.assertEqual(len(client.session.posts), 1)
+        self.assertTrue(client.session.posts[0]["url"].endswith("/register"))
 
 
 if __name__ == "__main__":

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -327,6 +327,52 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         adapter_mock.assert_called_once_with("Use only this instruction text.", task_data)
         complete_mock.assert_called_once_with("task_interbot", "reply")
 
+    def test_process_task_reports_bridge_status_when_github_bridge_metadata_is_present(self):
+        node = _runtime_node()
+        task_data = {
+            "id": "task_bridge_status",
+            "bounty": 0.0,
+            "payload": json.dumps(
+                {
+                    "spec_version": "mep.interbot.v1",
+                    "message_id": "msg-bridge-status",
+                    "trace_id": "trace-bridge-status",
+                    "source": {"node_id": "node_bridge"},
+                    "target": {"node_id": node.node_id},
+                    "conversation": {"context_id": "ctx-bridge-status"},
+                    "intent": {"type": "code.review.approve", "priority": "high"},
+                    "task": {
+                        "instructions": "Approve this PR if it looks good.",
+                        "inputs": {
+                            "bridge_metadata": {
+                                "source_type": "github",
+                                "bridge_id": "br-123",
+                                "status_endpoint": "https://bridge.example.test/bridge/status",
+                                "status_token": "status-token",
+                            }
+                        },
+                    },
+                    "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+                    "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+                }
+            ),
+        }
+        with (
+            patch.object(node.adapter, "generate_reply", return_value="Looks good to me."),
+            patch.object(node, "complete") as complete_mock,
+            patch("node.mep_runtime._safe_request", return_value=(200, {}, "")) as request_mock,
+        ):
+            asyncio.run(node.process_task(task_data))
+
+        complete_mock.assert_called_once_with("task_bridge_status", "Looks good to me.")
+        request_mock.assert_called_once()
+        self.assertEqual(request_mock.call_args.args, ("POST", "https://bridge.example.test/bridge/status"))
+        self.assertEqual(request_mock.call_args.kwargs["json_body"]["bridge_id"], "br-123")
+        self.assertEqual(request_mock.call_args.kwargs["json_body"]["status"], "completed")
+        self.assertEqual(request_mock.call_args.kwargs["json_body"]["action"], "approved")
+        self.assertEqual(request_mock.call_args.kwargs["json_body"]["detail"], "Looks good to me.")
+        self.assertEqual(request_mock.call_args.kwargs["headers"]["Authorization"], "Bearer status-token")
+
     def test_process_task_live_bridge_sends_frame_and_settles_when_call_is_accepted(self):
         node = _runtime_node()
         node.live_call_enabled = True


### PR DESCRIPTION
## Summary
- fail fast when the bridge node registers as `pending` instead of surfacing a later `401`
- raise a clear operator-facing error that tells the deployer to approve the bridge registration
- add regression coverage for the pending-registration path

## Testing
- `python -m pytest tests/test_github_bridge.py -q`