### PR TITLE
fix(runtime): use reviewer prompts for bridge tasks

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -334,6 +334,68 @@ class MockAdapter:
         )
 
 
+def _interbot_message_from_task_data(task_data: dict[str, Any]) -> Optional[dict[str, Any]]:
+    payload = task_data.get("payload")
+    if isinstance(payload, str) and payload.strip():
+        if MEPClient is not None:
+            try:
+                _instructions, interbot_message = MEPClient.extract_interbot_instructions(payload)
+            except Exception:  # noqa: BLE001
+                interbot_message = None
+            if isinstance(interbot_message, dict):
+                return interbot_message
+        try:
+            decoded = json.loads(payload)
+        except ValueError:
+            decoded = None
+        if isinstance(decoded, dict):
+            return decoded
+    return None
+
+
+def _task_requires_review_prompt(task_data: dict[str, Any]) -> bool:
+    interbot_message = _interbot_message_from_task_data(task_data)
+    task: Any = task_data.get("task")
+    if not isinstance(task, dict) and isinstance(interbot_message, dict):
+        task = interbot_message.get("task")
+    inputs = task.get("inputs") if isinstance(task, dict) else None
+    bridge_metadata = inputs.get("bridge_metadata") if isinstance(inputs, dict) else None
+    if isinstance(bridge_metadata, dict) and str(bridge_metadata.get("bridge_id") or "").strip():
+        return True
+
+    intent: Any = task_data.get("intent")
+    if not isinstance(intent, dict) and isinstance(interbot_message, dict):
+        intent = interbot_message.get("intent")
+    intent_type = str(intent.get("type") or "").strip() if isinstance(intent, dict) else ""
+    return intent_type in {
+        "code.review.request",
+        "code.review.approve",
+        "code.review.comment",
+        "analysis.request",
+        "issue.triage.request",
+    }
+
+
+def _system_prompt_for_task(
+    task_data: dict[str, Any],
+    *,
+    generic_max_chars: int,
+    review_max_chars: int,
+) -> str:
+    if _task_requires_review_prompt(task_data):
+        return (
+            "You are a code reviewer for the MEP (Miao Exchange Protocol) project. "
+            "Analyze PR tasks and respond as one of: approve, request_changes, or comment. "
+            "Be specific, reference files, logic, or tests when helpful, and keep the "
+            f"response within {review_max_chars} characters."
+        )
+    return (
+        "You are a helpful MEP (Miao Exchange Protocol) bot. "
+        "MEP is an AI-to-AI economy protocol where agents earn SECONDS by doing work. "
+        f"Reply concisely (max {generic_max_chars} chars)."
+    )
+
+
 @dataclass
 class AIAdapter:
     """Real AI adapter using Ollama for provider task processing."""
@@ -345,7 +407,7 @@ class AIAdapter:
 
         try:
             prompt = (
-                "You are a helpful MEP bot. Respond to this task concisely (max 300 chars).\n\n"
+                f"{_system_prompt_for_task(task_data, generic_max_chars=300, review_max_chars=500)}\n\n"
                 f"Task: {payload}\n\nReply:"
             )
             result = subprocess.run(
@@ -384,10 +446,10 @@ class DeepSeekAdapter:
                     "messages": [
                         {
                             "role": "system",
-                            "content": (
-                                "You are a helpful MEP (Miao Exchange Protocol) bot. "
-                                "MEP is an AI-to-AI economy protocol where agents earn "
-                                "SECONDS by doing work. Reply concisely (max 500 chars)."
+                            "content": _system_prompt_for_task(
+                                task_data,
+                                generic_max_chars=500,
+                                review_max_chars=500,
                             ),
                         },
                         {"role": "user", "content": payload},

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -78,6 +78,11 @@ class _FakeRuntime:
         return 0
 
 
+class _FakeCompletedProcess:
+    def __init__(self, stdout=""):
+        self.stdout = stdout
+
+
 class TestMockAdapter(unittest.TestCase):
     def test_mock_adapter_labels_compute_chat_and_data_markets(self):
         adapter = mep_runtime.MockAdapter()
@@ -309,6 +314,73 @@ class TestRuntimeBidPolicy(unittest.TestCase):
         node = _runtime_node()
 
         self.assertFalse(node.should_bid({"id": "task_bad", "bounty": "not-a-number"}))
+
+
+class TestRuntimeReviewPrompts(unittest.TestCase):
+    @staticmethod
+    def _bridge_review_task_data(intent_type: str = "code.review.request") -> dict:
+        return {
+            "id": "task_bridge_review",
+            "bounty": 0.0,
+            "payload": json.dumps(
+                {
+                    "spec_version": "mep.interbot.v1",
+                    "message_id": "msg-bridge-review",
+                    "trace_id": "trace-bridge-review",
+                    "source": {"node_id": "node_bridge"},
+                    "target": {"node_id": "node_runtime"},
+                    "conversation": {"context_id": "ctx-bridge-review"},
+                    "intent": {"type": intent_type, "priority": "high"},
+                    "task": {
+                        "instructions": "Review this PR and provide a concise decision.",
+                        "inputs": {
+                            "bridge_metadata": {
+                                "source_type": "github",
+                                "bridge_id": "br-review-123",
+                                "status_endpoint": "https://bridge.example.test/bridge/status",
+                                "status_token": "bridge-status-token",
+                            }
+                        },
+                    },
+                    "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+                    "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+                }
+            ),
+        }
+
+    def test_bridge_review_tasks_request_reviewer_prompt(self):
+        self.assertTrue(mep_runtime._task_requires_review_prompt(self._bridge_review_task_data()))  # noqa: SLF001
+        self.assertFalse(
+            mep_runtime._task_requires_review_prompt(  # noqa: SLF001
+                {"id": "task_generic", "bounty": 0.0, "payload": "hello"}
+            )
+        )
+
+    def test_ai_adapter_uses_reviewer_prompt_for_bridge_review_tasks(self):
+        adapter = mep_runtime.AIAdapter(model="tinyllama")
+        task_data = self._bridge_review_task_data()
+        with patch("subprocess.run", return_value=_FakeCompletedProcess(stdout="review output")) as run_mock:
+            reply = adapter.generate_reply("Review this PR", task_data)
+
+        self.assertEqual(reply, "review output")
+        prompt = run_mock.call_args.args[0][3]
+        self.assertIn("You are a code reviewer for the MEP", prompt)
+        self.assertIn("approve, request_changes, or comment", prompt)
+
+    def test_deepseek_adapter_uses_reviewer_prompt_for_bridge_review_tasks(self):
+        adapter = mep_runtime.DeepSeekAdapter(api_key="secret-key", model="deepseek-chat")
+        task_data = self._bridge_review_task_data()
+        fake_response = _FakeResponse(
+            200,
+            {"choices": [{"message": {"content": "**Request Changes** file reference"}}]},
+        )
+        with patch("node.mep_runtime.requests.post", return_value=fake_response) as post_mock:
+            reply = adapter.generate_reply("Review this PR", task_data)
+
+        self.assertEqual(reply, "**Request Changes** file reference")
+        system_prompt = post_mock.call_args.kwargs["json"]["messages"][0]["content"]
+        self.assertIn("You are a code reviewer for the MEP", system_prompt)
+        self.assertIn("approve, request_changes, or comment", system_prompt)
 
 
 class TestRuntimeWebSocketLoop(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add bridge-aware review prompt selection for runtime adapters
- switch DeepSeek and Ollama to use reviewer prompts for GitHub bridge review tasks
- add focused runtime tests for review prompt selection

## Verification
- python -m pytest tests/test_node_runtime.py -q
- 39 passed