### PR TITLE
feat(bridge): multi-target alias routing from one webhook endpoint

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -64,6 +64,7 @@ class BridgeConfig:
     target_node_id: str
     target_alias: str
     trigger_aliases: list[str]
+    alias_map: dict[str, str]
     public_base_url: str
     status_secret: str
     status_token_lifetime_seconds: int
@@ -82,10 +83,33 @@ class BridgeConfig:
 
     @classmethod
     def from_env(cls) -> "BridgeConfig":
+        # --- Multi-target alias map ---
+        alias_map_raw = os.getenv("MEP_BRIDGE_ALIAS_MAP", "").strip()
+        if alias_map_raw:
+            try:
+                alias_map = json.loads(alias_map_raw)
+                if not isinstance(alias_map, dict) or not alias_map:
+                    raise ValueError("MEP_BRIDGE_ALIAS_MAP must be a non-empty JSON dict")
+            except (json.JSONDecodeError, ValueError) as exc:
+                raise RuntimeError(f"Invalid MEP_BRIDGE_ALIAS_MAP: {exc}") from exc
+        else:
+            alias_map = {}
+
         target_alias = os.getenv("MEP_BRIDGE_TARGET_ALIAS", "Hub Sentinel").strip() or "Hub Sentinel"
-        trigger_aliases = _split_csv(os.getenv("MEP_BRIDGE_TRIGGER_ALIASES", target_alias))
-        if not trigger_aliases:
+        target_node_id = os.getenv("MEP_BRIDGE_TARGET_NODE_ID", "").strip()
+
+        # Populate alias_map from legacy single-target vars if no explicit map
+        if not alias_map and target_node_id:
+            alias_map[target_alias] = target_node_id
+
+        # trigger_aliases = all keys in alias_map, supplemented by env
+        trigger_aliases = _split_csv(os.getenv("MEP_BRIDGE_TRIGGER_ALIASES", ""))
+        for alias in alias_map:
+            if alias not in trigger_aliases:
+                trigger_aliases.append(alias)
+        if not trigger_aliases and target_alias:
             trigger_aliases = [target_alias]
+
         allowed_repos = set(_split_csv(os.getenv("GITHUB_ALLOWED_REPOS", "")))
         allowed_associations = set(
             item.upper() for item in _split_csv(os.getenv("MEP_BRIDGE_ALLOWED_ASSOCIATIONS", "OWNER,MEMBER,COLLABORATOR"))
@@ -105,9 +129,10 @@ class BridgeConfig:
             ),
             webhook_secret=os.getenv("GITHUB_WEBHOOK_SECRET", ""),
             github_token=(os.getenv("GITHUB_TOKEN") or os.getenv("GITHUB_API_TOKEN") or "").strip() or None,
-            target_node_id=os.getenv("MEP_BRIDGE_TARGET_NODE_ID", "").strip(),
+            target_node_id=target_node_id,
             target_alias=target_alias,
             trigger_aliases=trigger_aliases,
+            alias_map=alias_map,
             public_base_url=os.getenv("MEP_BRIDGE_PUBLIC_BASE_URL", "http://localhost:8787").rstrip("/"),
             status_secret=os.getenv("MEP_BRIDGE_STATUS_SECRET", ""),
             status_token_lifetime_seconds=max(
@@ -156,11 +181,20 @@ class NormalizedGitHubEvent:
 
 
 @dataclass(slots=True)
+class TriggerMatch:
+    alias: str
+    verb: str
+    intent_type: str
+    node_id: str
+
+
+@dataclass(slots=True)
 class PendingContext:
     context_id: str
     bridge_id: str
     event: NormalizedGitHubEvent
-    first_seen: float
+    targets: list[TriggerMatch] = field(default_factory=list)
+    first_seen: float = 0.0
     flush_task: Optional[asyncio.Task] = None
 
 
@@ -585,8 +619,18 @@ class GitHubToMEPBridgeService:
                     "coalesced": True,
                 }
 
+            targets = self._get_targets_for_event(event)
+            if not targets:
+                targets = [TriggerMatch(
+                    alias=self.config.target_alias,
+                    verb=event.imperative_verb,
+                    intent_type=event.intent_type,
+                    node_id=self.config.target_node_id,
+                )]
             bridge_id = f"br-{secrets.token_hex(8)}"
-            event_sequence = self.store.create_execution(event, bridge_id, self.config.target_node_id)
+            event_sequence = self.store.create_execution(
+                event, bridge_id, targets[0].node_id
+            )
             event.bridge_id = bridge_id
             event.event_sequence = event_sequence
             if not event.coalesced_delivery_ids:
@@ -608,6 +652,7 @@ class GitHubToMEPBridgeService:
                 context_id=event.context_id,
                 bridge_id=bridge_id,
                 event=event,
+                targets=targets,
                 first_seen=time.time(),
             )
             pending.flush_task = asyncio.create_task(self._flush_after_delay(event.context_id))
@@ -661,49 +706,82 @@ class GitHubToMEPBridgeService:
         if pending.flush_task and pending.flush_task is not asyncio.current_task():
             pending.flush_task.cancel()
 
-        self.store.update_execution(pending.bridge_id, status="submitting")
-        envelope = self._build_interbot_envelope(pending.event)
-        try:
-            response = await asyncio.to_thread(
-                self.submission_client.submit_structured_dm,
-                envelope,
-                self.config.target_node_id,
-                pending.event.intent_type,
-            )
-        except Exception as exc:  # noqa: BLE001
-            self.store.update_execution(pending.bridge_id, status="submit_failed", action="error")
-            await self._notify_status(
-                pending.bridge_id,
-                self._render_status_text(pending.event, "submit_failed", detail=str(exc)),
-            )
-            return
+        targets = pending.targets or []
+        if not targets:
+            targets = [TriggerMatch(
+                alias=self.config.target_alias,
+                verb=pending.event.imperative_verb,
+                intent_type=pending.event.intent_type,
+                node_id=self.config.target_node_id,
+            )]
 
-        status_code = int(response.get("status_code") or 500)
-        payload = response.get("json") if isinstance(response, dict) else None
-        if status_code >= 400 or not isinstance(payload, dict):
-            detail = json.dumps(payload) if payload is not None else f"http_{status_code}"
-            self.store.update_execution(pending.bridge_id, status="submit_failed", action="error")
-            await self._notify_status(
-                pending.bridge_id,
-                self._render_status_text(pending.event, "submit_failed", detail=detail),
+        for target in targets:
+            target_bridge_id = f"{pending.bridge_id}-{target.alias.replace(' ', '-').lower()}"
+            self.store.create_execution(
+                pending.event, target_bridge_id, target.node_id
             )
-            return
+            self.store.update_execution(target_bridge_id, status="submitting")
+            envelope = self._build_interbot_envelope(
+                pending.event, target_node_id=target.node_id,
+                target_alias=target.alias, bridge_id=target_bridge_id,
+            )
+            try:
+                response = await asyncio.to_thread(
+                    self.submission_client.submit_structured_dm,
+                    envelope,
+                    target.node_id,
+                    target.intent_type,
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.store.update_execution(
+                    target_bridge_id, status="submit_failed", action="error"
+                )
+                await self._notify_status(
+                    target_bridge_id,
+                    self._render_status_text(
+                        pending.event, "submit_failed",
+                        target_alias=target.alias,
+                        target_node_id=target.node_id,
+                        detail=str(exc),
+                    ),
+                )
+                continue
 
-        task_id = payload.get("task_id")
-        execution_status = str(payload.get("status") or "submitted")
-        self.store.update_execution(
-            pending.bridge_id,
-            status=execution_status,
-            task_id=str(task_id) if task_id else None,
-        )
-        await self._notify_status(
-            pending.bridge_id,
-            self._render_status_text(
-                pending.event,
-                execution_status,
+            status_code = int(response.get("status_code") or 500)
+            payload = response.get("json") if isinstance(response, dict) else None
+            if status_code >= 400 or not isinstance(payload, dict):
+                detail = json.dumps(payload) if payload is not None else f"http_{status_code}"
+                self.store.update_execution(
+                    target_bridge_id, status="submit_failed", action="error"
+                )
+                await self._notify_status(
+                    target_bridge_id,
+                    self._render_status_text(
+                        pending.event, "submit_failed",
+                        target_alias=target.alias,
+                        target_node_id=target.node_id,
+                        detail=detail,
+                    ),
+                )
+                continue
+
+            task_id = payload.get("task_id")
+            execution_status = str(payload.get("status") or "submitted")
+            self.store.update_execution(
+                target_bridge_id,
+                status=execution_status,
                 task_id=str(task_id) if task_id else None,
-            ),
-        )
+            )
+            await self._notify_status(
+                target_bridge_id,
+                self._render_status_text(
+                    pending.event,
+                    execution_status,
+                    task_id=str(task_id) if task_id else None,
+                    target_alias=target.alias,
+                    target_node_id=target.node_id,
+                ),
+            )
 
     async def _notify_status(self, bridge_id: str, text: str) -> None:
         execution = self.store.get_execution(bridge_id)
@@ -773,10 +851,12 @@ class GitHubToMEPBridgeService:
             if author_association.upper() not in self.config.allowed_associations:
                 return None
 
-        trigger = self._extract_trigger(trigger_text)
-        if trigger is None:
+        triggers = self._extract_triggers(trigger_text)
+        if not triggers:
             return None
-        verb, intent_type = trigger
+        # Use first trigger as primary; all triggers stored on event via _pending_targets
+        first_verb = triggers[0].verb
+        first_intent = triggers[0].intent_type
 
         owner, repo_name = repo_full_name.split("/", 1)
         context_id = f"github-{owner}-{repo_name}-{entity_type}-{number}"
@@ -788,7 +868,7 @@ class GitHubToMEPBridgeService:
             url=url,
             actor_login=actor_login,
             action=action,
-            imperative_verb=verb,
+            imperative_verb=first_verb,
             trigger_text=trigger_text,
         )
         return NormalizedGitHubEvent(
@@ -803,18 +883,29 @@ class GitHubToMEPBridgeService:
             actor_login=actor_login,
             author_association=author_association.upper(),
             context_id=context_id,
-            imperative_verb=verb,
-            intent_type=intent_type,
+            imperative_verb=first_verb,
+            intent_type=first_intent,
             instructions=instructions,
             raw_trigger_text=trigger_text.strip(),
             coalesced_delivery_ids=[delivery_id],
             coalesced_actions=[action],
         )
 
-    def _extract_trigger(self, text: str) -> Optional[tuple[str, str]]:
+    def _get_targets_for_event(
+        self, event: NormalizedGitHubEvent
+    ) -> list[TriggerMatch]:
+        """Re-extract multi-target triggers from a normalized event's trigger text."""
+        return self._extract_triggers(event.raw_trigger_text)
+
+    def _extract_triggers(self, text: str) -> list[TriggerMatch]:
+        """Extract ALL actionable @alias verb mentions from text."""
         if not isinstance(text, str) or not text.strip():
-            return None
+            return []
+        matches: list[TriggerMatch] = []
+        seen_aliases: set[str] = set()
         for alias in self.config.trigger_aliases:
+            if alias in seen_aliases:
+                continue
             pattern = re.compile(
                 rf"@{re.escape(alias)}\b(?:\s+|[,:]\s*)(?P<verb>[a-z][a-z_-]*)",
                 re.IGNORECASE,
@@ -824,9 +915,22 @@ class GitHubToMEPBridgeService:
                 continue
             verb = match.group("verb").strip().lower()
             intent_type = DEFAULT_TRIGGER_VERBS.get(verb)
-            if intent_type:
-                return verb, intent_type
-        return None
+            if not intent_type:
+                continue
+            node_id = self.config.alias_map.get(alias, self.config.target_node_id)
+            if not node_id:
+                continue
+            matches.append(TriggerMatch(alias=alias, verb=verb, intent_type=intent_type, node_id=node_id))
+            seen_aliases.add(alias)
+        return matches
+
+    def _extract_trigger(self, text: str) -> Optional[tuple[str, str]]:
+        """Legacy single-match method retained for backward-compatible callers."""
+        triggers = self._extract_triggers(text)
+        if not triggers:
+            return None
+        first = triggers[0]
+        return first.verb, first.intent_type
 
     def _contains_bridge_output_marker(self, text: str) -> bool:
         return isinstance(text, str) and BRIDGE_OUTPUT_MARKER in text.lower()
@@ -866,22 +970,34 @@ class GitHubToMEPBridgeService:
             f"{clipped_trigger}"
         )
 
-    def _build_interbot_envelope(self, event: NormalizedGitHubEvent) -> dict[str, Any]:
+    def _build_interbot_envelope(
+        self,
+        event: NormalizedGitHubEvent,
+        *,
+        target_node_id: Optional[str] = None,
+        target_alias: Optional[str] = None,
+        bridge_id: Optional[str] = None,
+    ) -> dict[str, Any]:
         timestamp_ms = int(time.time() * 1000)
         status_endpoint = f"{self.config.public_base_url}/bridge/status"
-        status_token = self._generate_status_token(event.bridge_id, self.config.target_node_id)
+        effective_target_node = target_node_id or self.config.target_node_id
+        effective_target_alias = target_alias or self.config.target_alias
+        effective_bridge_id = bridge_id or event.bridge_id
+        status_token = self._generate_status_token(
+            effective_bridge_id, effective_target_node
+        )
         return {
             "spec_version": "mep.interbot.v1",
             "message_id": str(uuid.uuid4()),
-            "trace_id": event.bridge_id,
+            "trace_id": effective_bridge_id,
             "timestamp_ms": timestamp_ms,
             "source": {
                 "node_id": self.submission_client.node_id,
                 "alias": self.config.bridge_source_alias,
             },
             "target": {
-                "node_id": self.config.target_node_id,
-                "alias": self.config.target_alias,
+                "node_id": effective_target_node,
+                "alias": effective_target_alias,
             },
             "conversation": {
                 "context_id": event.context_id,
@@ -900,7 +1016,7 @@ class GitHubToMEPBridgeService:
                     "bridge_metadata": {
                         "source_type": "github",
                         "delivery_id": event.delivery_id,
-                        "bridge_id": event.bridge_id,
+                        "bridge_id": effective_bridge_id,
                         "status_endpoint": status_endpoint,
                         "status_token": status_token,
                         "event_sequence": event.event_sequence,
@@ -1098,13 +1214,17 @@ class GitHubToMEPBridgeService:
         task_id: Optional[str] = None,
         action: Optional[str] = None,
         detail: Optional[str] = None,
+        target_alias: Optional[str] = None,
+        target_node_id: Optional[str] = None,
     ) -> str:
         kind = "PR" if event.entity_type == "pr" else "Issue"
+        effective_target_alias = target_alias or self.config.target_alias
+        effective_target_node_id = target_node_id or self.config.target_node_id
         lines = [
             f"{kind} {event.repo_full_name}#{event.number}",
             f"verb: {event.imperative_verb}",
             f"status: {status}",
-            f"target: {self.config.target_alias} ({self.config.target_node_id})",
+            f"target: {effective_target_alias} ({effective_target_node_id})",
             f"bridge_id: {event.bridge_id}",
             f"context_id: {event.context_id}",
         ]
@@ -1153,6 +1273,8 @@ def create_app(
         return {
             "status": "ok",
             "bridge": "github_to_mep",
+            "multi_target": bool(bridge_service.config.alias_map),
+            "alias_map": bridge_service.config.alias_map,
             "target_node_id": bridge_service.config.target_node_id,
             "coalesce_window_seconds": bridge_service.config.coalesce_window_seconds,
         }

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -257,6 +257,7 @@ class BridgeStore:
                 repo_full_name TEXT NOT NULL,
                 issue_number INTEGER NOT NULL,
                 entity_type TEXT NOT NULL,
+                target_alias TEXT NOT NULL,
                 target_node_id TEXT NOT NULL,
                 imperative_verb TEXT NOT NULL,
                 intent_type TEXT NOT NULL,
@@ -284,6 +285,15 @@ class BridgeStore:
             ON bridge_deliveries (context_id, received_at)
             """
         )
+        cursor.execute("PRAGMA table_info(bridge_executions)")
+        execution_columns = {str(row["name"]) for row in cursor.fetchall()}
+        if "target_alias" not in execution_columns:
+            cursor.execute(
+                """
+                ALTER TABLE bridge_executions
+                ADD COLUMN target_alias TEXT NOT NULL DEFAULT ''
+                """
+            )
         conn.commit()
         conn.close()
 
@@ -303,7 +313,7 @@ class BridgeStore:
         conn.close()
         return exists
 
-    def _next_event_sequence(self, context_id: str) -> int:
+    def next_event_sequence(self, context_id: str) -> int:
         conn = self._connect()
         cursor = conn.cursor()
         cursor.execute(
@@ -324,19 +334,28 @@ class BridgeStore:
         conn.close()
         return next_sequence
 
-    def create_execution(self, event: NormalizedGitHubEvent, bridge_id: str, target_node_id: str) -> int:
+    def create_execution(
+        self,
+        event: NormalizedGitHubEvent,
+        bridge_id: str,
+        target_node_id: str,
+        *,
+        target_alias: str,
+        event_sequence: Optional[int] = None,
+    ) -> int:
         now = time.time()
-        event_sequence = self._next_event_sequence(event.context_id)
+        if event_sequence is None:
+            event_sequence = self.next_event_sequence(event.context_id)
         conn = self._connect()
         cursor = conn.cursor()
         cursor.execute(
             """
             INSERT INTO bridge_executions (
                 bridge_id, context_id, repo_full_name, issue_number, entity_type,
-                target_node_id, imperative_verb, intent_type, event_sequence,
+                target_alias, target_node_id, imperative_verb, intent_type, event_sequence,
                 status, created_at, updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 bridge_id,
@@ -344,6 +363,7 @@ class BridgeStore:
                 event.repo_full_name,
                 event.number,
                 event.entity_type,
+                target_alias,
                 target_node_id,
                 event.imperative_verb,
                 event.intent_type,
@@ -552,7 +572,7 @@ class GitHubToMEPBridgeService:
             missing.append("GITHUB_WEBHOOK_SECRET")
         if not self.config.hub_url:
             missing.append("MEP_HUB_URL")
-        if not self.config.target_node_id:
+        if not self.config.target_node_id and not self.config.alias_map:
             missing.append("MEP_BRIDGE_TARGET_NODE_ID")
         if not self.config.status_secret:
             missing.append("MEP_BRIDGE_STATUS_SECRET")
@@ -601,6 +621,16 @@ class GitHubToMEPBridgeService:
             pending = self._pending_by_context.get(event.context_id)
             if pending is not None:
                 pending.event = self._merge_events(pending.event, event)
+                pending.targets = self._get_targets_for_event(pending.event)
+                if not pending.targets and self.config.target_node_id:
+                    pending.targets = [
+                        TriggerMatch(
+                            alias=self.config.target_alias,
+                            verb=pending.event.imperative_verb,
+                            intent_type=pending.event.intent_type,
+                            node_id=self.config.target_node_id,
+                        )
+                    ]
                 self.store.record_delivery(
                     delivery_id=event.delivery_id,
                     bridge_id=pending.bridge_id,
@@ -628,9 +658,7 @@ class GitHubToMEPBridgeService:
                     node_id=self.config.target_node_id,
                 )]
             bridge_id = f"br-{secrets.token_hex(8)}"
-            event_sequence = self.store.create_execution(
-                event, bridge_id, targets[0].node_id
-            )
+            event_sequence = self.store.next_event_sequence(event.context_id)
             event.bridge_id = bridge_id
             event.event_sequence = event_sequence
             if not event.coalesced_delivery_ids:
@@ -715,10 +743,17 @@ class GitHubToMEPBridgeService:
                 node_id=self.config.target_node_id,
             )]
 
+        single_target = len(targets) == 1
         for target in targets:
-            target_bridge_id = f"{pending.bridge_id}-{target.alias.replace(' ', '-').lower()}"
+            target_bridge_id = pending.bridge_id if single_target else (
+                f"{pending.bridge_id}-{target.alias.replace(' ', '-').lower()}"
+            )
             self.store.create_execution(
-                pending.event, target_bridge_id, target.node_id
+                pending.event,
+                target_bridge_id,
+                target.node_id,
+                target_alias=target.alias,
+                event_sequence=pending.event.event_sequence,
             )
             self.store.update_execution(target_bridge_id, status="submitting")
             envelope = self._build_interbot_envelope(
@@ -901,27 +936,56 @@ class GitHubToMEPBridgeService:
         """Extract ALL actionable @alias verb mentions from text."""
         if not isinstance(text, str) or not text.strip():
             return []
+        alias_lookup = {
+            alias.strip().lower(): alias
+            for alias in self.config.trigger_aliases
+            if isinstance(alias, str) and alias.strip()
+        }
+        if not alias_lookup:
+            return []
+        alias_pattern = "|".join(
+            sorted((re.escape(alias) for alias in alias_lookup.values()), key=len, reverse=True)
+        )
+        mention_pattern = re.compile(rf"@(?P<alias>{alias_pattern})\b", re.IGNORECASE)
+        mention_matches = list(mention_pattern.finditer(text))
+        if not mention_matches:
+            return []
         matches: list[TriggerMatch] = []
         seen_aliases: set[str] = set()
-        for alias in self.config.trigger_aliases:
-            if alias in seen_aliases:
-                continue
-            pattern = re.compile(
-                rf"@{re.escape(alias)}\b(?:\s+|[,:]\s*)(?P<verb>[a-z][a-z_-]*)",
+        mention_index = 0
+        while mention_index < len(mention_matches):
+            grouped_mentions = [mention_matches[mention_index]]
+            cursor = mention_matches[mention_index].end()
+            mention_index += 1
+            while mention_index < len(mention_matches):
+                separator = text[cursor:mention_matches[mention_index].start()]
+                if re.fullmatch(r"(?:\s|[,:])+", separator):
+                    grouped_mentions.append(mention_matches[mention_index])
+                    cursor = mention_matches[mention_index].end()
+                    mention_index += 1
+                    continue
+                break
+            verb_match = re.match(
+                r"(?:\s+|[,:]\s*)(?P<verb>[a-z][a-z_-]*)\b",
+                text[cursor:],
                 re.IGNORECASE,
             )
-            match = pattern.search(text)
-            if not match:
+            if not verb_match:
                 continue
-            verb = match.group("verb").strip().lower()
+            verb = verb_match.group("verb").strip().lower()
             intent_type = DEFAULT_TRIGGER_VERBS.get(verb)
             if not intent_type:
                 continue
-            node_id = self.config.alias_map.get(alias, self.config.target_node_id)
-            if not node_id:
-                continue
-            matches.append(TriggerMatch(alias=alias, verb=verb, intent_type=intent_type, node_id=node_id))
-            seen_aliases.add(alias)
+            for mention in grouped_mentions:
+                raw_alias = mention.group("alias").strip().lower()
+                alias = alias_lookup.get(raw_alias)
+                if not alias or raw_alias in seen_aliases:
+                    continue
+                node_id = self.config.alias_map.get(alias, self.config.target_node_id)
+                if not node_id:
+                    continue
+                matches.append(TriggerMatch(alias=alias, verb=verb, intent_type=intent_type, node_id=node_id))
+                seen_aliases.add(raw_alias)
         return matches
 
     def _extract_trigger(self, text: str) -> Optional[tuple[str, str]]:
@@ -1097,8 +1161,17 @@ class GitHubToMEPBridgeService:
             return "commented"
         return "commented"
 
-    def _render_github_writeback_body(self, bridge_id: str, action: str, detail: Optional[str]) -> str:
-        detail_text = (detail or "").strip() or f"{self.config.target_alias} completed the requested action."
+    def _render_github_writeback_body(
+        self,
+        bridge_id: str,
+        action: str,
+        detail: Optional[str],
+        *,
+        target_alias: Optional[str] = None,
+    ) -> str:
+        detail_text = (detail or "").strip() or (
+            f"{target_alias or self.config.target_alias} completed the requested action."
+        )
         marker = f"{BRIDGE_OUTPUT_MARKER} bridge_id={bridge_id} action={action} -->"
         return f"{detail_text}\n\n{marker}"
 
@@ -1137,7 +1210,12 @@ class GitHubToMEPBridgeService:
         number = int(execution.get("issue_number") or 0)
         entity_type = str(execution.get("entity_type") or "").strip().lower()
         action = self._resolve_github_writeback_action(execution, update)
-        body = self._render_github_writeback_body(str(execution.get("bridge_id") or update.bridge_id), action, update.detail)
+        body = self._render_github_writeback_body(
+            str(execution.get("bridge_id") or update.bridge_id),
+            action,
+            update.detail,
+            target_alias=str(execution.get("target_alias") or "").strip() or None,
+        )
         review_events = {
             "approved": "APPROVE",
             "reviewed": "COMMENT",
@@ -1202,6 +1280,8 @@ class GitHubToMEPBridgeService:
                 task_id=update.task_id or refreshed.get("task_id"),
                 action=resolved_action,
                 detail=update.detail,
+                target_alias=str(refreshed.get("target_alias") or "").strip() or None,
+                target_node_id=str(refreshed.get("target_node_id") or "").strip() or None,
             ),
         )
         return {"status": "ok", "bridge_id": update.bridge_id}

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -96,6 +96,7 @@ def _build_config(tmp_dir: str) -> BridgeConfig:
         target_node_id="node_target",
         target_alias="Hub Sentinel",
         trigger_aliases=["Hub-Sentinel"],
+        alias_map={"Hub-Sentinel": "node_target"},
         public_base_url="http://bridge.example.test",
         status_secret="status-secret",
         status_token_lifetime_seconds=1800,
@@ -179,6 +180,13 @@ class TestGitHubToMEPBridge(unittest.TestCase):
     def _flush_context(self, context_id: str) -> None:
         asyncio.run(self.service._flush_context(context_id))
 
+    def _configure_multi_target_aliases(self) -> None:
+        self.config.trigger_aliases = ["Hub Sentinel", "Elsaws Bot"]
+        self.config.alias_map = {
+            "Hub Sentinel": "node_target",
+            "Elsaws Bot": "node_elsaws",
+        }
+
     def test_actionable_webhook_submits_structured_dm_after_coalescence(self):
         response = self._post_webhook(
             _issue_comment_payload("@Hub-Sentinel review this PR"),
@@ -224,6 +232,45 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         bridge_metadata = self.submission.calls[0]["envelope"]["task"]["inputs"]["bridge_metadata"]
         self.assertEqual(set(bridge_metadata["coalesced_delivery_ids"]), {"delivery-a", "delivery-b"})
         self.assertEqual(self.submission.calls[0]["intent_type"], "analysis.request")
+        github_inputs = self.submission.calls[0]["envelope"]["task"]["inputs"]["github"]
+        self.assertEqual(github_inputs["source_action"], "edited")
+
+    def test_grouped_multi_alias_trigger_routes_each_target(self):
+        self._configure_multi_target_aliases()
+
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub Sentinel @Elsaws Bot review this PR"),
+            delivery_id="delivery-multi",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        self._flush_context(response.json()["context_id"])
+
+        self.assertEqual(len(self.submission.calls), 2)
+        routed_targets = {call["target_node_id"] for call in self.submission.calls}
+        self.assertEqual(routed_targets, {"node_target", "node_elsaws"})
+        routed_aliases = {
+            call["envelope"]["target"]["alias"]: call["envelope"]["task"]["inputs"]["bridge_metadata"]["bridge_id"]
+            for call in self.submission.calls
+        }
+        self.assertIn("Hub Sentinel", routed_aliases)
+        self.assertIn("Elsaws Bot", routed_aliases)
+        self.assertNotEqual(routed_aliases["Hub Sentinel"], routed_aliases["Elsaws Bot"])
+
+    def test_same_context_burst_recomputes_targets_from_latest_trigger_text(self):
+        self._configure_multi_target_aliases()
+        payload_one = _issue_comment_payload("@Hub Sentinel review this PR", action="created")
+        payload_two = _issue_comment_payload("@Elsaws Bot review this PR", action="edited")
+
+        first = self._post_webhook(payload_one, delivery_id="delivery-target-a")
+        second = self._post_webhook(payload_two, delivery_id="delivery-target-b")
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+
+        self._flush_context(first.json()["context_id"])
+
+        self.assertEqual(len(self.submission.calls), 1)
+        self.assertEqual(self.submission.calls[0]["target_node_id"], "node_elsaws")
         github_inputs = self.submission.calls[0]["envelope"]["task"]["inputs"]["github"]
         self.assertEqual(github_inputs["source_action"], "edited")
 
@@ -289,6 +336,36 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(len(self.github_session.posts), 1)
         self.assertTrue(self.github_session.posts[0]["url"].endswith("/repos/WUAIBING/MEP/issues/227/comments"))
         self.assertEqual(self.github_session.posts[0]["json"]["body"].splitlines()[0], "Analysis complete.")
+
+    def test_status_callback_uses_actual_target_metadata_for_non_default_alias(self):
+        self._configure_multi_target_aliases()
+        response = self._post_webhook(
+            _issue_comment_payload("@Elsaws Bot analyze this PR", delivery_number=228),
+            delivery_id="delivery-elsaws-status",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        self._flush_context(response.json()["context_id"])
+
+        self.assertEqual(len(self.submission.calls), 1)
+        envelope = self.submission.calls[0]["envelope"]
+        bridge_id = envelope["task"]["inputs"]["bridge_metadata"]["bridge_id"]
+        token = self.service._generate_status_token(bridge_id, "node_elsaws")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_elsaws",
+                "task_id": "task-elsaws",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertIn("target: Elsaws Bot (node_elsaws)", self.notifier.calls[-1]["text"])
+        self.assertEqual(len(self.github_session.posts), 1)
+        self.assertTrue(self.github_session.posts[0]["url"].endswith("/repos/WUAIBING/MEP/issues/228/comments"))
+        self.assertIn("Elsaws Bot completed the requested action.", self.github_session.posts[0]["json"]["body"])
 
     def test_non_maintainer_trigger_is_ignored_when_policy_enabled(self):
         payload = _issue_comment_payload("@Hub-Sentinel review this PR")


### PR DESCRIPTION
## What

Converts the GitHub→MEP bridge from single-target to multi-target. One webhook endpoint, one webhook secret, multiple bot routes.

## Why

Currently the bridge routes all mentions to a single `MEP_BRIDGE_TARGET_NODE_ID`. When a PR comment says:

```
@Hub Sentinel @Elsaws Bot review this PR
```

Only the first-matched alias gets the task. The second bot is dropped silently.

## Changes

- **New env var:** `MEP_BRIDGE_ALIAS_MAP` — JSON dict `{"alias": "node_id", ...}`
- **New dataclass:** `TriggerMatch` — carries alias, verb, intent_type, node_id
- **`_extract_triggers()`** — returns ALL actionable mentions, not just first
- **`_flush_context()`** — submits one DM per target, with per-target bridge_id
- **`_build_interbot_envelope()`** — accepts optional target/bridge_id overrides
- **`/health`** — now shows `alias_map` and `multi_target` flag
- **Legacy `_extract_trigger()`** — retained as wrapper for backward compat

## Backward Compat

Without `MEP_BRIDGE_ALIAS_MAP`, the bridge falls back to legacy single-target behavior:
- `MEP_BRIDGE_TARGET_ALIAS` → populates `alias_map[target_alias] = target_node_id`
- All existing single-target configs continue to work unchanged

## Example Config (Multi-Target)

```env
MEP_BRIDGE_ALIAS_MAP={"Hub Sentinel":"node_b2f19654a37c","Elsaws Bot":"node_bf4960a5112a"}
```

## Routing Model

- **Shared endpoint:** `/github/webhook`
- **Shared secret:** `GITHUB_WEBHOOK_SECRET` (one secret at bridge layer)
- **Internal routing:** alias → node_id map
- **Dual mention:** `@Hub Sentinel @Elsaws Bot review this PR` → two DM tasks, same `context_id`, separate `bridge_id` per target

## Test Plan

1. `_extract_triggers("@Hub Sentinel @Elsaws Bot review this PR")` → 2 TriggerMatch entries
2. Single-target config without ALIAS_MAP → behavior unchanged
3. Webhook with dual mention → 2 bridge executions, each with correct target_node_id
4. Per-target bridge_id derivation: `br-{hex}-hub-sentinel`, `br-{hex}-elsaws-bot`