### PR TITLE
feat(finance): legacy adapter layer over canonical ns path (PR 4)

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -701,6 +701,29 @@ def get_balance(node_id: str) -> Optional[float]:
     _release_conn(conn)
     return row[0] if row else None
 
+# Public alias: the integer ns column is the canonical source of truth, and
+# the money layer reads financial rows through this coercion helper.
+coerce_ns_from_row = _coerce_ns_from_row
+
+def get_balance_row(node_id: str) -> Optional[tuple]:
+    """Return (balance, balance_ns) for a node, or None if it does not exist.
+
+    Exposes the canonical integer-ns column alongside the legacy float so
+    callers can treat ns as the source of truth and convert to float only at
+    the response boundary.
+    """
+    conn = _get_conn()
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute("SELECT balance, balance_ns FROM ledger WHERE node_id = %s", (node_id,))
+    else:
+        cursor.execute("SELECT balance, balance_ns FROM ledger WHERE node_id = ?", (node_id,))
+    row = cursor.fetchone()
+    _release_conn(conn)
+    if not row:
+        return None
+    return (row[0], row[1])
+
 def get_node_count() -> int:
     conn = _get_conn()
     cursor = conn.cursor()

--- a/hub/main.py
+++ b/hub/main.py
@@ -52,7 +52,8 @@ from v2_models import (
     V2LedgerListResponse,
 )
 
-from nanoseconds import legacy_seconds_to_ns, ns_to_legacy_seconds
+from nanoseconds import ns_to_legacy_seconds
+import money
 
 app = FastAPI(title="MEP Hub", description="The Time Exchange Clearinghouse", version="0.1.2", docs_url="/docs", redoc_url="/redoc")
 
@@ -1708,12 +1709,14 @@ async def register_node_v2(node: NodeRegistration, request: Request):
         log_event("node_pending", f"Node {node_id} registration pending approval", node_id=node_id)
 
     hub_url, ws_url = get_hub_urls(request)
-    balance_ns = legacy_seconds_to_ns(balance, "balance")
+    balance_row = db.get_balance_row(node_id)
+    balance_ns_value = balance_row[1] if balance_row else None
+    balance_ns_str = money.to_v2_ns_string(balance, balance_ns_value, "balance", allow_negative=False)
 
     return V2RegistrationResponse(
         status=status,
         node_id=node_id,
-        balance_ns=str(balance_ns),
+        balance_ns=balance_ns_str,
         hub_url=hub_url,
         ws_url=ws_url
     )
@@ -2142,18 +2145,21 @@ async def get_reputation(node_id: str):
 
 @app.get("/balance/{node_id}")
 async def get_balance(node_id: str):
-    balance = db.get_balance(node_id)
-    if balance is None:
+    row = db.get_balance_row(node_id)
+    if row is None:
         raise HTTPException(status_code=404, detail="Node not found")
-    return {"node_id": node_id, "balance_seconds": balance}
+    balance, balance_ns = row
+    balance_seconds = money.to_legacy_seconds(balance, balance_ns, "balance", allow_negative=False)
+    return {"node_id": node_id, "balance_seconds": balance_seconds}
 
 @app.get("/v2/balance/{node_id}")
 async def get_balance_v2(node_id: str):
-    balance = db.get_balance(node_id)
-    if balance is None:
+    row = db.get_balance_row(node_id)
+    if row is None:
         raise HTTPException(status_code=404, detail="Node not found")
-    balance_ns = legacy_seconds_to_ns(balance, "balance")
-    return V2BalanceResponse(node_id=node_id, balance_ns=str(balance_ns))
+    balance, balance_ns = row
+    balance_ns_str = money.to_v2_ns_string(balance, balance_ns, "balance", allow_negative=False)
+    return V2BalanceResponse(node_id=node_id, balance_ns=balance_ns_str)
 
 @app.post("/tasks/submit")
 async def submit_task(
@@ -2765,11 +2771,14 @@ async def get_task_result(task_id: str, authenticated_node: str = Depends(verify
         raise HTTPException(status_code=404, detail="Task not found or not completed")
     if authenticated_node not in (task["consumer_id"], task["provider_id"]):
         raise HTTPException(status_code=403, detail="Not authorized to view this result")
+    bounty_seconds = money.to_legacy_seconds(
+        task["bounty"], task.get("bounty_ns"), "bounty", allow_negative=True
+    )
     return {
         "task_id": task["task_id"],
         "consumer_id": task["consumer_id"],
         "provider_id": task["provider_id"],
-        "bounty": task["bounty"],
+        "bounty": bounty_seconds,
         "result_payload": task["result_payload"],
         "result_uri": task.get("result_uri")
     }
@@ -2782,14 +2791,16 @@ async def get_task_result_v2(task_id: str, authenticated_node: str = Depends(ver
     if authenticated_node not in (task["consumer_id"], task["provider_id"]):
         raise HTTPException(status_code=403, detail="Not authorized to view this result")
     
-    bounty_ns = legacy_seconds_to_ns(task["bounty"], "bounty_ns")
+    bounty_ns_str = money.to_v2_ns_string(
+        task["bounty"], task.get("bounty_ns"), "bounty", allow_negative=True
+    )
     
     return V2TaskResponse(
         task_id=task["task_id"],
         consumer_id=task["consumer_id"],
         provider_id=task["provider_id"],
         status=task["status"],
-        bounty_ns=str(bounty_ns),
+        bounty_ns=bounty_ns_str,
         result_uri=task.get("result_uri")
     )
 
@@ -3181,26 +3192,27 @@ async def ledger_entries_v2(node_id: str, limit: int = 50, authenticated_node: s
                     key, value = part.split(":", 1)
                     entry_dict[key.strip().lower()] = value.strip()
             
-            # Convert financial values to ns
+            # Ledger entries come from the audit log (legacy text, no ns column),
+            # so this is pure boundary adaptation routed through the money layer.
             amount_ns = None
             balance_ns = None
             if "amount" in entry_dict:
                 try:
                     amount = float(entry_dict["amount"])
-                    amount_ns = legacy_seconds_to_ns(amount, "amount")
+                    amount_ns = money.to_v2_ns_string(amount, None, "amount", allow_negative=True)
                 except (ValueError, KeyError):
                     pass
             if "balance" in entry_dict:
                 try:
                     balance = float(entry_dict["balance"])
-                    balance_ns = legacy_seconds_to_ns(balance, "balance")
+                    balance_ns = money.to_v2_ns_string(balance, None, "balance", allow_negative=False)
                 except (ValueError, KeyError):
                     pass
             
             v2_entries.append(V2LedgerEntryResponse(
                 node_id=node_id,
-                amount_ns=str(amount_ns) if amount_ns is not None else None,
-                balance_ns=str(balance_ns) if balance_ns is not None else None,
+                amount_ns=amount_ns,
+                balance_ns=balance_ns,
                 kind=entry_dict.get("action", "unknown"),
                 reference_id=entry_dict.get("reference")
             ))
@@ -3221,13 +3233,15 @@ async def get_escrow_v2(task_id: str, authenticated_node: str = Depends(verify_r
     if authenticated_node not in (escrow["consumer_id"], escrow.get("provider_id")):
         raise HTTPException(status_code=403, detail="Not authorized to view this escrow")
     
-    amount_ns = legacy_seconds_to_ns(escrow["amount"], "amount")
+    amount_ns_str = money.to_v2_ns_string(
+        escrow["amount"], escrow.get("amount_ns"), "amount", allow_negative=False
+    )
     
     return V2EscrowResponse(
         task_id=task_id,
         consumer_id=escrow["consumer_id"],
         provider_id=escrow.get("provider_id"),
-        amount_ns=str(amount_ns),
+        amount_ns=amount_ns_str,
         status=escrow["status"]
     )
 
@@ -3237,12 +3251,14 @@ async def list_escrows_v2(authenticated_node: str = Depends(verify_request)):
     
     v2_escrows = []
     for escrow in escrows:
-        amount_ns = legacy_seconds_to_ns(escrow["amount"], "amount")
+        amount_ns_str = money.to_v2_ns_string(
+            escrow["amount"], escrow.get("amount_ns"), "amount", allow_negative=False
+        )
         v2_escrows.append(V2EscrowResponse(
             task_id=escrow["task_id"],
             consumer_id=escrow["consumer_id"],
             provider_id=escrow.get("provider_id"),
-            amount_ns=str(amount_ns),
+            amount_ns=amount_ns_str,
             status=escrow["status"]
         ))
     

--- a/hub/money.py
+++ b/hub/money.py
@@ -1,0 +1,108 @@
+"""Canonical ns-first internal money path (PR 4 legacy adapter layer).
+
+This module is the single internal path that financial endpoints — both the
+legacy float surface and the v2 ns surface — read money through. The integer
+nanosecond column is the source of truth; legacy float values are produced only
+at the response boundary via :func:`nanoseconds.ns_to_legacy_seconds`.
+
+Design-lock acceptance criterion (issues #223/#224, PR #225):
+
+    "Legacy financial endpoint handlers contain no direct financial float
+    arithmetic. Money operations must route through the canonical ns-first
+    helpers/internal path, with any legacy float translation confined to
+    request/response boundary adaptation."
+
+Endpoints call into this module instead of doing their own seconds<->ns math,
+so the canonical value is read from the ns column, not recomputed from floats.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import db
+from nanoseconds import (
+    NanosecondsError,
+    format_ns_string,
+    legacy_seconds_to_ns,
+    ns_to_legacy_seconds,
+)
+
+
+def canonical_ns(
+    legacy_value,
+    ns_value,
+    field_name: str,
+    *,
+    allow_negative: bool,
+) -> Optional[int]:
+    """Resolve the canonical integer-ns amount for a financial row.
+
+    Prefers the ns column (source of truth). For pre-migration rows whose ns
+    column is still NULL and whose legacy float is not exactly representable in
+    nanoseconds, returns ``None`` so the caller can degrade gracefully at the
+    boundary rather than raising. A populated-but-invalid ns column still
+    raises, because that is a storage-integrity problem, not a migration gap.
+    """
+
+    if ns_value is None and legacy_value is None:
+        return None
+    try:
+        return db.coerce_ns_from_row(
+            legacy_value, ns_value, field_name, allow_negative=allow_negative
+        )
+    except NanosecondsError:
+        if ns_value is not None:
+            # ns column is populated but malformed — surface the integrity error.
+            raise
+        # ns column absent and legacy float is not exact ns: no canonical truth.
+        return None
+
+
+def to_legacy_seconds(
+    legacy_value,
+    ns_value,
+    field_name: str,
+    *,
+    allow_negative: bool,
+) -> float:
+    """Legacy float boundary value derived from the canonical ns source.
+
+    When a canonical ns value exists it is converted to float here (the only
+    place float translation is allowed). Pre-migration rows without a canonical
+    ns value fall back to the stored legacy float unchanged.
+    """
+
+    ns = canonical_ns(legacy_value, ns_value, field_name, allow_negative=allow_negative)
+    if ns is None:
+        return legacy_value
+    return ns_to_legacy_seconds(ns)
+
+
+def to_v2_ns_string(
+    legacy_value,
+    ns_value,
+    field_name: str,
+    *,
+    allow_negative: bool,
+) -> str:
+    """Canonical v2 ns JSON string derived from the ns source of truth.
+
+    Falls back to an exact boundary conversion of the legacy float only for
+    pre-migration rows whose ns column is still NULL.
+    """
+
+    ns = canonical_ns(legacy_value, ns_value, field_name, allow_negative=allow_negative)
+    if ns is None:
+        ns = legacy_seconds_to_ns(legacy_value, field_name)
+    return format_ns_string(ns)
+
+
+def balance_ns(node_id: str) -> Optional[int]:
+    """Canonical balance in integer nanoseconds, or None if the node is unknown."""
+
+    row = db.get_balance_row(node_id)
+    if row is None:
+        return None
+    balance, balance_ns_value = row
+    return canonical_ns(balance, balance_ns_value, "balance", allow_negative=False)

--- a/tests/test_legacy_adapter.py
+++ b/tests/test_legacy_adapter.py
@@ -1,0 +1,259 @@
+"""Tests for PR 4: legacy adapter layer + regression coverage.
+
+These tests lock the design-lock acceptance criterion from #223/#224:
+
+    Legacy financial endpoint handlers contain no direct financial float
+    arithmetic. Money operations route through the canonical ns-first internal
+    path (``hub/money.py``), with legacy float translation confined to the
+    response boundary.
+
+Two things are verified:
+- the canonical money path treats the integer ns column as the source of truth
+- the legacy float surface and the v2 ns surface stay consistent because they
+  are both derived from that single canonical path
+"""
+
+import base64
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+import uuid
+
+# Dedicated SQLite file; tests only ever read nodes/tasks they create, so they
+# are correct regardless of which test module initialised the DB first.
+_test_db = os.path.join(tempfile.gettempdir(), "mep_test_legacy_adapter.db")
+os.environ["MEP_SQLITE_PATH"] = _test_db
+os.environ.setdefault("MEP_DATABASE_URL", "")  # force SQLite
+os.environ.setdefault("MEP_ADMIN_KEY", "test-admin-key")
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "hub"))
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: E402
+from cryptography.hazmat.primitives import serialization  # noqa: E402
+
+import db  # noqa: E402
+import money  # noqa: E402
+from main import app  # noqa: E402
+from nanoseconds import NanosecondsError, NS_PER_SECOND  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers (mirror test_hub_api.py)
+# ---------------------------------------------------------------------------
+def _make_identity():
+    private_key = Ed25519PrivateKey.generate()
+    pub_pem = private_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    from auth import derive_node_id
+    return private_key, pub_pem, derive_node_id(pub_pem)
+
+
+def _auth_headers(private_key, node_id: str, payload_str: str) -> dict:
+    ts = str(int(time.time()))
+    message = f"{payload_str}{ts}".encode("utf-8")
+    signature = base64.b64encode(private_key.sign(message)).decode("utf-8")
+    return {
+        "X-MEP-NodeID": node_id,
+        "X-MEP-Timestamp": ts,
+        "X-MEP-Signature": signature,
+        "Content-Type": "application/json",
+    }
+
+
+def _register(pub_pem: str) -> dict:
+    resp = client.post("/register", json={"pubkey": pub_pem})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    if data["status"] == "pending":
+        approve = client.post(
+            "/admin/approve-registration",
+            json={"node_id": data["node_id"]},
+            headers={"x-mep-admin-key": "test-admin-key"},
+        )
+        assert approve.status_code == 200, approve.text
+        data = approve.json()
+    return data
+
+
+def _set_balance_ns_raw(node_id: str, balance_ns: int):
+    """Force the canonical ns column to a value, leaving the legacy float alone."""
+    conn = db._get_conn()
+    cursor = conn.cursor()
+    placeholder = "%s" if db._is_postgres() else "?"
+    cursor.execute(
+        f"UPDATE ledger SET balance_ns = {placeholder} WHERE node_id = {placeholder}",
+        (balance_ns, node_id),
+    )
+    conn.commit()
+    db._release_conn(conn)
+
+
+# ---------------------------------------------------------------------------
+# Canonical money path (pure unit tests)
+# ---------------------------------------------------------------------------
+class TestMoneyCanonicalPath(unittest.TestCase):
+    def test_prefers_ns_column_over_float(self):
+        # ns column is the source of truth even when the float disagrees.
+        self.assertEqual(
+            money.canonical_ns(10.0, 7_000_000_000, "balance", allow_negative=False),
+            7_000_000_000,
+        )
+
+    def test_falls_back_to_exact_float_when_ns_null(self):
+        self.assertEqual(
+            money.canonical_ns(5.0, None, "balance", allow_negative=False),
+            5_000_000_000,
+        )
+
+    def test_returns_none_for_nonexact_float_without_ns(self):
+        # Pre-migration row whose float cannot be represented exactly in ns.
+        self.assertIsNone(
+            money.canonical_ns(0.0000000015, None, "balance", allow_negative=False)
+        )
+
+    def test_raises_for_negative_ns_when_not_allowed(self):
+        with self.assertRaises(NanosecondsError):
+            money.canonical_ns(None, -5_000_000_000, "balance", allow_negative=False)
+
+    def test_allows_negative_ns_for_bounty(self):
+        self.assertEqual(
+            money.canonical_ns(None, -5_000_000_000, "bounty", allow_negative=True),
+            -5_000_000_000,
+        )
+
+    def test_to_legacy_seconds_prefers_ns(self):
+        self.assertEqual(
+            money.to_legacy_seconds(10.0, 7_000_000_000, "balance", allow_negative=False),
+            7.0,
+        )
+
+    def test_to_legacy_seconds_falls_back_to_raw_float(self):
+        # No canonical ns truth available -> return the stored legacy float as-is.
+        self.assertEqual(
+            money.to_legacy_seconds(0.0000000015, None, "balance", allow_negative=False),
+            0.0000000015,
+        )
+
+    def test_to_v2_ns_string_prefers_ns(self):
+        self.assertEqual(
+            money.to_v2_ns_string(10.0, 7_000_000_000, "balance", allow_negative=False),
+            "7000000000",
+        )
+
+    def test_to_v2_ns_string_falls_back_to_exact_convert(self):
+        self.assertEqual(
+            money.to_v2_ns_string(5.0, None, "balance", allow_negative=False),
+            "5000000000",
+        )
+
+    def test_legacy_and_v2_are_consistent(self):
+        # Both surfaces derive from the same canonical ns value.
+        legacy = money.to_legacy_seconds(0.0, 2_500_000_000, "amount", allow_negative=False)
+        v2 = money.to_v2_ns_string(0.0, 2_500_000_000, "amount", allow_negative=False)
+        self.assertEqual(int(v2), round(legacy * NS_PER_SECOND))
+        self.assertEqual(int(v2), 2_500_000_000)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint regression coverage (legacy vs v2 consistency)
+# ---------------------------------------------------------------------------
+class TestBalanceAdapter(unittest.TestCase):
+    def test_legacy_and_v2_balance_consistent(self):
+        _, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+
+        legacy = client.get(f"/balance/{node_id}")
+        v2 = client.get(f"/v2/balance/{node_id}")
+        self.assertEqual(legacy.status_code, 200, legacy.text)
+        self.assertEqual(v2.status_code, 200, v2.text)
+
+        balance_seconds = legacy.json()["balance_seconds"]
+        balance_ns = int(v2.json()["balance_ns"])
+        self.assertEqual(balance_ns, round(balance_seconds * NS_PER_SECOND))
+        # Approved nodes start with 10 SECONDS.
+        self.assertEqual(balance_ns, 10_000_000_000)
+
+    def test_balance_uses_ns_column_as_source_of_truth(self):
+        _, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+
+        # Diverge the canonical ns column from the legacy float. Both endpoints
+        # must now reflect the ns value, proving they read through the ns path.
+        _set_balance_ns_raw(node_id, 7_000_000_000)
+
+        legacy = client.get(f"/balance/{node_id}").json()
+        v2 = client.get(f"/v2/balance/{node_id}").json()
+        self.assertEqual(legacy["balance_seconds"], 7.0)
+        self.assertEqual(v2["balance_ns"], "7000000000")
+
+    def test_unknown_node_returns_404_on_both_surfaces(self):
+        self.assertEqual(client.get("/balance/does-not-exist").status_code, 404)
+        self.assertEqual(client.get("/v2/balance/does-not-exist").status_code, 404)
+
+
+class TestEscrowAdapter(unittest.TestCase):
+    def test_escrow_amount_ns_consistent_with_bounty(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "work", "bounty": 3.0})
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(submit.status_code, 200, submit.text)
+        task_id = submit.json()["task_id"]
+
+        # Escrow held for the bounty; v2 escrow amount is the canonical ns value.
+        v2_escrow = client.get(
+            f"/v2/escrows/{task_id}",
+            headers=_auth_headers(consumer_priv, consumer_id, ""),
+        )
+        self.assertEqual(v2_escrow.status_code, 200, v2_escrow.text)
+        self.assertEqual(v2_escrow.json()["amount_ns"], "3000000000")
+
+        # Consumer balance dropped by the bounty on both surfaces (10 - 3 = 7).
+        legacy_balance = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+        v2_balance = client.get(f"/v2/balance/{consumer_id}").json()["balance_ns"]
+        self.assertEqual(legacy_balance, 7.0)
+        self.assertEqual(v2_balance, "7000000000")
+
+
+class TestTaskResultAdapter(unittest.TestCase):
+    def test_legacy_and_v2_task_result_bounty_consistent(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+
+        task_id = f"legacy-adapter-result-{uuid.uuid4()}"
+        db.create_task(
+            task_id, consumer_id, "payload", 2.0, "completed", None, None, time.time(),
+            result_payload="done",
+        )
+
+        legacy = client.get(
+            f"/tasks/result/{task_id}",
+            headers=_auth_headers(consumer_priv, consumer_id, ""),
+        )
+        v2 = client.get(
+            f"/v2/tasks/{task_id}/result",
+            headers=_auth_headers(consumer_priv, consumer_id, ""),
+        )
+        self.assertEqual(legacy.status_code, 200, legacy.text)
+        self.assertEqual(v2.status_code, 200, v2.text)
+
+        legacy_bounty = legacy.json()["bounty"]
+        v2_bounty_ns = int(v2.json()["bounty_ns"])
+        self.assertEqual(legacy_bounty, 2.0)
+        self.assertEqual(v2_bounty_ns, 2_000_000_000)
+        self.assertEqual(v2_bounty_ns, round(legacy_bounty * NS_PER_SECOND))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_legacy_adapter.py
+++ b/tests/test_legacy_adapter.py
@@ -43,6 +43,19 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 client = TestClient(app)
 
+# The hub app and this module share a single cached `db` module, whose DB path
+# and schema are bound once at import time. Other test modules in the suite
+# reload `db` against their own temp file and then delete it on teardown, which
+# can leave the shared connection pointing at an empty database. Re-running
+# init_db() in setUp guarantees the active database has its tables regardless of
+# cross-module test ordering.
+db.init_db()
+
+
+class _AdapterTestCase(unittest.TestCase):
+    def setUp(self):
+        db.init_db()
+
 
 # ---------------------------------------------------------------------------
 # Auth helpers (mirror test_hub_api.py)
@@ -166,7 +179,7 @@ class TestMoneyCanonicalPath(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # Endpoint regression coverage (legacy vs v2 consistency)
 # ---------------------------------------------------------------------------
-class TestBalanceAdapter(unittest.TestCase):
+class TestBalanceAdapter(_AdapterTestCase):
     def test_legacy_and_v2_balance_consistent(self):
         _, pub_pem, node_id = _make_identity()
         _register(pub_pem)
@@ -200,7 +213,7 @@ class TestBalanceAdapter(unittest.TestCase):
         self.assertEqual(client.get("/v2/balance/does-not-exist").status_code, 404)
 
 
-class TestEscrowAdapter(unittest.TestCase):
+class TestEscrowAdapter(_AdapterTestCase):
     def test_escrow_amount_ns_consistent_with_bounty(self):
         consumer_priv, consumer_pub, consumer_id = _make_identity()
         _register(consumer_pub)
@@ -226,7 +239,7 @@ class TestEscrowAdapter(unittest.TestCase):
         self.assertEqual(v2_balance, "7000000000")
 
 
-class TestTaskResultAdapter(unittest.TestCase):
+class TestTaskResultAdapter(_AdapterTestCase):
     def test_legacy_and_v2_task_result_bounty_consistent(self):
         consumer_priv, consumer_pub, consumer_id = _make_identity()
         _register(consumer_pub)


### PR DESCRIPTION
## Summary
PR 4 of the ns financial migration tracked in #224 and designed in #223 (design lock #225): the **legacy adapter layer + regression coverage**.

Previously the v2 endpoints (PR 3) derived ns values by re-converting the legacy float (`legacy_seconds_to_ns(get_balance(...))`) rather than reading the canonical `*_ns` columns added in PR 2. This PR makes the integer ns column the **source of truth** for financial responses and routes both the legacy float surface and the v2 ns surface through a single canonical internal path.

## What's included
- `hub/money.py` — new canonical ns-first internal money path:
  - `canonical_ns(...)` prefers the ns column; pre-migration rows whose ns column is still NULL fall back to an exact float conversion, returning `None` when no exact ns truth exists (graceful, no crash)
  - `to_legacy_seconds(...)` produces the legacy float **only at the boundary** from the canonical ns value
  - `to_v2_ns_string(...)` produces the canonical v2 ns string
- `hub/db.py` — ns-first reads:
  - `get_balance_row()` returns `(balance, balance_ns)`
  - `coerce_ns_from_row` made public (the ns column is authoritative)
- `hub/main.py` — financial handlers now route through `money` instead of recomputing ns from floats in-handler: `/balance`, `/v2/balance`, `/v2/register`, `/tasks/result`, `/v2/tasks/{id}/result`, `/v2/escrows/{task_id}`, `/v2/escrows`, `/v2/ledger/{node_id}`
- `tests/test_legacy_adapter.py` — regression coverage

## Design-lock criterion
Satisfies the testable criterion ratified in #224:

> Legacy financial endpoint handlers contain no direct financial float arithmetic. Money operations route through the canonical ns-first helpers/internal path, with any legacy float translation confined to request/response boundary adaptation.

The legacy `/balance` and `/tasks/result` handlers no longer read the float column directly — they derive the legacy float from the canonical ns value at the boundary. A test diverges the `balance_ns` column from the float and asserts both surfaces report the ns-derived value, proving ns is authoritative.

## What's NOT included
- No core `submit_task` / settlement pipeline rewrite (write-path arithmetic stays as PR 2's dual-write)
- No `/v2` schema/endpoint additions
- No legacy endpoint removal or REAL-column drop
- No deprecation switch

## Test plan
- [x] `python -m pytest tests/test_legacy_adapter.py -v` — 15 passed
- [x] `python -m pytest tests/test_hub_api.py -q` — 58 passed (no regressions on balance/task lifecycle)
- [x] `python -m pytest tests/test_ns_storage.py tests/test_nanoseconds.py tests/test_v2_endpoints.py -q` — 52 passed
- [x] `python -m ruff check hub/money.py hub/db.py hub/main.py tests/test_legacy_adapter.py`

Generated with [Devin](https://devin.ai)
