### PR TITLE
fix(bridge): block cross-bot GitHub writeback

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -45,6 +45,12 @@ def _split_csv(raw: str) -> list[str]:
     return [item.strip() for item in raw.split(",") if item and item.strip()]
 
 
+def _normalize_alias_key(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    return re.sub(r"[\s_-]+", " ", value).strip().lower()
+
+
 def _base64url_encode(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
 
@@ -61,6 +67,8 @@ class BridgeConfig:
     sqlite_path: str
     webhook_secret: str
     github_token: Optional[str]
+    github_writeback_aliases: set[str]
+    github_writeback_login: Optional[str]
     target_node_id: str
     target_alias: str
     trigger_aliases: list[str]
@@ -117,6 +125,7 @@ class BridgeConfig:
         trusted_bot_logins = set(
             item.lower() for item in _split_csv(os.getenv("MEP_BRIDGE_TRUSTED_BOT_LOGINS", ""))
         )
+        github_writeback_aliases = set(_split_csv(os.getenv("MEP_BRIDGE_GITHUB_WRITEBACK_ALIASES", "")))
         return cls(
             hub_url=os.getenv("MEP_HUB_URL", "").rstrip("/"),
             key_path=os.getenv(
@@ -129,6 +138,8 @@ class BridgeConfig:
             ),
             webhook_secret=os.getenv("GITHUB_WEBHOOK_SECRET", ""),
             github_token=(os.getenv("GITHUB_TOKEN") or os.getenv("GITHUB_API_TOKEN") or "").strip() or None,
+            github_writeback_aliases=github_writeback_aliases,
+            github_writeback_login=(os.getenv("MEP_BRIDGE_GITHUB_WRITEBACK_LOGIN") or "").strip() or None,
             target_node_id=target_node_id,
             target_alias=target_alias,
             trigger_aliases=trigger_aliases,
@@ -1205,7 +1216,28 @@ class GitHubToMEPBridgeService:
         )
         response.raise_for_status()
 
+    def _assert_writeback_identity_allowed(self, execution: dict[str, Any]) -> None:
+        if not self.config.github_writeback_aliases:
+            return
+        target_alias = str(execution.get("target_alias") or self.config.target_alias or "").strip()
+        normalized_target = _normalize_alias_key(target_alias)
+        normalized_allowed = {
+            _normalize_alias_key(alias) for alias in self.config.github_writeback_aliases if alias and alias.strip()
+        }
+        if normalized_target in normalized_allowed:
+            return
+        identity_label = self.config.github_writeback_login or "configured GitHub token"
+        allowed_aliases = ", ".join(sorted(self.config.github_writeback_aliases))
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"GitHub writeback identity {identity_label} is not allowed for target alias {target_alias!r}. "
+                f"Allowed aliases: {allowed_aliases}"
+            ),
+        )
+
     def _write_back_to_github(self, execution: dict[str, Any], update: BridgeStatusUpdate) -> str:
+        self._assert_writeback_identity_allowed(execution)
         repo_full_name = str(execution.get("repo_full_name") or "")
         number = int(execution.get("issue_number") or 0)
         entity_type = str(execution.get("entity_type") or "").strip().lower()

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -93,6 +93,8 @@ def _build_config(tmp_dir: str) -> BridgeConfig:
         sqlite_path=os.path.join(tmp_dir, "bridge.sqlite3"),
         webhook_secret="github-secret",
         github_token="github-token",
+        github_writeback_aliases=set(),
+        github_writeback_login="bridge-writer",
         target_node_id="node_target",
         target_alias="Hub Sentinel",
         trigger_aliases=["Hub-Sentinel"],
@@ -275,6 +277,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(github_inputs["source_action"], "edited")
 
     def test_status_callback_requires_valid_token_and_updates_existing_message(self):
+        self.config.github_writeback_aliases = {"Hub Sentinel"}
         response = self._post_webhook(
             _issue_comment_payload("@Hub-Sentinel approve this PR"),
             delivery_id="delivery-status",
@@ -311,6 +314,37 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(self.github_session.posts[0]["json"]["event"], "APPROVE")
         self.assertIn("<!-- mep-bridge:output", self.github_session.posts[0]["json"]["body"])
 
+    def test_status_callback_blocks_writeback_when_alias_is_not_allowlisted(self):
+        self.config.github_writeback_login = "wuyanbingep-a11y"
+        self.config.github_writeback_aliases = {"Elsaws Bot"}
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=229),
+            delivery_id="delivery-writeback-mismatch",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-mismatch",
+                "action": "reviewed",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 409, status_response.text)
+        self.assertEqual(
+            status_response.json()["detail"],
+            "GitHub writeback identity wuyanbingep-a11y is not allowed for target alias 'Hub-Sentinel'. "
+            "Allowed aliases: Elsaws Bot",
+        )
+        self.assertEqual(len(self.github_session.posts), 0)
+
     def test_status_callback_posts_issue_comment_for_analysis_completion(self):
         response = self._post_webhook(
             _issue_comment_payload("@Hub-Sentinel analyze this PR", delivery_number=227),
@@ -339,6 +373,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
 
     def test_status_callback_uses_actual_target_metadata_for_non_default_alias(self):
         self._configure_multi_target_aliases()
+        self.config.github_writeback_aliases = {"Elsaws Bot"}
         response = self._post_webhook(
             _issue_comment_payload("@Elsaws Bot analyze this PR", delivery_number=228),
             delivery_id="delivery-elsaws-status",


### PR DESCRIPTION
## Summary
- add an explicit GitHub writeback alias allowlist for the configured bridge token
- fail closed when a bridge execution target alias does not match the configured GitHub identity
- add focused bridge tests for allowed and blocked writeback paths

## Testing
- python -m pytest tests/test_github_bridge.py -q