### PR TITLE
fix(runtime): recover assigned tasks after reconnect

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -1272,6 +1272,31 @@ def get_queued_dms_for_node(node_id: str) -> list:
     return result
 
 
+def get_pending_tasks_for_provider(node_id: str) -> list:
+    """Return assigned tasks for node_id that still need provider-side processing."""
+    conn = _get_conn()
+    if not _is_postgres():
+        conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute(
+            "SELECT * FROM tasks WHERE provider_id = %s AND status = 'assigned' ORDER BY created_at ASC",
+            (node_id,),
+        )
+    else:
+        cursor.execute(
+            "SELECT * FROM tasks WHERE provider_id = ? AND status = 'assigned' ORDER BY created_at ASC",
+            (node_id,),
+        )
+    rows = cursor.fetchall()
+    if _is_postgres():
+        result = [_row_to_dict(cursor, row) for row in rows]
+    else:
+        result = [dict(row) for row in rows]
+    _release_conn(conn)
+    return result
+
+
 def count_queued_dms_for_node(node_id: str) -> int:
     """Count store-and-forward DMs currently queued for node_id."""
     conn = _get_conn()

--- a/hub/main.py
+++ b/hub/main.py
@@ -2616,6 +2616,15 @@ async def complete_task(
         raise HTTPException(status_code=409, detail="Task could not be settled")
     return await _finalize_settled_task(settled, result.task_id, result.provider_id, result_payload, normalized_result_uri)
 
+
+@app.get("/tasks/pending/{node_id}")
+async def get_pending_tasks(node_id: str, authenticated_node: str = Depends(verify_request)):
+    if authenticated_node != node_id:
+        raise HTTPException(status_code=403, detail="Cannot view pending tasks for another node")
+    tasks = db.get_pending_tasks_for_provider(node_id)
+    return {"node_id": node_id, "tasks": tasks, "count": len(tasks)}
+
+
 @app.post("/tasks/reject")
 async def reject_task(
     rejection: TaskReject,

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -653,6 +653,29 @@ class RuntimeNode:
             print(f"[mep run] ws send failed event={payload.get('event')} detail={exc}")
             return False
 
+    def _fetch_pending_tasks(self) -> list[dict[str, Any]]:
+        code, body, raw = _safe_request(
+            "GET",
+            f"{self.hub_url}/tasks/pending/{self.node_id}",
+            headers=self._auth_headers(""),
+            timeout=20.0,
+        )
+        if code != 200:
+            print(f"[mep run] pending task poll failed status={code} detail={raw}")
+            return []
+        tasks = body.get("tasks") if isinstance(body, dict) else None
+        if not isinstance(tasks, list):
+            return []
+        return [task for task in tasks if isinstance(task, dict)]
+
+    async def _recover_pending_tasks(self) -> None:
+        tasks = self._fetch_pending_tasks()
+        if not tasks:
+            return
+        print(f"[mep run] recovered pending tasks count={len(tasks)} node={self.node_id}")
+        for task in tasks:
+            await self.handle_ws_event({"event": "new_task", "data": task})
+
     def _resolve_call_bridge(self, context_id: Optional[str], outcome: dict[str, Any]) -> None:
         if not context_id:
             return
@@ -1162,6 +1185,7 @@ class RuntimeNode:
                 async with ws_connect(uri) as ws:
                     self._ws = ws
                     print(f"[mep run] connected ws node={self.node_id}")
+                    await self._recover_pending_tasks()
                     await self._recv_loop(ws)
             except KeyboardInterrupt:
                 self.running = False

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -779,6 +779,32 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(stored["provider_id"], target_id)
         self.assertEqual(db.count_queued_dms_for_node(target_id), 0)
 
+    def test_pending_tasks_endpoint_lists_assigned_tasks_for_provider(self):
+        sender_priv, sender_pub, sender_id = _make_identity()
+        target_priv, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+
+        live_ws = _FakeWebSocket()
+        main.connected_nodes[target_id] = live_ws
+        try:
+            resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="recover me")
+        finally:
+            main.connected_nodes.pop(target_id, None)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "success")
+        task_id = resp.json()["task_id"]
+
+        pending = client.get(f"/tasks/pending/{target_id}", headers=_auth_headers(target_priv, target_id, ""))
+        self.assertEqual(pending.status_code, 200, pending.text)
+        body = pending.json()
+        self.assertEqual(body["node_id"], target_id)
+        self.assertEqual(body["count"], 1)
+        self.assertEqual(body["tasks"][0]["task_id"], task_id)
+        self.assertEqual(body["tasks"][0]["provider_id"], target_id)
+        self.assertEqual(body["tasks"][0]["status"], "assigned")
+
     def test_queued_dm_flush_matches_live_targeted_shape(self):
         """A queued DM must be flushed with the same new_task event contract as a
         live targeted delivery, so offline recipients are not handed a thinner

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -4,7 +4,7 @@ import json
 import os
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from node.identity import MEPIdentity
 from node import mep_runtime
@@ -424,6 +424,46 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
 
         pending_task = asyncio.run(_run())
         self.assertTrue(pending_task.cancelled())
+
+    def test_fetch_pending_tasks_uses_authenticated_get(self):
+        node = _runtime_node()
+        with patch("node.mep_runtime._safe_request", return_value=(200, {"tasks": [{"id": "task_pending"}]}, "")) as request_mock:
+            tasks = node._fetch_pending_tasks()  # noqa: SLF001
+
+        self.assertEqual(tasks, [{"id": "task_pending"}])
+        self.assertEqual(request_mock.call_args.args, ("GET", "http://hub/tasks/pending/node_runtime"))
+        self.assertEqual(request_mock.call_args.kwargs["headers"]["X-MEP-NodeID"], "node_runtime")
+
+    def test_recover_pending_tasks_replays_new_task_events(self):
+        node = _runtime_node()
+        with (
+            patch.object(node, "_fetch_pending_tasks", return_value=[{"id": "task_one"}, {"id": "task_two"}]),
+            patch.object(node, "handle_ws_event", new=AsyncMock()) as handle_mock,
+        ):
+            asyncio.run(node._recover_pending_tasks())  # noqa: SLF001
+
+        self.assertEqual(handle_mock.await_count, 2)
+        self.assertEqual(handle_mock.await_args_list[0].args[0], {"event": "new_task", "data": {"id": "task_one"}})
+        self.assertEqual(handle_mock.await_args_list[1].args[0], {"event": "new_task", "data": {"id": "task_two"}})
+
+    def test_run_forever_recovers_pending_tasks_after_connect(self):
+        node = _runtime_node()
+
+        async def _recv_loop(_ws) -> None:
+            node.running = False
+
+        async def _run() -> int:
+            with (
+                patch.object(node, "register", return_value=(True, "registered")),
+                patch.object(node, "_recover_pending_tasks", new=AsyncMock()) as recover_mock,
+                patch.object(node, "_recv_loop", side_effect=_recv_loop),
+                patch("node.ws_connect.ws_connect", return_value=_FakeConnectContext(_FakeWebSocket([]))),
+            ):
+                code = await node.run_forever()
+                self.assertEqual(recover_mock.await_count, 1)
+                return code
+
+        self.assertEqual(asyncio.run(_run()), 0)
 
     def test_process_task_uses_interbot_instructions_for_adapter_input(self):
         node = _runtime_node()


### PR DESCRIPTION
## Summary
- add an authenticated hub endpoint for a node to list its currently assigned tasks
- poll pending assigned tasks immediately after runtime websocket reconnect
- replay recovered tasks through the normal runtime 
ew_task path and cover the flow with focused tests

## Testing
- python -m pytest tests/test_node_runtime.py tests/test_hub_api.py -q