### PR TITLE
Improve GitHub review loop quality

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -45,6 +45,33 @@ def _split_csv(raw: str) -> list[str]:
     return [item.strip() for item in raw.split(",") if item and item.strip()]
 
 
+def _normalize_alias_key(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    return re.sub(r"[\s_-]+", " ", value).strip().lower()
+
+
+def _parse_json_str_dict_env(name: str) -> dict[str, str]:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid {name}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError(f"Invalid {name}: expected JSON object")
+    result: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not isinstance(item, str):
+            raise RuntimeError(f"Invalid {name}: expected string keys and values")
+        normalized_key = key.strip()
+        normalized_value = item.strip()
+        if normalized_key and normalized_value:
+            result[normalized_key] = normalized_value
+    return result
+
+
 def _base64url_encode(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
 
@@ -61,6 +88,10 @@ class BridgeConfig:
     sqlite_path: str
     webhook_secret: str
     github_token: Optional[str]
+    github_writeback_aliases: set[str]
+    github_writeback_login: Optional[str]
+    github_tokens_by_alias: dict[str, str]
+    github_logins_by_alias: dict[str, str]
     target_node_id: str
     target_alias: str
     trigger_aliases: list[str]
@@ -117,6 +148,9 @@ class BridgeConfig:
         trusted_bot_logins = set(
             item.lower() for item in _split_csv(os.getenv("MEP_BRIDGE_TRUSTED_BOT_LOGINS", ""))
         )
+        github_writeback_aliases = set(_split_csv(os.getenv("MEP_BRIDGE_GITHUB_WRITEBACK_ALIASES", "")))
+        github_tokens_by_alias = _parse_json_str_dict_env("MEP_BRIDGE_GITHUB_TOKENS_BY_ALIAS")
+        github_logins_by_alias = _parse_json_str_dict_env("MEP_BRIDGE_GITHUB_LOGINS_BY_ALIAS")
         return cls(
             hub_url=os.getenv("MEP_HUB_URL", "").rstrip("/"),
             key_path=os.getenv(
@@ -129,6 +163,10 @@ class BridgeConfig:
             ),
             webhook_secret=os.getenv("GITHUB_WEBHOOK_SECRET", ""),
             github_token=(os.getenv("GITHUB_TOKEN") or os.getenv("GITHUB_API_TOKEN") or "").strip() or None,
+            github_writeback_aliases=github_writeback_aliases,
+            github_writeback_login=(os.getenv("MEP_BRIDGE_GITHUB_WRITEBACK_LOGIN") or "").strip() or None,
+            github_tokens_by_alias=github_tokens_by_alias,
+            github_logins_by_alias=github_logins_by_alias,
             target_node_id=target_node_id,
             target_alias=target_alias,
             trigger_aliases=trigger_aliases,
@@ -1175,37 +1213,83 @@ class GitHubToMEPBridgeService:
         marker = f"{BRIDGE_OUTPUT_MARKER} bridge_id={bridge_id} action={action} -->"
         return f"{detail_text}\n\n{marker}"
 
-    def _post_github_comment(self, repo_full_name: str, number: int, body: str) -> None:
-        if not self.config.github_token:
-            raise HTTPException(status_code=500, detail="Bridge configuration missing: GITHUB_TOKEN")
+    def _target_alias_for_execution(self, execution: dict[str, Any]) -> str:
+        return str(execution.get("target_alias") or self.config.target_alias or "").strip()
+
+    def _lookup_alias_value(self, values: dict[str, str], target_alias: str) -> Optional[str]:
+        normalized_target = _normalize_alias_key(target_alias)
+        for alias, value in values.items():
+            if _normalize_alias_key(alias) == normalized_target and value and value.strip():
+                return value.strip()
+        return None
+
+    def _resolve_github_writeback_identity(self, execution: dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
+        target_alias = self._target_alias_for_execution(execution)
+        alias_token = self._lookup_alias_value(self.config.github_tokens_by_alias, target_alias)
+        alias_login = self._lookup_alias_value(self.config.github_logins_by_alias, target_alias)
+        if alias_token:
+            return alias_token, alias_login or target_alias
+        return self.config.github_token, self.config.github_writeback_login
+
+    def _post_github_comment(self, repo_full_name: str, number: int, body: str, github_token: str) -> None:
+        if not github_token:
+            raise HTTPException(status_code=500, detail="Bridge configuration missing: GitHub writeback token")
         response = self.github_session.post(
             f"https://api.github.com/repos/{repo_full_name}/issues/{number}/comments",
             json={"body": body},
             headers={
                 "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {self.config.github_token}",
+                "Authorization": f"Bearer {github_token}",
                 "X-GitHub-Api-Version": "2022-11-28",
             },
             timeout=20,
         )
         response.raise_for_status()
 
-    def _submit_github_review(self, repo_full_name: str, number: int, event: str, body: str) -> None:
-        if not self.config.github_token:
-            raise HTTPException(status_code=500, detail="Bridge configuration missing: GITHUB_TOKEN")
+    def _submit_github_review(
+        self, repo_full_name: str, number: int, event: str, body: str, github_token: str
+    ) -> None:
+        if not github_token:
+            raise HTTPException(status_code=500, detail="Bridge configuration missing: GitHub writeback token")
         response = self.github_session.post(
             f"https://api.github.com/repos/{repo_full_name}/pulls/{number}/reviews",
             json={"event": event, "body": body},
             headers={
                 "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {self.config.github_token}",
+                "Authorization": f"Bearer {github_token}",
                 "X-GitHub-Api-Version": "2022-11-28",
             },
             timeout=20,
         )
         response.raise_for_status()
 
+    def _assert_writeback_identity_allowed(self, execution: dict[str, Any]) -> None:
+        target_alias = self._target_alias_for_execution(execution)
+        if self._lookup_alias_value(self.config.github_tokens_by_alias, target_alias):
+            return
+        if not self.config.github_writeback_aliases:
+            return
+        normalized_target = _normalize_alias_key(target_alias)
+        normalized_allowed = {
+            _normalize_alias_key(alias) for alias in self.config.github_writeback_aliases if alias and alias.strip()
+        }
+        if normalized_target in normalized_allowed:
+            return
+        identity_label = self.config.github_writeback_login or "configured GitHub token"
+        allowed_aliases = ", ".join(sorted(self.config.github_writeback_aliases))
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"GitHub writeback identity {identity_label} is not allowed for target alias {target_alias!r}. "
+                f"Allowed aliases: {allowed_aliases}"
+            ),
+        )
+
     def _write_back_to_github(self, execution: dict[str, Any], update: BridgeStatusUpdate) -> str:
+        self._assert_writeback_identity_allowed(execution)
+        github_token, _identity_label = self._resolve_github_writeback_identity(execution)
+        if not github_token:
+            raise HTTPException(status_code=500, detail="Bridge configuration missing: GitHub writeback token")
         repo_full_name = str(execution.get("repo_full_name") or "")
         number = int(execution.get("issue_number") or 0)
         entity_type = str(execution.get("entity_type") or "").strip().lower()
@@ -1222,9 +1306,9 @@ class GitHubToMEPBridgeService:
             "changes_requested": "REQUEST_CHANGES",
         }
         if entity_type == "pr" and action in review_events:
-            self._submit_github_review(repo_full_name, number, review_events[action], body)
+            self._submit_github_review(repo_full_name, number, review_events[action], body, github_token)
             return action
-        self._post_github_comment(repo_full_name, number, body)
+        self._post_github_comment(repo_full_name, number, body, github_token)
         return "commented"
 
     async def handle_status_callback(self, update: BridgeStatusUpdate, token: str) -> dict[str, Any]:

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -658,8 +658,14 @@ class GitHubToMEPBridgeService:
         async with self._pending_lock:
             pending = self._pending_by_context.get(event.context_id)
             if pending is not None:
+                existing_targets = {
+                    _normalize_alias_key(target.alias): target
+                    for target in (pending.targets or [])
+                }
                 pending.event = self._merge_events(pending.event, event)
-                pending.targets = self._get_targets_for_event(pending.event)
+                for target in self._get_targets_for_event(pending.event):
+                    existing_targets[_normalize_alias_key(target.alias)] = target
+                pending.targets = list(existing_targets.values())
                 if not pending.targets and self.config.target_node_id:
                     pending.targets = [
                         TriggerMatch(
@@ -1042,6 +1048,88 @@ class GitHubToMEPBridgeService:
         sender_type = actor_type.strip().lower()
         return sender_type == "bot" or login.endswith("[bot]")
 
+    @staticmethod
+    def _clip_text(value: str, max_chars: int) -> str:
+        text = value.strip()
+        if len(text) <= max_chars:
+            return text
+        return text[:max_chars].rstrip() + "..."
+
+    def _github_read_token(self) -> Optional[str]:
+        if self.config.github_token:
+            return self.config.github_token
+        for token in self.config.github_tokens_by_alias.values():
+            if token and token.strip():
+                return token.strip()
+        return None
+
+    def _fetch_pr_review_context(self, repo_full_name: str, number: int) -> str:
+        token = self._github_read_token()
+        if not token:
+            return ""
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        try:
+            pr_response = self.github_session.get(
+                f"https://api.github.com/repos/{repo_full_name}/pulls/{number}",
+                headers=headers,
+                timeout=20,
+            )
+            if pr_response.status_code != 200:
+                return ""
+            pr_data = pr_response.json()
+            files_response = self.github_session.get(
+                f"https://api.github.com/repos/{repo_full_name}/pulls/{number}/files?per_page=20",
+                headers=headers,
+                timeout=20,
+            )
+            files = files_response.json() if files_response.status_code == 200 else []
+        except Exception:
+            return ""
+
+        sections: list[str] = []
+        pr_body = str(pr_data.get("body") or "").strip()
+        if pr_body:
+            sections.append("PR description:\n" + self._clip_text(pr_body, 700))
+
+        changed_files = pr_data.get("changed_files")
+        additions = pr_data.get("additions")
+        deletions = pr_data.get("deletions")
+        commits = pr_data.get("commits")
+        sections.append(
+            "PR stats: "
+            f"changed_files={changed_files}, additions={additions}, deletions={deletions}, commits={commits}"
+        )
+
+        if isinstance(files, list) and files:
+            file_lines: list[str] = []
+            remaining_budget = 2000
+            for item in files[:8]:
+                if not isinstance(item, dict):
+                    continue
+                filename = str(item.get("filename") or "").strip()
+                status = str(item.get("status") or "modified").strip()
+                additions = item.get("additions")
+                deletions = item.get("deletions")
+                changes = item.get("changes")
+                line = f"- {filename} ({status}, +{additions}/-{deletions}, changes={changes})"
+                patch = str(item.get("patch") or "").strip()
+                if patch:
+                    clipped_patch = self._clip_text(patch, 320)
+                    line += "\n  Patch excerpt:\n  " + clipped_patch.replace("\n", "\n  ")
+                if len(line) > remaining_budget:
+                    line = self._clip_text(line, max(120, remaining_budget))
+                file_lines.append(line)
+                remaining_budget -= len(line) + 2
+                if remaining_budget <= 120:
+                    break
+            if file_lines:
+                sections.append("Changed files and patch excerpts:\n" + "\n".join(file_lines))
+        return "\n\n".join(section for section in sections if section.strip())
+
     def _build_instructions(
         self,
         *,
@@ -1059,7 +1147,7 @@ class GitHubToMEPBridgeService:
         if len(clipped_trigger) > 1200:
             clipped_trigger = clipped_trigger[:1200].rstrip() + "..."
         kind = "pull request" if entity_type == "pr" else "issue"
-        return (
+        instructions = (
             f"GitHub {kind} automation request.\n"
             f"Repository: {repo_full_name}\n"
             f"{kind.title()} number: {number}\n"
@@ -1071,6 +1159,18 @@ class GitHubToMEPBridgeService:
             "Instructions:\n"
             f"{clipped_trigger}"
         )
+        if entity_type == "pr":
+            review_context = self._fetch_pr_review_context(repo_full_name, number)
+            if review_context:
+                instructions += (
+                    "\n\nReview guidance:\n"
+                    "Use the actual diff context below to review correctness, regressions, edge cases, "
+                    "security, and missing tests. Reference concrete files or patch excerpts when possible.\n\n"
+                    f"{review_context}"
+                )
+        if len(instructions) > 3800:
+            instructions = instructions[:3800].rstrip() + "..."
+        return instructions
 
     def _build_interbot_envelope(
         self,

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -7,6 +7,7 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import time
 import urllib.parse
 import uuid
@@ -384,9 +385,13 @@ def _system_prompt_for_task(
 ) -> str:
     if _task_requires_review_prompt(task_data):
         return (
-            "You are a code reviewer for the MEP (Miao Exchange Protocol) project. "
-            "Analyze PR tasks and respond as one of: approve, request_changes, or comment. "
-            "Be specific, reference files, logic, or tests when helpful, and keep the "
+            "You are a senior code reviewer for the MEP (Miao Exchange Protocol) project. "
+            "Review the provided GitHub PR context and return ONLY a JSON object with this schema: "
+            '{"summary": string, "findings": [{"file": string, "issue": string, "rationale": string}]}. '
+            "Use at most 2 findings. "
+            "Only include a finding when it is directly supported by the provided diff, file list, PR description, or patch excerpts. "
+            "Do not speculate about unseen code, do not ask for more context, and do not include chain-of-thought or any text outside the JSON object. "
+            "If the change looks good, keep findings empty and use summary to say what you verified and mention any residual risk briefly. Keep the "
             f"response within {review_max_chars} characters."
         )
     return (
@@ -394,6 +399,158 @@ def _system_prompt_for_task(
         "MEP is an AI-to-AI economy protocol where agents earn SECONDS by doing work. "
         f"Reply concisely (max {generic_max_chars} chars)."
     )
+
+
+def _extract_first_json_object(text: str) -> Optional[dict[str, Any]]:
+    if not text:
+        return None
+    start = text.find("{")
+    while start != -1:
+        depth = 0
+        in_string = False
+        escape = False
+        for index in range(start, len(text)):
+            char = text[index]
+            if in_string:
+                if escape:
+                    escape = False
+                elif char == "\\":
+                    escape = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+                continue
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = text[start : index + 1]
+                    try:
+                        value = json.loads(candidate)
+                    except json.JSONDecodeError:
+                        break
+                    if isinstance(value, dict):
+                        return value
+                    break
+        start = text.find("{", start + 1)
+    return None
+
+
+def _clean_review_text(value: Any, *, max_chars: int) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > max_chars:
+        clipped = text[:max_chars].rstrip()
+        sentence_break = max(clipped.rfind(". "), clipped.rfind("! "), clipped.rfind("? "))
+        if sentence_break >= max(40, max_chars // 2):
+            clipped = clipped[: sentence_break + 1].rstrip()
+        text = clipped
+    if text and text[-1] not in ".!?":
+        text += "."
+    return text
+
+
+_WEAK_REVIEW_PATTERNS = [
+    r"\bmissing context\b",
+    r"\bpatch excerpt\b",
+    r"\btruncated\b",
+    r"\bcannot verify\b",
+    r"\bimpossible to verify\b",
+    r"\bwithout seeing\b",
+    r"\bwithout the full\b",
+    r"\bdoes not show\b",
+    r"\bdoesn't show\b",
+    r"\bnot enough context\b",
+    r"\bwe need to\b",
+    r"\bwe should\b",
+]
+
+
+def _is_weak_review_text(text: str) -> bool:
+    lowered = text.strip().lower()
+    if not lowered:
+        return True
+    return any(re.search(pattern, lowered) for pattern in _WEAK_REVIEW_PATTERNS)
+
+
+def _finalize_model_reply(text: str, *, max_chars: int) -> str:
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return ""
+    cleaned = cleaned.replace("\r\n", "\n")
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    if len(cleaned) > max_chars:
+        clipped = cleaned[:max_chars].rstrip()
+        breakpoints = [
+            clipped.rfind("\n\n"),
+            clipped.rfind("\n- "),
+            clipped.rfind(". "),
+            clipped.rfind("! "),
+            clipped.rfind("? "),
+        ]
+        best_break = max(breakpoints)
+        if best_break >= max(120, max_chars // 2):
+            if clipped[best_break : best_break + 2] in {". ", "! ", "? "}:
+                clipped = clipped[: best_break + 1].rstrip()
+            else:
+                clipped = clipped[:best_break].rstrip()
+        cleaned = clipped
+    if cleaned and cleaned[-1] not in ".!?":
+        last_sentence = max(cleaned.rfind(". "), cleaned.rfind("! "), cleaned.rfind("? "))
+        if last_sentence >= max(80, len(cleaned) // 2):
+            cleaned = cleaned[: last_sentence + 1].rstrip()
+        if cleaned and cleaned[-1] not in ".!?":
+            cleaned += "."
+    return cleaned
+
+
+def _render_structured_review(text: str, *, max_chars: int) -> str:
+    parsed = _extract_first_json_object(text)
+    if not isinstance(parsed, dict):
+        return ""
+    summary = _clean_review_text(parsed.get("summary"), max_chars=220)
+    if _is_weak_review_text(summary):
+        summary = ""
+    findings_raw = parsed.get("findings")
+    findings: list[str] = []
+    if isinstance(findings_raw, list):
+        for item in findings_raw[:2]:
+            if not isinstance(item, dict):
+                continue
+            issue = _clean_review_text(item.get("issue"), max_chars=140)
+            if not issue:
+                continue
+            rationale = _clean_review_text(item.get("rationale"), max_chars=260)
+            combined = f"{issue} {rationale}".strip()
+            if _is_weak_review_text(combined):
+                continue
+            file_name = _clean_review_text(item.get("file"), max_chars=80)
+            if file_name:
+                findings.append(f"**{issue}** (`{file_name}`): {rationale or 'Check this path.'}")
+            else:
+                findings.append(f"**{issue}**: {rationale or 'Check this logic.'}")
+    sections: list[str] = []
+    if findings:
+        sections.append("## Review Findings")
+        if summary:
+            sections.append(summary)
+        for index, finding in enumerate(findings, start=1):
+            sections.append(f"{index}. {finding}")
+    elif summary:
+        sections.append("## Review Summary")
+        sections.append(summary)
+    else:
+        sections.append("## Review Summary")
+        sections.append(
+            "Reviewed the provided diff context and did not identify a concrete issue that is directly supported by the supplied patch excerpts."
+        )
+    rendered = "\n\n".join(section for section in sections if section.strip())
+    return _finalize_model_reply(rendered, max_chars=max_chars)
 
 
 @dataclass
@@ -407,7 +564,7 @@ class AIAdapter:
 
         try:
             prompt = (
-                f"{_system_prompt_for_task(task_data, generic_max_chars=300, review_max_chars=500)}\n\n"
+                f"{_system_prompt_for_task(task_data, generic_max_chars=300, review_max_chars=1000)}\n\n"
                 f"Task: {payload}\n\nReply:"
             )
             result = subprocess.run(
@@ -419,6 +576,14 @@ class AIAdapter:
             reply = (result.stdout or "").strip()
             if not reply:
                 return f"[AI adapter] empty response from {self.model}"
+            if _task_requires_review_prompt(task_data):
+                rendered = _render_structured_review(reply, max_chars=1000)
+                if rendered:
+                    return rendered
+                finalized = _finalize_model_reply(reply, max_chars=1000)
+                if finalized:
+                    return finalized
+                return reply[:1000].rstrip() or "[AI adapter] review response was empty"
             return reply
         except subprocess.TimeoutExpired:
             return f"[AI adapter] {self.model} timed out"
@@ -449,18 +614,30 @@ class DeepSeekAdapter:
                             "content": _system_prompt_for_task(
                                 task_data,
                                 generic_max_chars=500,
-                                review_max_chars=500,
+                                review_max_chars=1000,
                             ),
                         },
                         {"role": "user", "content": payload},
                     ],
-                    "max_tokens": 300,
-                    "temperature": 0.7,
+                    "max_tokens": 450,
+                    "temperature": 0.1,
                 },
                 timeout=30,
             )
             if resp.status_code == 200:
-                return resp.json()["choices"][0]["message"]["content"].strip()
+                message = resp.json()["choices"][0]["message"]
+                reply = str(message.get("content") or "").strip()
+                if not reply:
+                    reply = str(message.get("reasoning_content") or "").strip()
+                if _task_requires_review_prompt(task_data):
+                    rendered = _render_structured_review(reply, max_chars=1000)
+                    if rendered:
+                        return rendered
+                    finalized = _finalize_model_reply(reply, max_chars=1000)
+                    if finalized:
+                        return finalized
+                    return reply[:1000].rstrip() or "[DeepSeek] review response was empty"
+                return reply
             return f"[DeepSeek] API error {resp.status_code}: {resp.text[:200]}"
         except Exception as exc:  # noqa: BLE001
             return f"[DeepSeek] error: {exc}"

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -7,6 +7,7 @@ import tempfile
 import time
 import asyncio
 import unittest
+from typing import Any
 
 from fastapi.testclient import TestClient
 
@@ -59,7 +60,7 @@ class _FakeNotifier:
 
 
 class _FakeResponse:
-    def __init__(self, payload, *, status_code: int = 200):
+    def __init__(self, payload: Any, *, status_code: int = 200):
         self._payload = payload
         self.status_code = status_code
 

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -93,6 +93,10 @@ def _build_config(tmp_dir: str) -> BridgeConfig:
         sqlite_path=os.path.join(tmp_dir, "bridge.sqlite3"),
         webhook_secret="github-secret",
         github_token="github-token",
+        github_writeback_aliases=set(),
+        github_writeback_login="bridge-writer",
+        github_tokens_by_alias={},
+        github_logins_by_alias={},
         target_node_id="node_target",
         target_alias="Hub Sentinel",
         trigger_aliases=["Hub-Sentinel"],
@@ -366,6 +370,78 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(len(self.github_session.posts), 1)
         self.assertTrue(self.github_session.posts[0]["url"].endswith("/repos/WUAIBING/MEP/issues/228/comments"))
         self.assertIn("Elsaws Bot completed the requested action.", self.github_session.posts[0]["json"]["body"])
+
+    def test_status_callback_blocks_writeback_when_alias_is_not_allowlisted(self):
+        self._configure_multi_target_aliases()
+        self.config.github_writeback_aliases = {"Hub Sentinel"}
+        self.config.github_writeback_login = "wuyanbingep-a11y"
+        response = self._post_webhook(
+            _issue_comment_payload("@Elsaws Bot analyze this PR", delivery_number=229),
+            delivery_id="delivery-blocked-elsaws",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        self._flush_context(response.json()["context_id"])
+
+        self.assertEqual(len(self.submission.calls), 1)
+        envelope = self.submission.calls[0]["envelope"]
+        bridge_id = envelope["task"]["inputs"]["bridge_metadata"]["bridge_id"]
+        token = self.service._generate_status_token(bridge_id, "node_elsaws")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_elsaws",
+                "task_id": "task-blocked",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 409, status_response.text)
+        self.assertEqual(
+            status_response.json()["detail"],
+            "GitHub writeback identity wuyanbingep-a11y is not allowed for target alias 'Elsaws Bot'. "
+            "Allowed aliases: Hub Sentinel",
+        )
+        self.assertEqual(len(self.github_session.posts), 0)
+
+    def test_status_callback_uses_alias_specific_github_token_for_non_default_alias(self):
+        self._configure_multi_target_aliases()
+        self.config.github_writeback_aliases = {"Hub Sentinel"}
+        self.config.github_writeback_login = "bridge-writer"
+        self.config.github_tokens_by_alias = {"Elsaws Bot": "elsaws-token"}
+        self.config.github_logins_by_alias = {"Elsaws Bot": "wuyanbingep-a11y"}
+        response = self._post_webhook(
+            _issue_comment_payload("@Elsaws Bot analyze this PR", delivery_number=230),
+            delivery_id="delivery-elsaws-token",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        self._flush_context(response.json()["context_id"])
+
+        self.assertEqual(len(self.submission.calls), 1)
+        envelope = self.submission.calls[0]["envelope"]
+        bridge_id = envelope["task"]["inputs"]["bridge_metadata"]["bridge_id"]
+        token = self.service._generate_status_token(bridge_id, "node_elsaws")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_elsaws",
+                "task_id": "task-elsaws-token",
+                "detail": "Elsaws analysis complete.",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 1)
+        self.assertEqual(
+            self.github_session.posts[0]["headers"]["Authorization"],
+            "Bearer elsaws-token",
+        )
+        self.assertTrue(self.github_session.posts[0]["url"].endswith("/repos/WUAIBING/MEP/issues/230/comments"))
+        self.assertEqual(self.github_session.posts[0]["json"]["body"].splitlines()[0], "Elsaws analysis complete.")
 
     def test_non_maintainer_trigger_is_ignored_when_policy_enabled(self):
         payload = _issue_comment_payload("@Hub-Sentinel review this PR")

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -59,7 +59,7 @@ class _FakeNotifier:
 
 
 class _FakeResponse:
-    def __init__(self, payload: dict, *, status_code: int = 200):
+    def __init__(self, payload, *, status_code: int = 200):
         self._payload = payload
         self.status_code = status_code
 
@@ -72,10 +72,13 @@ class _FakeResponse:
 
 
 class _FakeRequestsSession:
-    def __init__(self, responses=None, *, default_response=None):
+    def __init__(self, responses=None, *, default_response=None, get_responses=None, default_get_response=None):
         self.responses = list(responses or [])
+        self.get_responses = list(get_responses or [])
         self.default_response = default_response
+        self.default_get_response = default_get_response or _FakeResponse({}, status_code=404)
         self.posts = []
+        self.gets = []
 
     def post(self, url, **kwargs):
         self.posts.append({"url": url, **kwargs})
@@ -84,6 +87,12 @@ class _FakeRequestsSession:
         if self.default_response is None:
             raise AssertionError("No fake responses remaining")
         return self.default_response
+
+    def get(self, url, **kwargs):
+        self.gets.append({"url": url, **kwargs})
+        if self.get_responses:
+            return self.get_responses.pop(0)
+        return self.default_get_response
 
 
 def _build_config(tmp_dir: str) -> BridgeConfig:
@@ -261,7 +270,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertIn("Elsaws Bot", routed_aliases)
         self.assertNotEqual(routed_aliases["Hub Sentinel"], routed_aliases["Elsaws Bot"])
 
-    def test_same_context_burst_recomputes_targets_from_latest_trigger_text(self):
+    def test_same_context_burst_preserves_targets_from_separate_mentions(self):
         self._configure_multi_target_aliases()
         payload_one = _issue_comment_payload("@Hub Sentinel review this PR", action="created")
         payload_two = _issue_comment_payload("@Elsaws Bot review this PR", action="edited")
@@ -273,10 +282,53 @@ class TestGitHubToMEPBridge(unittest.TestCase):
 
         self._flush_context(first.json()["context_id"])
 
+        self.assertEqual(len(self.submission.calls), 2)
+        routed_targets = {call["target_node_id"] for call in self.submission.calls}
+        self.assertEqual(routed_targets, {"node_target", "node_elsaws"})
+        for call in self.submission.calls:
+            github_inputs = call["envelope"]["task"]["inputs"]["github"]
+            self.assertEqual(github_inputs["source_action"], "edited")
+
+    def test_pr_review_instructions_include_diff_context(self):
+        self.github_session.get_responses = [
+            _FakeResponse(
+                {
+                    "body": "Adds review quality handling for bridge-triggered PR reviews.",
+                    "changed_files": 1,
+                    "additions": 12,
+                    "deletions": 3,
+                    "commits": 1,
+                }
+            ),
+            _FakeResponse(
+                [
+                    {
+                        "filename": "bridge/github_to_mep.py",
+                        "status": "modified",
+                        "additions": 12,
+                        "deletions": 3,
+                        "changes": 15,
+                        "patch": "@@ -1,3 +1,8 @@\n+def improved_review_context():\n+    return True",
+                    }
+                ]
+            ),
+        ]
+
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR"),
+            delivery_id="delivery-context",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        self._flush_context(response.json()["context_id"])
+
         self.assertEqual(len(self.submission.calls), 1)
-        self.assertEqual(self.submission.calls[0]["target_node_id"], "node_elsaws")
-        github_inputs = self.submission.calls[0]["envelope"]["task"]["inputs"]["github"]
-        self.assertEqual(github_inputs["source_action"], "edited")
+        instructions = self.submission.calls[0]["envelope"]["task"]["instructions"]
+        self.assertIn("Review guidance:", instructions)
+        self.assertIn("PR description:", instructions)
+        self.assertIn("Changed files and patch excerpts:", instructions)
+        self.assertIn("bridge/github_to_mep.py", instructions)
+        self.assertEqual(len(self.github_session.gets), 2)
 
     def test_status_callback_requires_valid_token_and_updates_existing_message(self):
         response = self._post_webhook(

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -359,28 +359,75 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
     def test_ai_adapter_uses_reviewer_prompt_for_bridge_review_tasks(self):
         adapter = mep_runtime.AIAdapter(model="tinyllama")
         task_data = self._bridge_review_task_data()
-        with patch("subprocess.run", return_value=_FakeCompletedProcess(stdout="review output")) as run_mock:
+        with patch(
+            "subprocess.run",
+            return_value=_FakeCompletedProcess(
+                stdout='{"summary":"Checked the provided diff.","findings":[]}'
+            ),
+        ) as run_mock:
             reply = adapter.generate_reply("Review this PR", task_data)
 
-        self.assertEqual(reply, "review output")
+        self.assertIn("## Review Summary", reply)
+        self.assertIn("Checked the provided diff.", reply)
         prompt = run_mock.call_args.args[0][3]
-        self.assertIn("You are a code reviewer for the MEP", prompt)
-        self.assertIn("approve, request_changes, or comment", prompt)
+        self.assertIn("You are a senior code reviewer for the MEP", prompt)
+        self.assertIn('"summary": string', prompt)
 
     def test_deepseek_adapter_uses_reviewer_prompt_for_bridge_review_tasks(self):
         adapter = mep_runtime.DeepSeekAdapter(api_key="secret-key", model="deepseek-chat")
         task_data = self._bridge_review_task_data()
         fake_response = _FakeResponse(
             200,
-            {"choices": [{"message": {"content": "**Request Changes** file reference"}}]},
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                '{"summary":"Checked the bridge diff.","findings":'
+                                '[{"file":"bridge/github_to_mep.py","issue":"Preserve coalesced targets",'
+                                '"rationale":"Otherwise the second mention can overwrite the first target during the coalesce window."}]}'
+                            )
+                        }
+                    }
+                ]
+            },
         )
         with patch("node.mep_runtime.requests.post", return_value=fake_response) as post_mock:
             reply = adapter.generate_reply("Review this PR", task_data)
 
-        self.assertEqual(reply, "**Request Changes** file reference")
+        self.assertIn("## Review Findings", reply)
+        self.assertIn("Preserve coalesced targets", reply)
+        self.assertIn("bridge/github_to_mep.py", reply)
         system_prompt = post_mock.call_args.kwargs["json"]["messages"][0]["content"]
-        self.assertIn("You are a code reviewer for the MEP", system_prompt)
-        self.assertIn("approve, request_changes, or comment", system_prompt)
+        self.assertIn("return ONLY a JSON object", system_prompt)
+
+    def test_deepseek_adapter_filters_weak_review_findings(self):
+        adapter = mep_runtime.DeepSeekAdapter(api_key="secret-key", model="deepseek-chat")
+        task_data = self._bridge_review_task_data()
+        fake_response = _FakeResponse(
+            200,
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                '{"summary":"Missing context to verify the rest of the patch.",'
+                                '"findings":[{"file":"bridge/github_to_mep.py","issue":"Need more context",'
+                                '"rationale":"Cannot verify this path without seeing the full patch excerpt."}]}'
+                            )
+                        }
+                    }
+                ]
+            },
+        )
+
+        with patch("node.mep_runtime.requests.post", return_value=fake_response):
+            reply = adapter.generate_reply("Review this PR", task_data)
+
+        self.assertEqual(
+            reply,
+            "## Review Summary\n\nReviewed the provided diff context and did not identify a concrete issue that is directly supported by the supplied patch excerpts.",
+        )
 
 
 class TestRuntimeWebSocketLoop(unittest.TestCase):


### PR DESCRIPTION
Summary: preserve coalesced multi-bot targets, enrich PR review tasks with diff context, and structure runtime review output with weak-finding filtering. Testing: python -m pytest tests/test_github_bridge.py -q ; python -m pytest tests/test_node_runtime.py -q