### PR TITLE
Add pending-task recovery observability

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -661,6 +661,17 @@ class RuntimeNode:
         self._ws: Any = None
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._pending_call_bridges: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self.pending_task_recovery_metrics: dict[str, Any] = {
+            "poll_attempts": 0,
+            "poll_successes": 0,
+            "poll_failures": 0,
+            "malformed_responses": 0,
+            "tasks_recovered": 0,
+            "last_poll_status": None,
+            "last_poll_failure_at": None,
+            "last_poll_failure_detail": None,
+            "last_recovered_at": None,
+        }
 
     def _auth_headers(self, payload: str) -> dict[str, str]:
         headers = self.identity.get_auth_headers(payload)
@@ -830,7 +841,20 @@ class RuntimeNode:
             print(f"[mep run] ws send failed event={payload.get('event')} detail={exc}")
             return False
 
+    def _record_pending_task_poll_failure(self, *, status: Optional[int], detail: str) -> None:
+        metrics = self.pending_task_recovery_metrics
+        metrics["poll_failures"] += 1
+        metrics["last_poll_status"] = status
+        metrics["last_poll_failure_at"] = time.time()
+        metrics["last_poll_failure_detail"] = detail[:240]
+        print(
+            "[mep run] pending task poll failed "
+            f"node={self.node_id} status={status} failures={metrics['poll_failures']} detail={metrics['last_poll_failure_detail']}"
+        )
+
     def _fetch_pending_tasks(self) -> list[dict[str, Any]]:
+        metrics = self.pending_task_recovery_metrics
+        metrics["poll_attempts"] += 1
         code, body, raw = _safe_request(
             "GET",
             f"{self.hub_url}/tasks/pending/{self.node_id}",
@@ -838,18 +862,35 @@ class RuntimeNode:
             timeout=20.0,
         )
         if code != 200:
-            print(f"[mep run] pending task poll failed status={code} detail={raw}")
+            self._record_pending_task_poll_failure(
+                status=code,
+                detail=raw or "pending task poll returned non-200 status",
+            )
             return []
         tasks = body.get("tasks") if isinstance(body, dict) else None
         if not isinstance(tasks, list):
+            metrics["malformed_responses"] += 1
+            self._record_pending_task_poll_failure(
+                status=code,
+                detail="pending task poll returned invalid tasks payload",
+            )
             return []
+        metrics["poll_successes"] += 1
+        metrics["last_poll_status"] = code
         return [task for task in tasks if isinstance(task, dict)]
 
     async def _recover_pending_tasks(self) -> None:
         tasks = self._fetch_pending_tasks()
         if not tasks:
             return
-        print(f"[mep run] recovered pending tasks count={len(tasks)} node={self.node_id}")
+        metrics = self.pending_task_recovery_metrics
+        metrics["tasks_recovered"] += len(tasks)
+        metrics["last_recovered_at"] = time.time()
+        print(
+            "[mep run] recovered pending tasks "
+            f"count={len(tasks)} total_recovered={metrics['tasks_recovered']} "
+            f"successful_polls={metrics['poll_successes']} node={self.node_id}"
+        )
         for task in tasks:
             await self.handle_ws_event({"event": "new_task", "data": task})
 

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -480,6 +480,37 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         self.assertEqual(tasks, [{"id": "task_pending"}])
         self.assertEqual(request_mock.call_args.args, ("GET", "http://hub/tasks/pending/node_runtime"))
         self.assertEqual(request_mock.call_args.kwargs["headers"]["X-MEP-NodeID"], "node_runtime")
+        self.assertEqual(node.pending_task_recovery_metrics["poll_attempts"], 1)  # noqa: SLF001
+        self.assertEqual(node.pending_task_recovery_metrics["poll_successes"], 1)  # noqa: SLF001
+
+    def test_fetch_pending_tasks_records_poll_failure_metrics(self):
+        node = _runtime_node()
+        with patch("node.mep_runtime._safe_request", return_value=(503, None, "hub unavailable")):
+            tasks = node._fetch_pending_tasks()  # noqa: SLF001
+
+        self.assertEqual(tasks, [])
+        metrics = node.pending_task_recovery_metrics  # noqa: SLF001
+        self.assertEqual(metrics["poll_attempts"], 1)
+        self.assertEqual(metrics["poll_failures"], 1)
+        self.assertEqual(metrics["poll_successes"], 0)
+        self.assertEqual(metrics["last_poll_status"], 503)
+        self.assertEqual(metrics["last_poll_failure_detail"], "hub unavailable")
+        self.assertIsNotNone(metrics["last_poll_failure_at"])
+
+    def test_fetch_pending_tasks_records_malformed_response_metrics(self):
+        node = _runtime_node()
+        with patch("node.mep_runtime._safe_request", return_value=(200, {"tasks": "not-a-list"}, "")):
+            tasks = node._fetch_pending_tasks()  # noqa: SLF001
+
+        self.assertEqual(tasks, [])
+        metrics = node.pending_task_recovery_metrics  # noqa: SLF001
+        self.assertEqual(metrics["poll_attempts"], 1)
+        self.assertEqual(metrics["poll_failures"], 1)
+        self.assertEqual(metrics["malformed_responses"], 1)
+        self.assertEqual(metrics["poll_successes"], 0)
+        self.assertEqual(metrics["last_poll_status"], 200)
+        self.assertEqual(metrics["last_poll_failure_detail"], "pending task poll returned invalid tasks payload")
+        self.assertIsNotNone(metrics["last_poll_failure_at"])
 
     def test_recover_pending_tasks_replays_new_task_events(self):
         node = _runtime_node()
@@ -492,6 +523,8 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         self.assertEqual(handle_mock.await_count, 2)
         self.assertEqual(handle_mock.await_args_list[0].args[0], {"event": "new_task", "data": {"id": "task_one"}})
         self.assertEqual(handle_mock.await_args_list[1].args[0], {"event": "new_task", "data": {"id": "task_two"}})
+        self.assertEqual(node.pending_task_recovery_metrics["tasks_recovered"], 2)  # noqa: SLF001
+        self.assertIsNotNone(node.pending_task_recovery_metrics["last_recovered_at"])  # noqa: SLF001
 
     def test_run_forever_recovers_pending_tasks_after_connect(self):
         node = _runtime_node()


### PR DESCRIPTION
## Summary
- add lightweight metrics for pending-task poll attempts, failures, malformed responses, and recovered tasks
- improve runtime logging for pending-task poll failures and successful recovery replays
- add focused runtime tests covering failure, malformed response, and recovery counter behavior

## Validation
- python -m pytest tests/test_node_runtime.py -q