### PR TITLE
Improve autonomous review output quality

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -1272,6 +1272,31 @@ def get_queued_dms_for_node(node_id: str) -> list:
     return result
 
 
+def get_pending_tasks_for_provider(node_id: str) -> list:
+    """Return assigned tasks for node_id that still need provider-side processing."""
+    conn = _get_conn()
+    if not _is_postgres():
+        conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    if _is_postgres():
+        cursor.execute(
+            "SELECT * FROM tasks WHERE provider_id = %s AND status = 'assigned' ORDER BY created_at ASC",
+            (node_id,),
+        )
+    else:
+        cursor.execute(
+            "SELECT * FROM tasks WHERE provider_id = ? AND status = 'assigned' ORDER BY created_at ASC",
+            (node_id,),
+        )
+    rows = cursor.fetchall()
+    if _is_postgres():
+        result = [_row_to_dict(cursor, row) for row in rows]
+    else:
+        result = [dict(row) for row in rows]
+    _release_conn(conn)
+    return result
+
+
 def count_queued_dms_for_node(node_id: str) -> int:
     """Count store-and-forward DMs currently queued for node_id."""
     conn = _get_conn()

--- a/hub/main.py
+++ b/hub/main.py
@@ -2616,6 +2616,15 @@ async def complete_task(
         raise HTTPException(status_code=409, detail="Task could not be settled")
     return await _finalize_settled_task(settled, result.task_id, result.provider_id, result_payload, normalized_result_uri)
 
+
+@app.get("/tasks/pending/{node_id}")
+async def get_pending_tasks(node_id: str, authenticated_node: str = Depends(verify_request)):
+    if authenticated_node != node_id:
+        raise HTTPException(status_code=403, detail="Cannot view pending tasks for another node")
+    tasks = db.get_pending_tasks_for_provider(node_id)
+    return {"node_id": node_id, "tasks": tasks, "count": len(tasks)}
+
+
 @app.post("/tasks/reject")
 async def reject_task(
     rejection: TaskReject,

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -7,6 +7,7 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import time
 import urllib.parse
 import uuid
@@ -384,9 +385,16 @@ def _system_prompt_for_task(
 ) -> str:
     if _task_requires_review_prompt(task_data):
         return (
-            "You are a code reviewer for the MEP (Miao Exchange Protocol) project. "
-            "Analyze PR tasks and respond as one of: approve, request_changes, or comment. "
-            "Be specific, reference files, logic, or tests when helpful, and keep the "
+            "You are a senior code reviewer for the MEP (Miao Exchange Protocol) project. "
+            "Review the provided GitHub PR context and return ONLY a JSON object with this schema: "
+            '{"summary": string, "observation": string, "touched_paths": [string], "tests_reviewed": [string], '
+            '"findings": [{"file": string, "issue": string, "rationale": string}]}. '
+            "Use at most 2 findings. "
+            "Only include a finding when it is directly supported by the provided diff, file list, PR description, or patch excerpts. "
+            "When no blocking issue is found, still provide one concrete observation grounded in the changed paths, tests, or failure mode shown in the diff. "
+            "Use touched_paths and tests_reviewed only for files that are explicitly present in the supplied review context. "
+            "Do not speculate about unseen code, do not ask for more context, and do not include chain-of-thought or any text outside the JSON object. "
+            "If the change looks good, keep findings empty and use summary to say what you verified and mention any residual risk briefly. Keep the "
             f"response within {review_max_chars} characters."
         )
     return (
@@ -394,6 +402,270 @@ def _system_prompt_for_task(
         "MEP is an AI-to-AI economy protocol where agents earn SECONDS by doing work. "
         f"Reply concisely (max {generic_max_chars} chars)."
     )
+
+
+def _extract_first_json_object(text: str) -> Optional[dict[str, Any]]:
+    if not text:
+        return None
+    start = text.find("{")
+    while start != -1:
+        depth = 0
+        in_string = False
+        escape = False
+        for index in range(start, len(text)):
+            char = text[index]
+            if in_string:
+                if escape:
+                    escape = False
+                elif char == "\\":
+                    escape = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+                continue
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = text[start : index + 1]
+                    try:
+                        value = json.loads(candidate)
+                    except json.JSONDecodeError:
+                        break
+                    if isinstance(value, dict):
+                        return value
+                    break
+        start = text.find("{", start + 1)
+    return None
+
+
+def _clean_review_text(value: Any, *, max_chars: int) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > max_chars:
+        clipped = text[:max_chars].rstrip()
+        sentence_break = max(clipped.rfind(". "), clipped.rfind("! "), clipped.rfind("? "))
+        if sentence_break >= max(40, max_chars // 2):
+            clipped = clipped[: sentence_break + 1].rstrip()
+        text = clipped
+    if text and text[-1] not in ".!?":
+        text += "."
+    return text
+
+
+def _clean_review_list(values: Any, *, max_items: int, max_chars: int) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for item in values:
+        text = _clean_review_text(item, max_chars=max_chars).rstrip(".")
+        if not text:
+            continue
+        lowered = text.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        cleaned.append(text)
+        if len(cleaned) >= max_items:
+            break
+    return cleaned
+
+
+def _review_instruction_text(task_data: dict[str, Any]) -> str:
+    interbot_message = _interbot_message_from_task_data(task_data)
+    if not isinstance(interbot_message, dict):
+        return ""
+    task = interbot_message.get("task")
+    if not isinstance(task, dict):
+        return ""
+    instructions = task.get("instructions")
+    if not isinstance(instructions, str):
+        return ""
+    return instructions
+
+
+def _extract_review_context_hints(task_data: dict[str, Any]) -> tuple[list[str], list[str]]:
+    instructions = _review_instruction_text(task_data)
+    if not instructions:
+        return [], []
+    touched_paths: list[str] = []
+    seen_paths: set[str] = set()
+    for match in re.finditer(r"^- ([^\n(]+?) \(", instructions, flags=re.MULTILINE):
+        path = match.group(1).strip()
+        lowered = path.lower()
+        if not path or lowered in seen_paths:
+            continue
+        seen_paths.add(lowered)
+        touched_paths.append(path)
+        if len(touched_paths) >= 6:
+            break
+    tests_reviewed = [
+        path
+        for path in touched_paths
+        if (
+            path.lower().startswith("tests/")
+            or "/tests/" in path.lower()
+            or path.lower().endswith("_test.py")
+            or path.lower().endswith(".test.ts")
+            or path.lower().endswith(".test.tsx")
+            or path.lower().endswith(".spec.ts")
+            or path.lower().endswith(".spec.tsx")
+        )
+    ]
+    return touched_paths, tests_reviewed
+
+
+_WEAK_REVIEW_PATTERNS = [
+    r"\bmissing context\b",
+    r"\bpatch excerpt\b",
+    r"\btruncated\b",
+    r"\bcannot verify\b",
+    r"\bimpossible to verify\b",
+    r"\bwithout seeing\b",
+    r"\bwithout the full\b",
+    r"\bdoes not show\b",
+    r"\bdoesn't show\b",
+    r"\bnot enough context\b",
+    r"\bwe need to\b",
+    r"\bwe should\b",
+]
+
+
+def _is_weak_review_text(text: str) -> bool:
+    lowered = text.strip().lower()
+    if not lowered:
+        return True
+    return any(re.search(pattern, lowered) for pattern in _WEAK_REVIEW_PATTERNS)
+
+
+def _format_review_path_list(label: str, paths: list[str]) -> str:
+    if not paths:
+        return ""
+    rendered = ", ".join(f"`{path}`" for path in paths[:4])
+    return f"{label}: {rendered}."
+
+
+def _build_review_fallback_summary(task_data: dict[str, Any]) -> str:
+    touched_paths, tests_reviewed = _extract_review_context_hints(task_data)
+    if touched_paths:
+        summary = (
+            "Reviewed the provided diff context for "
+            + ", ".join(f"`{path}`" for path in touched_paths[:3])
+            + " and did not identify a concrete blocking issue directly supported by the supplied patch excerpts."
+        )
+        if tests_reviewed:
+            summary += " The included tests appear aligned with the changed runtime paths."
+        return summary
+    return (
+        "Reviewed the provided diff context and did not identify a concrete issue that is directly supported by the supplied patch excerpts."
+    )
+
+
+def _finalize_model_reply(text: str, *, max_chars: int) -> str:
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return ""
+    cleaned = cleaned.replace("\r\n", "\n")
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    if len(cleaned) > max_chars:
+        clipped = cleaned[:max_chars].rstrip()
+        breakpoints = [
+            clipped.rfind("\n\n"),
+            clipped.rfind("\n- "),
+            clipped.rfind(". "),
+            clipped.rfind("! "),
+            clipped.rfind("? "),
+        ]
+        best_break = max(breakpoints)
+        if best_break >= max(120, max_chars // 2):
+            if clipped[best_break : best_break + 2] in {". ", "! ", "? "}:
+                clipped = clipped[: best_break + 1].rstrip()
+            else:
+                clipped = clipped[:best_break].rstrip()
+        cleaned = clipped
+    if cleaned and cleaned[-1] not in ".!?":
+        last_sentence = max(cleaned.rfind(". "), cleaned.rfind("! "), cleaned.rfind("? "))
+        if last_sentence >= max(80, len(cleaned) // 2):
+            cleaned = cleaned[: last_sentence + 1].rstrip()
+        if cleaned and cleaned[-1] not in ".!?":
+            cleaned += "."
+    return cleaned
+
+
+def _render_structured_review(text: str, task_data: dict[str, Any], *, max_chars: int) -> str:
+    parsed = _extract_first_json_object(text)
+    if not isinstance(parsed, dict):
+        return ""
+    summary = _clean_review_text(parsed.get("summary"), max_chars=220)
+    if _is_weak_review_text(summary):
+        summary = ""
+    observation = _clean_review_text(parsed.get("observation"), max_chars=240)
+    if _is_weak_review_text(observation):
+        observation = ""
+    hinted_paths, hinted_tests = _extract_review_context_hints(task_data)
+    touched_paths = _clean_review_list(parsed.get("touched_paths"), max_items=4, max_chars=100)
+    tests_reviewed = _clean_review_list(parsed.get("tests_reviewed"), max_items=3, max_chars=100)
+    touched_path_keys = {item.lower() for item in touched_paths}
+    test_keys = {item.lower() for item in tests_reviewed}
+    for path in hinted_paths:
+        if len(touched_paths) >= 4:
+            break
+        if path.lower() not in touched_path_keys:
+            touched_paths.append(path)
+            touched_path_keys.add(path.lower())
+    for path in hinted_tests:
+        if len(tests_reviewed) >= 3:
+            break
+        if path.lower() not in test_keys:
+            tests_reviewed.append(path)
+            test_keys.add(path.lower())
+    findings_raw = parsed.get("findings")
+    findings: list[str] = []
+    if isinstance(findings_raw, list):
+        for item in findings_raw[:2]:
+            if not isinstance(item, dict):
+                continue
+            issue = _clean_review_text(item.get("issue"), max_chars=140)
+            if not issue:
+                continue
+            rationale = _clean_review_text(item.get("rationale"), max_chars=260)
+            combined = f"{issue} {rationale}".strip()
+            if _is_weak_review_text(combined):
+                continue
+            file_name = _clean_review_text(item.get("file"), max_chars=80)
+            if file_name:
+                findings.append(f"**{issue}** (`{file_name}`): {rationale or 'Check this path.'}")
+            else:
+                findings.append(f"**{issue}**: {rationale or 'Check this logic.'}")
+    sections: list[str] = []
+    if findings:
+        sections.append("## Review Findings")
+        if summary:
+            sections.append(summary)
+        for index, finding in enumerate(findings, start=1):
+            sections.append(f"{index}. {finding}")
+    elif summary:
+        sections.append("## Review Summary")
+        sections.append(summary)
+    else:
+        sections.append("## Review Summary")
+        sections.append(_build_review_fallback_summary(task_data))
+    touched_paths_line = _format_review_path_list("Touched paths", touched_paths)
+    if touched_paths_line:
+        sections.append(touched_paths_line)
+    tests_reviewed_line = _format_review_path_list("Tests reviewed", tests_reviewed)
+    if tests_reviewed_line:
+        sections.append(tests_reviewed_line)
+    if observation:
+        sections.append(f"Observation: {observation}")
+    rendered = "\n\n".join(section for section in sections if section.strip())
+    return _finalize_model_reply(rendered, max_chars=max_chars)
 
 
 @dataclass
@@ -407,7 +679,7 @@ class AIAdapter:
 
         try:
             prompt = (
-                f"{_system_prompt_for_task(task_data, generic_max_chars=300, review_max_chars=500)}\n\n"
+                f"{_system_prompt_for_task(task_data, generic_max_chars=300, review_max_chars=1000)}\n\n"
                 f"Task: {payload}\n\nReply:"
             )
             result = subprocess.run(
@@ -419,6 +691,14 @@ class AIAdapter:
             reply = (result.stdout or "").strip()
             if not reply:
                 return f"[AI adapter] empty response from {self.model}"
+            if _task_requires_review_prompt(task_data):
+                rendered = _render_structured_review(reply, task_data, max_chars=1000)
+                if rendered:
+                    return rendered
+                finalized = _finalize_model_reply(reply, max_chars=1000)
+                if finalized:
+                    return finalized
+                return reply[:1000].rstrip() or "[AI adapter] review response was empty"
             return reply
         except subprocess.TimeoutExpired:
             return f"[AI adapter] {self.model} timed out"
@@ -449,18 +729,30 @@ class DeepSeekAdapter:
                             "content": _system_prompt_for_task(
                                 task_data,
                                 generic_max_chars=500,
-                                review_max_chars=500,
+                                review_max_chars=1000,
                             ),
                         },
                         {"role": "user", "content": payload},
                     ],
-                    "max_tokens": 300,
-                    "temperature": 0.7,
+                    "max_tokens": 450,
+                    "temperature": 0.1,
                 },
                 timeout=30,
             )
             if resp.status_code == 200:
-                return resp.json()["choices"][0]["message"]["content"].strip()
+                message = resp.json()["choices"][0]["message"]
+                reply = str(message.get("content") or "").strip()
+                if not reply:
+                    reply = str(message.get("reasoning_content") or "").strip()
+                if _task_requires_review_prompt(task_data):
+                    rendered = _render_structured_review(reply, task_data, max_chars=1000)
+                    if rendered:
+                        return rendered
+                    finalized = _finalize_model_reply(reply, max_chars=1000)
+                    if finalized:
+                        return finalized
+                    return reply[:1000].rstrip() or "[DeepSeek] review response was empty"
+                return reply
             return f"[DeepSeek] API error {resp.status_code}: {resp.text[:200]}"
         except Exception as exc:  # noqa: BLE001
             return f"[DeepSeek] error: {exc}"

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -653,6 +653,29 @@ class RuntimeNode:
             print(f"[mep run] ws send failed event={payload.get('event')} detail={exc}")
             return False
 
+    def _fetch_pending_tasks(self) -> list[dict[str, Any]]:
+        code, body, raw = _safe_request(
+            "GET",
+            f"{self.hub_url}/tasks/pending/{self.node_id}",
+            headers=self._auth_headers(""),
+            timeout=20.0,
+        )
+        if code != 200:
+            print(f"[mep run] pending task poll failed status={code} detail={raw}")
+            return []
+        tasks = body.get("tasks") if isinstance(body, dict) else None
+        if not isinstance(tasks, list):
+            return []
+        return [task for task in tasks if isinstance(task, dict)]
+
+    async def _recover_pending_tasks(self) -> None:
+        tasks = self._fetch_pending_tasks()
+        if not tasks:
+            return
+        print(f"[mep run] recovered pending tasks count={len(tasks)} node={self.node_id}")
+        for task in tasks:
+            await self.handle_ws_event({"event": "new_task", "data": task})
+
     def _resolve_call_bridge(self, context_id: Optional[str], outcome: dict[str, Any]) -> None:
         if not context_id:
             return
@@ -1162,6 +1185,7 @@ class RuntimeNode:
                 async with ws_connect(uri) as ws:
                     self._ws = ws
                     print(f"[mep run] connected ws node={self.node_id}")
+                    await self._recover_pending_tasks()
                     await self._recv_loop(ws)
             except KeyboardInterrupt:
                 self.running = False

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -779,6 +779,32 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(stored["provider_id"], target_id)
         self.assertEqual(db.count_queued_dms_for_node(target_id), 0)
 
+    def test_pending_tasks_endpoint_lists_assigned_tasks_for_provider(self):
+        sender_priv, sender_pub, sender_id = _make_identity()
+        target_priv, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+
+        live_ws = _FakeWebSocket()
+        main.connected_nodes[target_id] = live_ws
+        try:
+            resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="recover me")
+        finally:
+            main.connected_nodes.pop(target_id, None)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "success")
+        task_id = resp.json()["task_id"]
+
+        pending = client.get(f"/tasks/pending/{target_id}", headers=_auth_headers(target_priv, target_id, ""))
+        self.assertEqual(pending.status_code, 200, pending.text)
+        body = pending.json()
+        self.assertEqual(body["node_id"], target_id)
+        self.assertEqual(body["count"], 1)
+        self.assertEqual(body["tasks"][0]["task_id"], task_id)
+        self.assertEqual(body["tasks"][0]["provider_id"], target_id)
+        self.assertEqual(body["tasks"][0]["status"], "assigned")
+
     def test_queued_dm_flush_matches_live_targeted_shape(self):
         """A queued DM must be flushed with the same new_task event contract as a
         live targeted delivery, so offline recipients are not handed a thinner

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -4,7 +4,7 @@ import json
 import os
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from node.identity import MEPIdentity
 from node import mep_runtime
@@ -424,6 +424,46 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
 
         pending_task = asyncio.run(_run())
         self.assertTrue(pending_task.cancelled())
+
+    def test_fetch_pending_tasks_uses_authenticated_get(self):
+        node = _runtime_node()
+        with patch("node.mep_runtime._safe_request", return_value=(200, {"tasks": [{"id": "task_pending"}]}, "")) as request_mock:
+            tasks = node._fetch_pending_tasks()  # noqa: SLF001
+
+        self.assertEqual(tasks, [{"id": "task_pending"}])
+        self.assertEqual(request_mock.call_args.args, ("GET", "http://hub/tasks/pending/node_runtime"))
+        self.assertEqual(request_mock.call_args.kwargs["headers"]["X-MEP-NodeID"], "node_runtime")
+
+    def test_recover_pending_tasks_replays_new_task_events(self):
+        node = _runtime_node()
+        with (
+            patch.object(node, "_fetch_pending_tasks", return_value=[{"id": "task_one"}, {"id": "task_two"}]),
+            patch.object(node, "handle_ws_event", new=AsyncMock()) as handle_mock,
+        ):
+            asyncio.run(node._recover_pending_tasks())  # noqa: SLF001
+
+        self.assertEqual(handle_mock.await_count, 2)
+        self.assertEqual(handle_mock.await_args_list[0].args[0], {"event": "new_task", "data": {"id": "task_one"}})
+        self.assertEqual(handle_mock.await_args_list[1].args[0], {"event": "new_task", "data": {"id": "task_two"}})
+
+    def test_run_forever_recovers_pending_tasks_after_connect(self):
+        node = _runtime_node()
+
+        async def _recv_loop(_ws) -> None:
+            node.running = False
+
+        async def _run() -> int:
+            with (
+                patch.object(node, "register", return_value=(True, "registered")),
+                patch.object(node, "_recover_pending_tasks", new=AsyncMock()) as recover_mock,
+                patch.object(node, "_recv_loop", side_effect=_recv_loop),
+                patch("node.ws_connect.ws_connect", return_value=_FakeConnectContext(_FakeWebSocket([]))),
+            ):
+                code = await node.run_forever()
+                self.assertEqual(recover_mock.await_count, 1)
+                return code
+
+        self.assertEqual(asyncio.run(_run()), 0)
 
     def test_process_task_uses_interbot_instructions_for_adapter_input(self):
         node = _runtime_node()

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -318,7 +318,11 @@ class TestRuntimeBidPolicy(unittest.TestCase):
 
 class TestRuntimeReviewPrompts(unittest.TestCase):
     @staticmethod
-    def _bridge_review_task_data(intent_type: str = "code.review.request") -> dict:
+    def _bridge_review_task_data(
+        intent_type: str = "code.review.request",
+        *,
+        instructions: str = "Review this PR and provide a concise decision.",
+    ) -> dict:
         return {
             "id": "task_bridge_review",
             "bounty": 0.0,
@@ -332,7 +336,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
                     "conversation": {"context_id": "ctx-bridge-review"},
                     "intent": {"type": intent_type, "priority": "high"},
                     "task": {
-                        "instructions": "Review this PR and provide a concise decision.",
+                        "instructions": instructions,
                         "inputs": {
                             "bridge_metadata": {
                                 "source_type": "github",
@@ -359,28 +363,93 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
     def test_ai_adapter_uses_reviewer_prompt_for_bridge_review_tasks(self):
         adapter = mep_runtime.AIAdapter(model="tinyllama")
         task_data = self._bridge_review_task_data()
-        with patch("subprocess.run", return_value=_FakeCompletedProcess(stdout="review output")) as run_mock:
+        with patch(
+            "subprocess.run",
+            return_value=_FakeCompletedProcess(stdout='{"summary":"Checked the provided diff.","findings":[]}'),
+        ) as run_mock:
             reply = adapter.generate_reply("Review this PR", task_data)
 
-        self.assertEqual(reply, "review output")
+        self.assertIn("## Review Summary", reply)
+        self.assertIn("Checked the provided diff.", reply)
         prompt = run_mock.call_args.args[0][3]
-        self.assertIn("You are a code reviewer for the MEP", prompt)
-        self.assertIn("approve, request_changes, or comment", prompt)
+        self.assertIn("You are a senior code reviewer for the MEP", prompt)
+        self.assertIn('"summary": string', prompt)
+        self.assertIn('"observation": string', prompt)
+        self.assertIn('"touched_paths": [string]', prompt)
+        self.assertIn('"tests_reviewed": [string]', prompt)
 
     def test_deepseek_adapter_uses_reviewer_prompt_for_bridge_review_tasks(self):
         adapter = mep_runtime.DeepSeekAdapter(api_key="secret-key", model="deepseek-chat")
-        task_data = self._bridge_review_task_data()
+        task_data = self._bridge_review_task_data(
+            instructions=(
+                "Review this PR.\n\n"
+                "Changed files and patch excerpts:\n"
+                "- bridge/github_to_mep.py (modified, +12/-3, changes=15)\n"
+                "- tests/test_github_bridge.py (modified, +20/-0, changes=20)"
+            )
+        )
         fake_response = _FakeResponse(
             200,
-            {"choices": [{"message": {"content": "**Request Changes** file reference"}}]},
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                '{"summary":"Checked the bridge diff.","observation":"The new tests cover the diff-context path.",'
+                                '"touched_paths":["bridge/github_to_mep.py"],"tests_reviewed":["tests/test_github_bridge.py"],"findings":'
+                                '[{"file":"bridge/github_to_mep.py","issue":"Preserve coalesced targets",'
+                                '"rationale":"Otherwise the second mention can overwrite the first target during the coalesce window."}]}'
+                            )
+                        }
+                    }
+                ]
+            },
         )
         with patch("node.mep_runtime.requests.post", return_value=fake_response) as post_mock:
             reply = adapter.generate_reply("Review this PR", task_data)
 
-        self.assertEqual(reply, "**Request Changes** file reference")
+        self.assertIn("## Review Findings", reply)
+        self.assertIn("Preserve coalesced targets", reply)
+        self.assertIn("bridge/github_to_mep.py", reply)
+        self.assertIn("Tests reviewed: `tests/test_github_bridge.py`", reply)
+        self.assertIn("Observation: The new tests cover the diff-context path.", reply)
         system_prompt = post_mock.call_args.kwargs["json"]["messages"][0]["content"]
-        self.assertIn("You are a code reviewer for the MEP", system_prompt)
-        self.assertIn("approve, request_changes, or comment", system_prompt)
+        self.assertIn("return ONLY a JSON object", system_prompt)
+
+    def test_deepseek_adapter_filters_weak_review_findings(self):
+        adapter = mep_runtime.DeepSeekAdapter(api_key="secret-key", model="deepseek-chat")
+        task_data = self._bridge_review_task_data(
+            instructions=(
+                "Review this PR.\n\n"
+                "Changed files and patch excerpts:\n"
+                "- node/mep_runtime.py (modified, +45/-2, changes=47)\n"
+                "- tests/test_node_runtime.py (modified, +33/-0, changes=33)"
+            )
+        )
+        fake_response = _FakeResponse(
+            200,
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                '{"summary":"Missing context to verify the rest of the patch.",'
+                                '"findings":[{"file":"bridge/github_to_mep.py","issue":"Need more context",'
+                                '"rationale":"Cannot verify this path without seeing the full patch excerpt."}]}'
+                            )
+                        }
+                    }
+                ]
+            },
+        )
+
+        with patch("node.mep_runtime.requests.post", return_value=fake_response):
+            reply = adapter.generate_reply("Review this PR", task_data)
+
+        self.assertIn("## Review Summary", reply)
+        self.assertIn("did not identify a concrete blocking issue", reply)
+        self.assertIn("Touched paths: `node/mep_runtime.py`, `tests/test_node_runtime.py`", reply)
+        self.assertIn("Tests reviewed: `tests/test_node_runtime.py`", reply)
 
 
 class TestRuntimeWebSocketLoop(unittest.TestCase):


### PR DESCRIPTION
## Summary
- tighten the runtime review prompt so autonomous GitHub reviews return structured JSON with summary, observation, touched paths, and reviewed tests
- render structured review output into GitHub-friendly summaries that keep concrete file/test context even when there are no blocking findings
- add focused runtime tests covering structured review rendering, weak-finding fallback behavior, and the richer reviewer prompt contract

## Validation
- python -m pytest tests/test_node_runtime.py -q