### PR TITLE
Phase 2B: tighten review signal gating

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -46,6 +46,16 @@ _WEAK_GITHUB_REVIEW_PATTERNS = [
     r"\bno blocking issues\b",
     r"\bfocused runtime tests\b",
 ]
+_SPECULATIVE_FINDING_PATTERNS = [
+    r"\bif intended\b",
+    r"\bif .*? intended for\b",
+    r"\bif .*? meant to\b",
+    r"\bsuggests incomplete implementation\b",
+    r"\bpotentially leaving\b",
+    r"\bappears to\b",
+    r"\bseems to\b",
+    r"\bcould indicate\b",
+]
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -1538,6 +1548,29 @@ class GitHubToMEPBridgeService:
         return tokens
 
     @staticmethod
+    def _extract_observation_text(detail: str) -> str:
+        if not detail:
+            return ""
+        match = re.search(r"Observation:\s*(.+)", detail, re.IGNORECASE)
+        if not match:
+            return ""
+        return str(match.group(1) or "").strip()
+
+    @classmethod
+    def _grounded_code_tokens(cls, text: str, patch_text: str) -> set[str]:
+        if not text or not patch_text:
+            return set()
+        tokens = cls._extract_identifier_tokens(text)
+        return {token for token in tokens if token in patch_text.lower()}
+
+    @staticmethod
+    def _is_speculative_finding(text: str) -> bool:
+        lowered = str(text or "").strip().lower()
+        if not lowered:
+            return False
+        return any(re.search(pattern, lowered) for pattern in _SPECULATIVE_FINDING_PATTERNS)
+
+    @staticmethod
     def _is_auth_absence_claim(text: str) -> bool:
         lowered = str(text or "").lower()
         if "authentication" not in lowered and "authorization" not in lowered:
@@ -1619,6 +1652,9 @@ class GitHubToMEPBridgeService:
             identifier_tokens = cls._extract_identifier_tokens(finding_text)
             if identifier_tokens and not any(token in patch_text for token in identifier_tokens):
                 return "ungrounded_finding"
+            grounded_tokens = cls._grounded_code_tokens(finding_text, patch_text)
+            if cls._is_speculative_finding(finding_text) and len(grounded_tokens) < 2:
+                return "speculative_finding"
         return None
 
     def _classify_review_writeback_detail(self, execution: dict[str, Any], detail: Optional[str]) -> tuple[bool, str]:
@@ -1641,7 +1677,12 @@ class GitHubToMEPBridgeService:
                     if text and text not in expected_paths:
                         expected_paths.append(text)
         anchored_paths = self._grounded_review_paths(detail or "", expected_paths)
+        patches_by_path = self._patch_text_by_path(review_package)
+        anchored_patch_text = "\n".join(
+            patches_by_path.get(path, "") for path in anchored_paths if patches_by_path.get(path)
+        )
         has_findings = "## review findings" in lowered or bool(self._extract_review_finding_entries(detail or ""))
+        observation_text = self._extract_observation_text(detail or "")
         has_structured_sections = any(
             snippet in lowered
             for snippet in (
@@ -1657,13 +1698,18 @@ class GitHubToMEPBridgeService:
         finding_reason = self._verify_review_findings_against_patch(detail or "", review_package, expected_paths)
         if finding_reason:
             return True, finding_reason
+        grounded_tokens = self._grounded_code_tokens(detail or "", anchored_patch_text)
+        if has_findings and self._is_speculative_finding(detail or "") and len(grounded_tokens) < 2:
+            return True, "speculative_finding"
         if has_findings and anchored_paths and review_package:
-            patches_by_path = self._patch_text_by_path(review_package)
-            anchored_patch_text = "\n".join(
-                patches_by_path.get(path, "") for path in anchored_paths if patches_by_path.get(path)
-            )
             if self._finding_conflicts_with_patch(detail or "", anchored_patch_text):
                 return True, "ungrounded_finding"
+        if has_structured_sections and not has_findings:
+            if not observation_text and not grounded_tokens:
+                return True, "summary_without_code_evidence"
+            observation_tokens = self._extract_identifier_tokens(observation_text)
+            if observation_text and not grounded_tokens and len(observation_tokens) < 2:
+                return True, "generic_observation"
         if len(normalized) < 90 and not anchored_paths:
             return True, "too_short"
         if any(re.search(pattern, lowered) for pattern in _WEAK_GITHUB_REVIEW_PATTERNS) and not anchored_paths:

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -477,7 +477,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertIn("Touched tests:\n- src/test/webhook_security_test.py", instructions)
         self.assertIn("Risk tags: security", instructions)
 
-    def test_status_callback_requires_valid_token_and_updates_existing_message(self):
+    def test_status_callback_suppresses_approve_without_code_evidence_and_updates_existing_message(self):
         response = self._post_webhook(
             _issue_comment_payload("@Hub-Sentinel approve this PR"),
             delivery_id="delivery-status",
@@ -514,14 +514,12 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(len(self.notifier.calls), 2)
         final_message = self.notifier.calls[-1]
         self.assertTrue(final_message["editing"])
-        self.assertIn("status: completed", final_message["text"])
-        self.assertIn("action: approved", final_message["text"])
-        self.assertEqual(len(self.github_session.posts), 1)
-        self.assertTrue(self.github_session.posts[0]["url"].endswith("/repos/WUAIBING/MEP/pulls/226/reviews"))
-        self.assertEqual(self.github_session.posts[0]["json"]["event"], "APPROVE")
-        self.assertIn("<!-- mep-bridge:output", self.github_session.posts[0]["json"]["body"])
-        self.assertEqual(self.service.github_writeback_metrics["reviews_published"], 1)
-        self.assertEqual(self.service.github_writeback_metrics["suppressed_weak_reviews"], 0)
+        self.assertIn("action: suppressed", final_message["text"])
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(self.service.github_writeback_metrics["reviews_published"], 0)
+        self.assertEqual(self.service.github_writeback_metrics["suppressed_weak_reviews"], 1)
+        self.assertEqual(self.service.github_writeback_metrics["suppressed_approvals"], 1)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "generic_observation")
 
     def test_status_callback_suppresses_generic_pr_review_writeback(self):
         response = self._post_webhook(
@@ -578,7 +576,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         )
         self.assertEqual(status_response.status_code, 200, status_response.text)
         self.assertEqual(len(self.github_session.posts), 0)
-        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "no_touched_path_anchor")
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "generic_observation")
 
     def test_status_callback_suppresses_finding_conflicting_with_patch_evidence(self):
         self._set_pr_review_package(
@@ -703,6 +701,183 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(status_response.status_code, 200, status_response.text)
         self.assertEqual(len(self.github_session.posts), 1)
         self.assertTrue(self.github_session.posts[0]["url"].endswith("/repos/WUAIBING/MEP/pulls/149/reviews"))
+
+    def test_status_callback_suppresses_summary_with_paths_but_no_code_evidence(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 40,
+                    "deletions": 2,
+                    "changes": 42,
+                    "patch": (
+                        "@@ -945,0 +945,29 @@\n"
+                        "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_failure_detail'] = detail\n"
+                    ),
+                },
+                {
+                    "filename": "tests/test_node_runtime.py",
+                    "status": "modified",
+                    "additions": 20,
+                    "deletions": 0,
+                    "changes": 20,
+                    "patch": (
+                        "@@ -494,0 +494,20 @@\n"
+                        "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
+                        "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
+                    ),
+                },
+            ],
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=243),
+            delivery_id="delivery-summary-with-paths-only",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-summary-with-paths-only",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability with metrics and logging in mep_runtime.py, plus corresponding tests in test_node_runtime.py."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "summary_without_code_evidence")
+
+    def test_status_callback_allows_summary_with_grounded_code_observation(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 40,
+                    "deletions": 2,
+                    "changes": 42,
+                    "patch": (
+                        "@@ -945,0 +945,29 @@\n"
+                        "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_failure_detail'] = detail\n"
+                    ),
+                },
+                {
+                    "filename": "tests/test_node_runtime.py",
+                    "status": "modified",
+                    "additions": 20,
+                    "deletions": 0,
+                    "changes": 20,
+                    "patch": (
+                        "@@ -494,0 +494,20 @@\n"
+                        "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
+                        "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
+                    ),
+                },
+            ],
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=243),
+            delivery_id="delivery-summary-with-observation",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-summary-with-observation",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability in `node/mep_runtime.py` and corresponding tests in `tests/test_node_runtime.py`.\n\n"
+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, so malformed payloads will still surface `status=200` in the metrics."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 1)
+
+    def test_status_callback_suppresses_speculative_finding(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 37,
+                    "deletions": 4,
+                    "changes": 41,
+                    "patch": (
+                        "@@ -14,12 +14,51 @@\n"
+                        "+REQUIRED_PACKAGES = ['requests', 'cryptography', 'websockets']\n"
+                        "+def _check_dependencies() -> None:\n"
+                        "+    for pkg in REQUIRED_PACKAGES:\n"
+                        "+        __import__(pkg)\n"
+                    ),
+                },
+                {
+                    "filename": "README.md",
+                    "status": "modified",
+                    "additions": 5,
+                    "deletions": 4,
+                    "changes": 9,
+                    "patch": (
+                        "@@ -117,10 +117,11 @@\n"
+                        "+pip install requests websockets cryptography\n"
+                        "+cd node && python mep_runtime.py run --hub-url https://mep-hub.silentcopilot.ai\n"
+                    ),
+                },
+            ],
+            pr_body="Improves onboarding and adds startup dependency validation.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=123),
+            delivery_id="delivery-speculative-finding",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-speculative-finding",
+                "detail": (
+                    "## Review Findings\n\n"
+                    "Reviewed PR #123 onboarding dependency validation.\n\n"
+                    "1. **The dependency validation only checks `REQUIRED_PACKAGES`, but the rest of the validation flow may be incomplete.** (`node/mep_runtime.py`): "
+                    "If intended for broader startup validation, this suggests incomplete implementation and potentially leaving other dependencies unvalidated."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "speculative_finding")
 
     def test_status_callback_posts_issue_comment_for_analysis_completion(self):
         response = self._post_webhook(


### PR DESCRIPTION
## Summary
- tighten GitHub review writeback gating so path names alone no longer count as enough review evidence
- suppress summary-only reviews unless they carry code-level signal beyond touched file references
- suppress more speculative findings when they are not supported by concrete patch-grounded signal
- extend bridge regression coverage around weak summaries, generic observations, and speculative findings

## Why
The post-Phase-2A live validation exposed two remaining failure modes:
1. PR #243 still published summary-style reviews that named touched files but did not provide code-level evidence
2. PR #123 produced a more detailed finding, but it still included speculative reasoning not directly supported by the patch

Phase 2B tightens the publisher again: a path mention alone is not enough, and speculative findings are more likely to be withheld.

## Test
- `python -m pytest tests/test_github_bridge.py -q`
