### PR TITLE
Phase 2C: fail closed for strict reviewer adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,6 @@ R2_BUCKET_NAME=your_r2_bucket_name_here
 
 GEMINI_API_KEY=your_gemini_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
+MEP_STRICT_ADAPTERS=false
 GLM_API_KEY=your_glm_api_key_here
 MINIMAX_API_KEY=your_minimax_api_key_here

--- a/docs/external-bridge/README.md
+++ b/docs/external-bridge/README.md
@@ -114,6 +114,18 @@ Documented but not yet enforced in this first bridge-side implementation:
 
 These remain approved design follow-up settings, not active runtime behavior in this slice.
 
+## Reviewer Runtime Safety
+
+Production reviewer nodes such as `Hub Sentinel` and `Elsaws Bot` should not silently downgrade from a requested AI adapter to `MockAdapter`.
+
+Set these runtime variables for both reviewer nodes:
+
+- `DEEPSEEK_API_KEY=<real key>`
+- `MEP_AI_MODEL=deepseek-chat`
+- `MEP_STRICT_ADAPTERS=true`
+
+With `MEP_STRICT_ADAPTERS=true`, `python -m node.mep_runtime --adapter deepseek run` fails closed if `DEEPSEEK_API_KEY` is missing instead of publishing `MOCK_ADAPTER_OK` placeholder output. Keep mock mode only for local onboarding or smoke tests where deterministic non-AI output is intentional.
+
 ## Starting The Bridge
 
 The bridge is implemented as a Python module under `bridge/`.

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -41,6 +41,10 @@ def _env_truthy(name: str, default: str = "0") -> bool:
     return os.getenv(name, default) not in ("0", "false", "False", "")
 
 
+def _strict_adapter_mode() -> bool:
+    return _env_truthy("MEP_STRICT_ADAPTERS", "0")
+
+
 def _env_positive_int(name: str, default: int) -> int:
     raw = os.getenv(name)
     if raw is None:
@@ -1565,6 +1569,9 @@ def cmd_run(args: argparse.Namespace) -> int:
     if args.adapter == "deepseek":
         api_key = (os.getenv("DEEPSEEK_API_KEY") or "").strip()
         if not api_key:
+            if _strict_adapter_mode():
+                print("[mep run] DEEPSEEK_API_KEY not set; strict adapter mode refusing mock fallback")
+                return 2
             print("[mep run] DEEPSEEK_API_KEY not set, falling back to mock")
             adapter: Any = MockAdapter()
         else:

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -265,6 +265,24 @@ class TestRuntimeUx(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIsInstance(runtime_cls.call_args.kwargs["adapter"], mep_runtime.MockAdapter)
 
+    def test_run_with_strict_deepseek_without_api_key_fails_closed(self):
+        args = argparse.Namespace(
+            hub_url="http://hub",
+            ws_url="ws://hub",
+            key_path="C:/tmp/test_key.pem",
+            adapter="deepseek",
+            alias="Hub-Sentinel",
+        )
+        with (
+            patch.dict("os.environ", {"MEP_STRICT_ADAPTERS": "true"}, clear=True),
+            patch("node.mep_runtime._ensure_key_parent"),
+            patch("node.mep_runtime.RuntimeNode") as runtime_cls,
+        ):
+            code = mep_runtime.cmd_run(args)
+
+        self.assertEqual(code, 2)
+        runtime_cls.assert_not_called()
+
     def test_run_with_deepseek_api_key_uses_deepseek_adapter(self):
         args = argparse.Namespace(
             hub_url="http://hub",


### PR DESCRIPTION
## Summary
- add strict adapter mode so reviewer runtimes fail closed when `--adapter deepseek` is requested without `DEEPSEEK_API_KEY`
- keep `MockAdapter` available for local onboarding and smoke runs when strict mode is not enabled
- document the production reviewer runtime safety contract for both `Hub Sentinel` and `Elsaws Bot`

## Why
The live DO incident showed that a missing `DEEPSEEK_API_KEY` can silently downgrade a reviewer runtime into `MockAdapter`, which then emits `MOCK_ADAPTER_OK` placeholder output. That behavior is acceptable for onboarding, but not for production GitHub review bots.

## Validation
- `python -m pytest tests/test_node_runtime.py -q`
