### PR TITLE
Phase 3A: Strict Patch Grounding

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1248,6 +1248,7 @@ class GitHubToMEPBridgeService:
                         "additions": file_additions,
                         "deletions": file_deletions,
                         "changes": changes,
+                        "patch": patch,
                         "patch_excerpt": patch_excerpt,
                     }
                 )
@@ -1739,12 +1740,13 @@ class GitHubToMEPBridgeService:
             if not observation_text and not grounded_tokens:
                 return True, "summary_without_code_evidence"
             observation_tokens = self._extract_identifier_tokens(observation_text)
-            if observation_text and not grounded_tokens and len(observation_tokens) < 2:
-                return True, "generic_observation"
             
             # Phase 3A: Summary-only reviews must anchor to at least one changed token if they mention code
             if observation_tokens and not changed_tokens:
                 return True, "observation_in_context_only"
+
+            if observation_text and not grounded_tokens and len(observation_tokens) < 2:
+                return True, "generic_observation"
         if len(normalized) < 90 and not anchored_paths:
             return True, "too_short"
         if any(re.search(pattern, lowered) for pattern in _WEAK_GITHUB_REVIEW_PATTERNS) and not anchored_paths:

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1541,7 +1541,7 @@ class GitHubToMEPBridgeService:
             lowered = token.lower()
             if len(lowered) >= 4 and lowered not in excluded:
                 tokens.add(lowered)
-        for token in re.findall(r"\b[A-Za-z]+_[A-Za-z0-9_]+\b", text):
+        for token in re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*_[A-Za-z0-9_]+\b", text):
             lowered = token.lower()
             if len(lowered) >= 4 and lowered not in excluded:
                 tokens.add(lowered)
@@ -1557,11 +1557,19 @@ class GitHubToMEPBridgeService:
         return str(match.group(1) or "").strip()
 
     @classmethod
-    def _grounded_code_tokens(cls, text: str, patch_text: str) -> set[str]:
-        if not text or not patch_text:
+    def _grounded_code_tokens(cls, text: str, patch_info: dict[str, str]) -> set[str]:
+        if not text or not patch_info:
             return set()
         tokens = cls._extract_identifier_tokens(text)
-        return {token for token in tokens if token in patch_text.lower()}
+        full_text = patch_info.get("full", "").lower()
+        changed_text = patch_info.get("changes", "").lower()
+
+        # Priority: tokens in actual changes
+        grounded = {token for token in tokens if token in changed_text}
+        # Secondary: tokens in context lines
+        context_grounded = {token for token in tokens if token in full_text}
+
+        return grounded | context_grounded
 
     @staticmethod
     def _is_speculative_finding(text: str) -> bool:
@@ -1611,8 +1619,8 @@ class GitHubToMEPBridgeService:
         return False
 
     @staticmethod
-    def _patch_text_by_path(review_package: dict[str, Any]) -> dict[str, str]:
-        patches: dict[str, str] = {}
+    def _patch_text_by_path(review_package: dict[str, Any]) -> dict[str, dict[str, str]]:
+        patches: dict[str, dict[str, str]] = {}
         changed_files = review_package.get("changed_files")
         if not isinstance(changed_files, list):
             return patches
@@ -1622,7 +1630,14 @@ class GitHubToMEPBridgeService:
             filename = str(item.get("filename") or "").strip()
             patch = str(item.get("patch") or "").strip()
             if filename and patch:
-                patches[filename] = patch.lower()
+                lowered_patch = patch.lower()
+                changes_only = "\n".join(
+                    line[1:] for line in lowered_patch.splitlines() if line.startswith(("+", "-"))
+                )
+                patches[filename] = {
+                    "full": lowered_patch,
+                    "changes": changes_only,
+                }
         return patches
 
     @classmethod
@@ -1644,15 +1659,25 @@ class GitHubToMEPBridgeService:
                 matched_paths = cls._grounded_review_paths(finding_text, expected_paths)
             if not matched_paths:
                 return "finding_without_touched_path"
-            patch_text = "\n".join(patches_by_path.get(path, "") for path in matched_paths if patches_by_path.get(path))
-            if not patch_text:
+            patch_info = {
+                "full": "\n".join(patches_by_path.get(path, {}).get("full", "") for path in matched_paths),
+                "changes": "\n".join(patches_by_path.get(path, {}).get("changes", "") for path in matched_paths),
+            }
+            if not patch_info["full"]:
                 continue
-            if cls._finding_conflicts_with_patch(finding_text, patch_text):
+            if cls._finding_conflicts_with_patch(finding_text, patch_info["full"]):
                 return "ungrounded_finding"
             identifier_tokens = cls._extract_identifier_tokens(finding_text)
-            if identifier_tokens and not any(token in patch_text for token in identifier_tokens):
+            if identifier_tokens and not any(token in patch_info["full"] for token in identifier_tokens):
                 return "ungrounded_finding"
-            grounded_tokens = cls._grounded_code_tokens(finding_text, patch_text)
+            
+            grounded_tokens = cls._grounded_code_tokens(finding_text, patch_info)
+            changed_tokens = {t for t in grounded_tokens if t in patch_info["changes"]}
+            
+            if identifier_tokens and not changed_tokens:
+                # Finding mentions code identifiers, but none of them are in the actual diff (+/-)
+                return "finding_in_context_only"
+
             if cls._is_speculative_finding(finding_text) and len(grounded_tokens) < 2:
                 return "speculative_finding"
         return None
@@ -1678,9 +1703,12 @@ class GitHubToMEPBridgeService:
                         expected_paths.append(text)
         anchored_paths = self._grounded_review_paths(detail or "", expected_paths)
         patches_by_path = self._patch_text_by_path(review_package)
-        anchored_patch_text = "\n".join(
-            patches_by_path.get(path, "") for path in anchored_paths if patches_by_path.get(path)
-        )
+        
+        anchored_patch_info = {
+            "full": "\n".join(patches_by_path.get(path, {}).get("full", "") for path in anchored_paths),
+            "changes": "\n".join(patches_by_path.get(path, {}).get("changes", "") for path in anchored_paths),
+        }
+
         has_findings = "## review findings" in lowered or bool(self._extract_review_finding_entries(detail or ""))
         observation_text = self._extract_observation_text(detail or "")
         has_structured_sections = any(
@@ -1698,11 +1726,14 @@ class GitHubToMEPBridgeService:
         finding_reason = self._verify_review_findings_against_patch(detail or "", review_package, expected_paths)
         if finding_reason:
             return True, finding_reason
-        grounded_tokens = self._grounded_code_tokens(detail or "", anchored_patch_text)
+        
+        grounded_tokens = self._grounded_code_tokens(detail or "", anchored_patch_info)
+        changed_tokens = {t for t in grounded_tokens if t in anchored_patch_info["changes"]}
+
         if has_findings and self._is_speculative_finding(detail or "") and len(grounded_tokens) < 2:
             return True, "speculative_finding"
         if has_findings and anchored_paths and review_package:
-            if self._finding_conflicts_with_patch(detail or "", anchored_patch_text):
+            if self._finding_conflicts_with_patch(detail or "", anchored_patch_info["full"]):
                 return True, "ungrounded_finding"
         if has_structured_sections and not has_findings:
             if not observation_text and not grounded_tokens:
@@ -1710,6 +1741,10 @@ class GitHubToMEPBridgeService:
             observation_tokens = self._extract_identifier_tokens(observation_text)
             if observation_text and not grounded_tokens and len(observation_tokens) < 2:
                 return True, "generic_observation"
+            
+            # Phase 3A: Summary-only reviews must anchor to at least one changed token if they mention code
+            if observation_tokens and not changed_tokens:
+                return True, "observation_in_context_only"
         if len(normalized) < 90 and not anchored_paths:
             return True, "too_short"
         if any(re.search(pattern, lowered) for pattern in _WEAK_GITHUB_REVIEW_PATTERNS) and not anchored_paths:

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -818,6 +818,127 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(status_response.status_code, 200, status_response.text)
         self.assertEqual(len(self.github_session.posts), 1)
 
+    def test_status_callback_suppresses_finding_grounded_only_to_context_lines(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "hub/main.py",
+                    "status": "modified",
+                    "patch": (
+                        " def existing_function():\n"
+                        "     pass\n"
+                        "+def new_function():\n"
+                        "+    pass\n"
+                    ),
+                },
+            ],
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR"),
+            delivery_id="delivery-context-only-finding",
+        )
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "detail": (
+                    "## Review Findings\n\n"
+                    "1. **Hallucinated issue in `existing_function`.** (`hub/main.py`): "
+                    "The `existing_function` is incorrectly implemented."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "finding_in_context_only")
+
+    def test_status_callback_suppresses_observation_grounded_only_to_context_lines(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "hub/main.py",
+                    "status": "modified",
+                    "patch": (
+                        " def important_variable = 42\n"
+                        "+def unrelated_change():\n"
+                        "+    pass\n"
+                    ),
+                },
+            ],
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR"),
+            delivery_id="delivery-context-only-observation",
+        )
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "Observation: This PR touches code near `important_variable`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "observation_in_context_only")
+
+    def test_status_callback_allows_finding_grounded_to_changed_lines(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "hub/main.py",
+                    "status": "modified",
+                    "patch": (
+                        " def existing_function():\n"
+                        "     pass\n"
+                        "+def new_function_with_bug():\n"
+                        "+    x = 1 / 0\n"
+                    ),
+                },
+            ],
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR"),
+            delivery_id="delivery-changed-line-finding",
+        )
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "detail": (
+                    "## Review Findings\n\n"
+                    "1. **Real bug in `new_function_with_bug`.** (`hub/main.py`): "
+                    "Division by zero in the new function."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200)
+        self.assertEqual(len(self.github_session.posts), 1)
+        self.assertIn("Real bug", self.github_session.posts[0]["json"]["body"])
+
     def test_status_callback_suppresses_speculative_finding(self):
         self._set_pr_review_package(
             [


### PR DESCRIPTION
## Summary
- implement strict patch grounding in bridge verifier
- differentiate between full patch context and actual changed lines (+/-)
- suppress findings and observations that anchor only to context lines (hallucinations)
- fix identifier token extraction for tokens with leading underscores

## Validation
- python -m pytest tests/test_github_bridge.py -q