### PR TITLE
Phase 4B: harden review retries and workspace grounding

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -330,6 +330,7 @@ class BridgeStore:
                 action TEXT,
                 telegram_message_id TEXT,
                 instructions TEXT NOT NULL DEFAULT '',
+                github_inputs_json TEXT NOT NULL DEFAULT '{}',
                 retry_count INTEGER NOT NULL DEFAULT 0,
                 created_at REAL NOT NULL,
                 updated_at REAL NOT NULL
@@ -371,6 +372,13 @@ class BridgeStore:
                 """
                 ALTER TABLE bridge_executions
                 ADD COLUMN instructions TEXT NOT NULL DEFAULT ''
+                """
+            )
+        if "github_inputs_json" not in execution_columns:
+            cursor.execute(
+                """
+                ALTER TABLE bridge_executions
+                ADD COLUMN github_inputs_json TEXT NOT NULL DEFAULT '{}'
                 """
             )
         conn.commit()
@@ -433,9 +441,9 @@ class BridgeStore:
             INSERT INTO bridge_executions (
                 bridge_id, context_id, repo_full_name, issue_number, entity_type,
                 target_alias, target_node_id, imperative_verb, intent_type, event_sequence,
-                status, instructions, retry_count, created_at, updated_at
+                status, instructions, github_inputs_json, retry_count, created_at, updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
             """,
             (
                 bridge_id,
@@ -450,6 +458,7 @@ class BridgeStore:
                 event_sequence,
                 "buffered",
                 instructions,
+                json.dumps(event.github_inputs or {}, separators=(",", ":"), sort_keys=True),
                 now,
                 now,
             ),
@@ -1838,6 +1847,17 @@ class GitHubToMEPBridgeService:
         marker = f"{BRIDGE_OUTPUT_MARKER} bridge_id={bridge_id} action={action} -->"
         return f"{detail_text}\n\n{marker}"
 
+    @staticmethod
+    def _execution_github_inputs(execution: dict[str, Any]) -> dict[str, Any]:
+        raw = str(execution.get("github_inputs_json") or "").strip()
+        if not raw:
+            return {}
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+
     def _target_alias_for_execution(self, execution: dict[str, Any]) -> str:
         return str(execution.get("target_alias") or self.config.target_alias or "").strip()
 
@@ -1976,8 +1996,9 @@ class GitHubToMEPBridgeService:
             if resolved_action == "suppressed":
                 retry_count = int(refreshed.get("retry_count") or 0)
                 if retry_count < 2:  # MAX_RETRIES = 2
-                    await self._issue_retry_task(refreshed, suppression_reason)
-                    resolved_action = "retrying"
+                    retry_queued = await self._issue_retry_task(refreshed, suppression_reason)
+                    if retry_queued:
+                        resolved_action = "retrying"
             if resolved_action != update.action:
                 self.store.update_execution(update.bridge_id, action=resolved_action)
                 refreshed = self.store.get_execution(update.bridge_id) or refreshed
@@ -2014,15 +2035,14 @@ class GitHubToMEPBridgeService:
         )
         return {"status": "ok", "bridge_id": update.bridge_id}
 
-    async def _issue_retry_task(self, execution: dict[str, Any], reason: Optional[str]) -> None:
+    async def _issue_retry_task(self, execution: dict[str, Any], reason: Optional[str]) -> bool:
         bridge_id = str(execution["bridge_id"])
         context_id = str(execution["context_id"])
         target_node_id = str(execution["target_node_id"])
         target_alias = str(execution["target_alias"])
         retry_count = int(execution.get("retry_count") or 0) + 1
-        
-        self.store.update_execution(bridge_id, retry_count=retry_count)
-        
+        github_inputs = self._execution_github_inputs(execution)
+
         # Build critique instructions
         critique = f"Your previous review was suppressed because: {reason or 'weak_output'}.\n"
         if reason == "summary_without_code_evidence":
@@ -2051,24 +2071,38 @@ class GitHubToMEPBridgeService:
             intent_type=str(execution["intent_type"]),
             instructions=f"{critique}\n\nOriginal instructions follow:\n{execution.get('instructions', '')}",
             raw_trigger_text="",
+            github_inputs=github_inputs,
             event_sequence=new_sequence,
             bridge_id=bridge_id,
         )
-        
+
         envelope = self._build_interbot_envelope(
             event, target_node_id=target_node_id,
             target_alias=target_alias, bridge_id=bridge_id,
         )
-        
+
         try:
-            await asyncio.to_thread(
+            response = await asyncio.to_thread(
                 self.submission_client.submit_structured_dm,
                 envelope,
                 target_node_id,
                 event.intent_type,
             )
+            status_code = int(response.get("status_code") or 500) if isinstance(response, dict) else 500
+            payload = response.get("json") if isinstance(response, dict) else None
+            if status_code >= 400 or not isinstance(payload, dict):
+                return False
+            task_id = payload.get("task_id")
+            execution_status = str(payload.get("status") or "submitted")
+            self.store.update_execution(
+                bridge_id,
+                status=execution_status,
+                task_id=str(task_id) if task_id else None,
+                retry_count=retry_count,
+            )
+            return True
         except Exception:  # noqa: BLE001
-            pass
+            return False
 
     def _render_status_text(
         self,

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1027,7 +1027,8 @@ class GitHubToMEPBridgeService:
         if entity_type == "pr":
             review_package = self._fetch_pr_review_package(repo_full_name, number)
             review_context = str(review_package.get("instructions_context") or "")
-            for key, value in review_package.items():
+            compact_review_package = self._compact_review_package_for_task_inputs(review_package)
+            for key, value in compact_review_package.items():
                 if key != "instructions_context":
                     github_inputs[key] = value
 
@@ -1162,6 +1163,56 @@ class GitHubToMEPBridgeService:
     def _fetch_pr_review_context(self, repo_full_name: str, number: int) -> str:
         review_package = self._fetch_pr_review_package(repo_full_name, number)
         return str(review_package.get("instructions_context") or "")
+
+    def _compact_review_package_for_task_inputs(self, review_package: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(review_package, dict):
+            return {}
+        compact: dict[str, Any] = {}
+        for key in (
+            "head_sha",
+            "base_sha",
+            "head_ref",
+            "base_ref",
+            "repo_clone_url",
+            "pr_stats",
+            "touched_paths",
+            "touched_tests",
+            "risk_tags",
+        ):
+            value = review_package.get(key)
+            if value not in (None, "", [], {}):
+                compact[key] = value
+
+        instructions_context = str(review_package.get("instructions_context") or "").strip()
+        if instructions_context:
+            compact["instructions_context"] = self._clip_text(instructions_context, 2200)
+
+        changed_files = review_package.get("changed_files")
+        compact_files: list[dict[str, Any]] = []
+        if isinstance(changed_files, list):
+            remaining_patch_budget = 1200
+            for item in changed_files[:6]:
+                if not isinstance(item, dict):
+                    continue
+                filename = str(item.get("filename") or "").strip()
+                if not filename:
+                    continue
+                entry = {
+                    "filename": filename,
+                    "status": str(item.get("status") or "modified").strip(),
+                    "additions": int(item.get("additions") or 0),
+                    "deletions": int(item.get("deletions") or 0),
+                    "changes": int(item.get("changes") or 0),
+                }
+                patch_excerpt = str(item.get("patch_excerpt") or "").strip()
+                if patch_excerpt and remaining_patch_budget > 0:
+                    clipped_excerpt = self._clip_text(patch_excerpt, min(remaining_patch_budget, 240))
+                    entry["patch_excerpt"] = clipped_excerpt
+                    remaining_patch_budget -= len(clipped_excerpt)
+                compact_files.append(entry)
+        if compact_files:
+            compact["changed_files"] = compact_files
+        return compact
 
     @staticmethod
     def _is_test_path(path: str) -> bool:

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import copy
 import json
 import os
 import re
@@ -418,6 +419,14 @@ def _system_prompt_for_task(
     review_max_chars: int,
 ) -> str:
     if _task_requires_review_prompt(task_data):
+        github_inputs = _review_github_inputs(task_data)
+        workspace_path = str(github_inputs.get("local_workspace_path") or "").strip()
+        workspace_hint = ""
+        if workspace_path:
+            workspace_hint = (
+                f" A checked-out local workspace is available at `{workspace_path}` and any embedded workspace excerpts "
+                "come from the PR head commit; treat that material as authoritative code context."
+            )
         return (
             "You are a senior code reviewer for the MEP (Miao Exchange Protocol) project. "
             "Review the provided GitHub PR context and return ONLY a JSON object with this schema: "
@@ -430,7 +439,7 @@ def _system_prompt_for_task(
             "Only include a finding when it is directly supported by the provided diff, file list, PR description, or patch excerpts. "
             "Do not speculate about unseen code, do not ask for more context, and do not include chain-of-thought or any text outside the JSON object. "
             "If the change looks good, keep findings empty and use summary to say what you verified, keep observation concrete, and set approval_recommendation to approve or comment. Keep the "
-            f"response within {review_max_chars} characters."
+            f"response within {review_max_chars} characters.{workspace_hint}"
         )
     return (
         "You are a helpful MEP (Miao Exchange Protocol) bot. "
@@ -777,6 +786,55 @@ class WorkspaceManager:
             return False, f"checkout failed: {out}"
 
         return True, workspace_path
+
+    @staticmethod
+    def _resolve_repo_file(workspace_path: str, relative_path: str) -> Optional[str]:
+        normalized_relative = str(relative_path or "").replace("\\", "/").strip("/")
+        if not normalized_relative:
+            return None
+        candidate = os.path.abspath(os.path.join(workspace_path, *normalized_relative.split("/")))
+        try:
+            if os.path.commonpath([os.path.abspath(workspace_path), candidate]) != os.path.abspath(workspace_path):
+                return None
+        except ValueError:
+            return None
+        return candidate
+
+    def build_review_context(
+        self,
+        workspace_path: str,
+        touched_paths: list[str],
+        *,
+        max_files: int = 3,
+        max_chars: int = 2200,
+    ) -> str:
+        if not workspace_path or not isinstance(touched_paths, list):
+            return ""
+        sections = [f"Local workspace path: {workspace_path}", "Workspace file excerpts:"]
+        remaining = max_chars
+        added = 0
+        for path in touched_paths:
+            if added >= max_files or remaining <= 180:
+                break
+            resolved = self._resolve_repo_file(workspace_path, str(path or ""))
+            if not resolved or not os.path.isfile(resolved):
+                continue
+            try:
+                with open(resolved, "r", encoding="utf-8", errors="replace") as handle:
+                    content = handle.read()
+            except OSError:
+                continue
+            content = content.strip()
+            if not content:
+                continue
+            excerpt = content[: min(remaining, 700)].strip()
+            block = f"- {path}\n{excerpt}"
+            sections.append(block)
+            remaining -= len(block) + 2
+            added += 1
+        if added == 0:
+            return ""
+        return "\n\n".join(sections)
 
 
 class RuntimeNode:
@@ -1423,28 +1481,53 @@ class RuntimeNode:
         task_id = str(task_data.get("id") or "")
         payload = str(task_data.get("payload") or "")
         instructions = payload
+        adapter_task_data = copy.deepcopy(task_data)
         interbot_message: Optional[dict[str, Any]] = None
         if MEPClient is not None:
             instructions, interbot_message = MEPClient.extract_interbot_instructions(payload)
-        
+        workspace_path = ""
+
         # Phase 4: Sync workspace if this is a GitHub PR task
         if interbot_message:
-            github_inputs = interbot_message.get("task", {}).get("inputs", {}).get("github", {})
+            task = interbot_message.get("task") if isinstance(interbot_message.get("task"), dict) else {}
+            inputs = task.get("inputs") if isinstance(task.get("inputs"), dict) else {}
+            github_inputs = dict(inputs.get("github") or {}) if isinstance(inputs.get("github"), dict) else {}
             repo_url = github_inputs.get("repo_clone_url")
             head_sha = github_inputs.get("head_sha")
             head_ref = github_inputs.get("head_ref")
             bridge_id = interbot_message.get("trace_id") or interbot_message.get("task", {}).get("inputs", {}).get("bridge_metadata", {}).get("bridge_id")
-            
+
             if repo_url and head_sha and head_ref:
                 print(f"[mep workspace] auto-syncing for task={task_id[:8]} bridge_id={bridge_id}")
                 ok, path_or_err = await asyncio.to_thread(self.workspace.sync_pr_workspace, repo_url, head_sha, head_ref, bridge_id=bridge_id)
                 if ok:
                     print(f"[mep workspace] synced to {path_or_err}")
+                    workspace_path = path_or_err
+                    github_inputs["local_workspace_path"] = workspace_path
+                    touched_paths = github_inputs.get("touched_paths") if isinstance(github_inputs.get("touched_paths"), list) else []
+                    workspace_context = await asyncio.to_thread(
+                        self.workspace.build_review_context,
+                        workspace_path,
+                        touched_paths,
+                    )
+                    if workspace_context:
+                        instructions = f"{instructions}\n\nAdditional local workspace context:\n{workspace_context}"
                 else:
                     print(f"[mep workspace] sync failed: {path_or_err}")
                     # We continue anyway, but the adapter might be working on stale code
 
-        result = self.adapter.generate_reply(instructions, task_data)
+            task_copy = copy.deepcopy(task) if isinstance(task, dict) else {}
+            inputs_copy = copy.deepcopy(inputs) if isinstance(inputs, dict) else {}
+            inputs_copy["github"] = github_inputs
+            if inputs_copy:
+                task_copy["inputs"] = inputs_copy
+            if task_copy:
+                adapter_task_data["task"] = task_copy
+            intent = interbot_message.get("intent")
+            if isinstance(intent, dict):
+                adapter_task_data["intent"] = copy.deepcopy(intent)
+
+        result = self.adapter.generate_reply(instructions, adapter_task_data)
         if self._bridge_eligible_interbot_message(task_data, interbot_message):
             bridged = await self._attempt_live_call_bridge(task_data, interbot_message, result)
             if bridged:

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -8,6 +8,7 @@ import time
 import asyncio
 import unittest
 from typing import Any
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
@@ -563,6 +564,81 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(self.service.github_writeback_metrics["attempts"], 1)
         self.assertEqual(self.service.github_writeback_metrics["suppressed_weak_reviews"], 1)
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "generic_summary")
+
+    def test_retry_task_preserves_original_github_inputs(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "bridge/github_to_mep.py",
+                    "status": "modified",
+                    "additions": 4,
+                    "deletions": 1,
+                    "changes": 5,
+                    "patch": (
+                        "@@ -1,2 +1,5 @@\n"
+                        "+def preserve_retry_context():\n"
+                        "+    return True\n"
+                    ),
+                }
+            ],
+            pr_body="Ensures retry submissions keep the original review package metadata.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=234),
+            delivery_id="delivery-retry-context",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "detail": "The change looks fine and focused.",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.submission.calls), 2)
+        retry_envelope = self.submission.calls[-1]["envelope"]
+        github_inputs = retry_envelope["task"]["inputs"]["github"]
+        self.assertEqual(github_inputs["head_sha"], "headsha123")
+        self.assertEqual(github_inputs["head_ref"], "headref")
+        self.assertEqual(github_inputs["repo_clone_url"], "https://github.com/example/repo.git")
+        self.assertEqual(github_inputs["touched_paths"], ["bridge/github_to_mep.py"])
+
+    def test_status_callback_keeps_action_suppressed_when_retry_submit_fails(self):
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=235),
+            delivery_id="delivery-retry-fail",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        with patch.object(self.submission, "submit_structured_dm", side_effect=RuntimeError("retry submit failed")):
+            status_response = self.client.post(
+                "/bridge/status",
+                json={
+                    "bridge_id": bridge_id,
+                    "status": "completed",
+                    "target_node_id": "node_target",
+                    "detail": "Too short review",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertIn("action: suppressed", self.notifier.calls[-1]["text"])
+        execution = self.store.get_execution(bridge_id)
+        self.assertIsNotNone(execution)
+        self.assertEqual(execution["action"], "suppressed")
+        self.assertEqual(execution["retry_count"], 0)
 
     def test_status_callback_stops_retrying_after_max_retries(self):
         response = self._post_webhook(

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -611,6 +611,52 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(github_inputs["repo_clone_url"], "https://github.com/example/repo.git")
         self.assertEqual(github_inputs["touched_paths"], ["bridge/github_to_mep.py"])
 
+    def test_pr_review_submission_compacts_review_package_payload(self):
+        large_patch = "@@ -1,1 +1,120 @@\n" + "\n".join(
+            f"+line_{index:03d} = 'payload'" for index in range(120)
+        )
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "bridge/github_to_mep.py",
+                    "status": "modified",
+                    "additions": 120,
+                    "deletions": 1,
+                    "changes": 121,
+                    "patch": large_patch,
+                },
+                {
+                    "filename": "tests/test_github_bridge.py",
+                    "status": "modified",
+                    "additions": 120,
+                    "deletions": 1,
+                    "changes": 121,
+                    "patch": large_patch,
+                },
+            ],
+            pr_body="Large review payload regression.",
+        )
+
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=236),
+            delivery_id="delivery-compact-review-package",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self._flush_context(response.json()["context_id"])
+        self.assertEqual(len(self.submission.calls), 1)
+
+        envelope = self.submission.calls[0]["envelope"]
+        github_inputs = envelope["task"]["inputs"]["github"]
+        serialized = json.dumps(envelope)
+        instructions = envelope["task"]["instructions"]
+
+        self.assertLess(len(serialized), 20_000)
+        self.assertIn("changed_files", github_inputs)
+        self.assertNotIn("patch", github_inputs["changed_files"][0])
+        self.assertIn("patch_excerpt", github_inputs["changed_files"][0])
+        self.assertNotIn("instructions_context", github_inputs)
+        self.assertLessEqual(len(instructions), 3803)
+
     def test_status_callback_keeps_action_suppressed_when_retry_submit_fails(self):
         response = self._post_webhook(
             _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=235),

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -593,7 +593,12 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         ):
             asyncio.run(node.process_task(task_data))
 
-        adapter_mock.assert_called_once_with("Use only this instruction text.", task_data)
+        adapter_mock.assert_called_once()
+        self.assertEqual(adapter_mock.call_args.args[0], "Use only this instruction text.")
+        adapter_task_data = adapter_mock.call_args.args[1]
+        self.assertEqual(adapter_task_data["payload"], task_data["payload"])
+        self.assertEqual(adapter_task_data["task"]["instructions"], "Use only this instruction text.")
+        self.assertEqual(adapter_task_data["intent"]["type"], "chat.request")
         complete_mock.assert_called_once_with("task_interbot", "reply")
 
     def test_process_task_reports_bridge_status_when_github_bridge_metadata_is_present(self):
@@ -641,6 +646,47 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         self.assertEqual(request_mock.call_args.kwargs["json_body"]["action"], "approved")
         self.assertEqual(request_mock.call_args.kwargs["json_body"]["detail"], "Looks good to me.")
         self.assertEqual(request_mock.call_args.kwargs["headers"]["Authorization"], "Bearer status-token")
+
+    def test_process_task_appends_synced_workspace_context_to_review_input(self):
+        node = _runtime_node()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "bridge"), exist_ok=True)
+            with open(os.path.join(tmpdir, "bridge", "github_to_mep.py"), "w", encoding="utf-8") as handle:
+                handle.write("def live_sync_context():\n    return True\n")
+
+            task_data = TestRuntimeReviewPrompts._bridge_review_task_data()
+            payload = json.loads(task_data["payload"])
+            payload["task"]["inputs"]["github"].update(
+                {
+                    "repo_clone_url": "https://github.com/example/repo.git",
+                    "head_sha": "abc12345",
+                    "head_ref": "feature/test",
+                }
+            )
+            task_data["payload"] = json.dumps(payload)
+
+            with (
+                patch.object(node.workspace, "sync_pr_workspace", return_value=(True, tmpdir)) as sync_mock,
+                patch.object(node.adapter, "generate_reply", return_value="reply") as adapter_mock,
+                patch.object(node, "complete") as complete_mock,
+            ):
+                asyncio.run(node.process_task(task_data))
+
+        sync_mock.assert_called_once_with(
+            "https://github.com/example/repo.git",
+            "abc12345",
+            "feature/test",
+            bridge_id="trace-bridge-review",
+        )
+        instructions, adapter_task_data = adapter_mock.call_args.args
+        self.assertIn("Additional local workspace context:", instructions)
+        self.assertIn("Local workspace path:", instructions)
+        self.assertIn("live_sync_context", instructions)
+        self.assertEqual(
+            adapter_task_data["task"]["inputs"]["github"]["local_workspace_path"],
+            tmpdir,
+        )
+        complete_mock.assert_called_once_with("task_bridge_review", "reply")
 
     def test_process_task_live_bridge_sends_frame_and_settles_when_call_is_accepted(self):
         node = _runtime_node()


### PR DESCRIPTION
## Summary
- preserve original GitHub PR metadata across retry submissions
- only mark executions as retrying after retry submission succeeds
- feed synced workspace excerpts into review tasks so Phase 4 checkout data is actually used

## Testing
- python -m pytest tests/test_github_bridge.py tests/test_node_runtime.py -q