### PR TITLE
Phase 4C: add review quality scoring and approval gate

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -671,6 +671,8 @@ class GitHubToMEPBridgeService:
             "last_detail_preview": None,
             "last_suppressed_reason": None,
             "last_suppressed_at": None,
+            "last_quality_score": 0,
+            "last_quality_reasons": [],
         }
 
     def _require_runtime_config(self) -> None:
@@ -1734,6 +1736,129 @@ class GitHubToMEPBridgeService:
                 }
         return patches
 
+    def _build_review_snapshot(self, execution: dict[str, Any], detail: Optional[str]) -> dict[str, Any]:
+        normalized = re.sub(r"\s+", " ", str(detail or "").strip())
+        lowered = normalized.lower()
+        review_package: dict[str, Any] = {}
+        entity_type = str(execution.get("entity_type") or "").strip().lower()
+        repo_full_name = str(execution.get("repo_full_name") or "").strip()
+        number = int(execution.get("issue_number") or 0)
+        if entity_type == "pr" and repo_full_name and number > 0:
+            review_package = self._fetch_pr_review_package(repo_full_name, number)
+        expected_paths: list[str] = []
+        expected_tests: list[str] = []
+        for key in ("touched_paths", "touched_tests"):
+            values = review_package.get(key)
+            if isinstance(values, list):
+                for value in values:
+                    text = str(value or "").strip()
+                    if not text:
+                        continue
+                    if text not in expected_paths:
+                        expected_paths.append(text)
+                    if key == "touched_tests" and text not in expected_tests:
+                        expected_tests.append(text)
+        anchored_paths = self._grounded_review_paths(detail or "", expected_paths)
+        anchored_tests = self._grounded_review_paths(detail or "", expected_tests)
+        patches_by_path = self._patch_text_by_path(review_package)
+        anchored_patch_info = {
+            "full": "\n".join(patches_by_path.get(path, {}).get("full", "") for path in anchored_paths),
+            "changes": "\n".join(patches_by_path.get(path, {}).get("changes", "") for path in anchored_paths),
+        }
+        has_findings = "## review findings" in lowered or bool(self._extract_review_finding_entries(detail or ""))
+        observation_text = self._extract_observation_text(detail or "")
+        has_structured_sections = any(
+            snippet in lowered
+            for snippet in (
+                "## review summary",
+                "## review findings",
+                "observation:",
+                "touched paths reviewed:",
+                "tests reviewed:",
+            )
+        )
+        grounded_tokens = self._grounded_code_tokens(detail or "", anchored_patch_info)
+        changed_tokens = {token for token in grounded_tokens if token in anchored_patch_info["changes"]}
+        mentions_tests = bool(anchored_tests)
+        if not mentions_tests and expected_tests:
+            mentions_tests = bool(re.search(r"\btest(?:s|ed|ing)?\b", lowered))
+        return {
+            "normalized": normalized,
+            "lowered": lowered,
+            "review_package": review_package,
+            "expected_paths": expected_paths,
+            "expected_tests": expected_tests,
+            "anchored_paths": anchored_paths,
+            "anchored_tests": anchored_tests,
+            "patches_by_path": patches_by_path,
+            "anchored_patch_info": anchored_patch_info,
+            "has_findings": has_findings,
+            "observation_text": observation_text,
+            "has_structured_sections": has_structured_sections,
+            "grounded_tokens": grounded_tokens,
+            "changed_tokens": changed_tokens,
+            "mentions_tests": mentions_tests,
+        }
+
+    def _score_review_quality(self, snapshot: dict[str, Any], *, action: str) -> tuple[int, list[str]]:
+        score = 0
+        reasons: list[str] = []
+        anchored_paths = snapshot.get("anchored_paths") or set()
+        changed_tokens = snapshot.get("changed_tokens") or set()
+        grounded_tokens = snapshot.get("grounded_tokens") or set()
+        has_findings = bool(snapshot.get("has_findings"))
+        observation_text = str(snapshot.get("observation_text") or "").strip()
+        expected_tests = snapshot.get("expected_tests") or []
+        mentions_tests = bool(snapshot.get("mentions_tests"))
+        lowered = str(snapshot.get("lowered") or "")
+
+        if anchored_paths:
+            score += 1
+            reasons.append("touched_path_anchor")
+        if len(anchored_paths) >= 2:
+            score += 1
+            reasons.append("multi_path_anchor")
+        if changed_tokens:
+            score += 1
+            reasons.append("changed_code_evidence")
+        if len(changed_tokens) >= 2:
+            score += 1
+            reasons.append("multiple_changed_identifiers")
+        if has_findings:
+            score += 2
+            reasons.append("concrete_findings")
+        elif observation_text and grounded_tokens:
+            score += 1
+            reasons.append("grounded_observation")
+        if mentions_tests:
+            score += 1
+            reasons.append("test_awareness")
+        elif not expected_tests and re.search(r"\btest(?:s|ed|ing)?\b", lowered):
+            score += 1
+            reasons.append("general_test_awareness")
+        if action == "approved" and "no risky changes" in lowered:
+            score += 1
+            reasons.append("explicit_low_risk_claim")
+        return score, reasons
+
+    def _approval_quality_failure(self, snapshot: dict[str, Any], score: int) -> Optional[str]:
+        if snapshot.get("has_findings"):
+            return "approval_contains_findings"
+        if not snapshot.get("anchored_paths"):
+            return "approval_without_touched_path_anchor"
+        if not snapshot.get("changed_tokens"):
+            return "approval_without_changed_code_evidence"
+        if snapshot.get("expected_tests") and not snapshot.get("mentions_tests"):
+            return "approval_without_test_awareness"
+        if score < 4:
+            return "approval_below_quality_bar"
+        return None
+
+    def _record_review_quality(self, score: int, reasons: list[str]) -> None:
+        metrics = self.github_writeback_metrics
+        metrics["last_quality_score"] = int(score)
+        metrics["last_quality_reasons"] = list(reasons)
+
     @classmethod
     def _verify_review_findings_against_patch(
         cls,
@@ -1776,53 +1901,32 @@ class GitHubToMEPBridgeService:
                 return "speculative_finding"
         return None
 
-    def _classify_review_writeback_detail(self, execution: dict[str, Any], detail: Optional[str]) -> tuple[bool, str]:
-        normalized = re.sub(r"\s+", " ", str(detail or "").strip())
+    def _classify_review_writeback_detail(
+        self,
+        execution: dict[str, Any],
+        detail: Optional[str],
+        *,
+        snapshot: Optional[dict[str, Any]] = None,
+    ) -> tuple[bool, str]:
+        snapshot = snapshot or self._build_review_snapshot(execution, detail)
+        normalized = str(snapshot.get("normalized") or "")
         if not normalized:
             return True, "empty_detail"
-        lowered = normalized.lower()
-        review_package: dict[str, Any] = {}
-        entity_type = str(execution.get("entity_type") or "").strip().lower()
-        repo_full_name = str(execution.get("repo_full_name") or "").strip()
-        number = int(execution.get("issue_number") or 0)
-        if entity_type == "pr" and repo_full_name and number > 0:
-            review_package = self._fetch_pr_review_package(repo_full_name, number)
-        expected_paths: list[str] = []
-        for key in ("touched_paths", "touched_tests"):
-            values = review_package.get(key)
-            if isinstance(values, list):
-                for value in values:
-                    text = str(value or "").strip()
-                    if text and text not in expected_paths:
-                        expected_paths.append(text)
-        anchored_paths = self._grounded_review_paths(detail or "", expected_paths)
-        patches_by_path = self._patch_text_by_path(review_package)
-        
-        anchored_patch_info = {
-            "full": "\n".join(patches_by_path.get(path, {}).get("full", "") for path in anchored_paths),
-            "changes": "\n".join(patches_by_path.get(path, {}).get("changes", "") for path in anchored_paths),
-        }
-
-        has_findings = "## review findings" in lowered or bool(self._extract_review_finding_entries(detail or ""))
-        observation_text = self._extract_observation_text(detail or "")
-        has_structured_sections = any(
-            snippet in lowered
-            for snippet in (
-                "## review summary",
-                "## review findings",
-                "observation:",
-                "touched paths reviewed:",
-                "tests reviewed:",
-            )
-        )
+        lowered = str(snapshot.get("lowered") or "")
+        review_package = snapshot.get("review_package") or {}
+        expected_paths = list(snapshot.get("expected_paths") or [])
+        anchored_paths = snapshot.get("anchored_paths") or set()
+        anchored_patch_info = snapshot.get("anchored_patch_info") or {"full": "", "changes": ""}
+        has_findings = bool(snapshot.get("has_findings"))
+        observation_text = str(snapshot.get("observation_text") or "")
+        has_structured_sections = bool(snapshot.get("has_structured_sections"))
+        grounded_tokens = snapshot.get("grounded_tokens") or set()
+        changed_tokens = snapshot.get("changed_tokens") or set()
         if has_findings and not anchored_paths:
             return True, "finding_without_touched_path"
         finding_reason = self._verify_review_findings_against_patch(detail or "", review_package, expected_paths)
         if finding_reason:
             return True, finding_reason
-        
-        grounded_tokens = self._grounded_code_tokens(detail or "", anchored_patch_info)
-        changed_tokens = {t for t in grounded_tokens if t in anchored_patch_info["changes"]}
 
         if has_findings and self._is_speculative_finding(detail or "") and len(grounded_tokens) < 2:
             return True, "speculative_finding"
@@ -1998,7 +2102,13 @@ class GitHubToMEPBridgeService:
         review_action = entity_type == "pr" and action in review_events
         self._record_github_writeback_attempt(action, update.detail)
         if review_action:
-            suppress, reason = self._classify_review_writeback_detail(execution, update.detail)
+            snapshot = self._build_review_snapshot(execution, update.detail)
+            suppress, reason = self._classify_review_writeback_detail(execution, update.detail, snapshot=snapshot)
+            score, reasons = self._score_review_quality(snapshot, action=action)
+            self._record_review_quality(score, reasons)
+            if not suppress and action == "approved":
+                reason = self._approval_quality_failure(snapshot, score)
+                suppress = reason is not None
             if suppress:
                 self._record_github_writeback_suppression(
                     bridge_id=str(execution.get("bridge_id") or update.bridge_id),
@@ -2100,6 +2210,12 @@ class GitHubToMEPBridgeService:
             critique += "Please provide a more detailed review with concrete code identifiers (variables, functions) found in the actual PR diff."
         elif reason in ("finding_in_context_only", "observation_in_context_only"):
             critique += "The code identifiers you mentioned are in the file context but NOT in the actual changed lines (+/-). Please focus your review on the actual changes."
+        elif reason == "approval_without_changed_code_evidence":
+            critique += "You attempted to approve the PR without citing changed-line code evidence. Reference concrete identifiers from the actual diff before approving."
+        elif reason == "approval_without_test_awareness":
+            critique += "You attempted to approve the PR without acknowledging the relevant changed tests. Re-check the diff and mention the test coverage you relied on."
+        elif reason == "approval_below_quality_bar":
+            critique += "You attempted to approve the PR with insufficient evidence density. Add concrete changed-line evidence and test/risk coverage before approving."
         else:
             critique += "Please re-examine the PR diff and provide a higher-quality review anchored to the actual changes."
             

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1177,6 +1177,7 @@ class GitHubToMEPBridgeService:
             "base_ref",
             "repo_clone_url",
             "pr_stats",
+            "ci_checks",
             "touched_paths",
             "touched_tests",
             "risk_tags",
@@ -1295,12 +1296,35 @@ class GitHubToMEPBridgeService:
         head_ref = str(head.get("ref") or "").strip()
         base_ref = str(base.get("ref") or "").strip()
         repo_clone_url = str((head.get("repo") or {}).get("clone_url") or "").strip()
+        check_runs_payload: Any = {}
+        if head_sha:
+            try:
+                check_runs_response = self.github_session.get(
+                    f"https://api.github.com/repos/{repo_full_name}/commits/{head_sha}/check-runs?per_page=20",
+                    headers=headers,
+                    timeout=20,
+                )
+                if check_runs_response.status_code == 200:
+                    check_runs_payload = check_runs_response.json()
+            except Exception:
+                check_runs_payload = {}
+        ci_checks = self._summarize_pr_checks(check_runs_payload)
 
         if head_sha or base_sha:
             sections.append(
                 "Revision identity: "
                 f"head_sha={head_sha or 'unknown'}, base_sha={base_sha or 'unknown'}, "
                 f"head_ref={head_ref or 'unknown'}, base_ref={base_ref or 'unknown'}"
+            )
+        if ci_checks.get("has_checks"):
+            check_lines = [
+                f"- {item.get('name')}: {item.get('state')}"
+                for item in ci_checks.get("summary", [])
+                if isinstance(item, dict)
+            ]
+            sections.append(
+                "PR checks: "
+                f"state={ci_checks.get('state')}\n" + "\n".join(check_lines)
             )
         sections.append(
             "PR stats: "
@@ -1372,6 +1396,7 @@ class GitHubToMEPBridgeService:
                 "deletions": deletions,
                 "commits": commits,
             },
+            "ci_checks": ci_checks,
             "touched_paths": touched_paths,
             "touched_tests": touched_tests,
             "risk_tags": risk_tags,
@@ -1736,6 +1761,58 @@ class GitHubToMEPBridgeService:
                 }
         return patches
 
+    @staticmethod
+    def _summarize_pr_checks(check_runs_payload: Any) -> dict[str, Any]:
+        raw_runs = check_runs_payload.get("check_runs") if isinstance(check_runs_payload, dict) else []
+        if not isinstance(raw_runs, list):
+            raw_runs = []
+        summary: list[dict[str, str]] = []
+        pending_count = 0
+        failing_count = 0
+        successful_count = 0
+        for item in raw_runs[:8]:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name") or "unnamed-check").strip() or "unnamed-check"
+            status = str(item.get("status") or "").strip().lower()
+            conclusion = str(item.get("conclusion") or "").strip().lower()
+            if status and status != "completed":
+                state = status
+                pending_count += 1
+            elif conclusion in {"success", "neutral", "skipped"}:
+                state = conclusion or "success"
+                successful_count += 1
+            else:
+                state = conclusion or "unknown"
+                failing_count += 1
+            summary.append(
+                {
+                    "name": name,
+                    "status": status,
+                    "conclusion": conclusion,
+                    "state": state,
+                }
+            )
+        if summary:
+            if pending_count:
+                overall_state = "pending"
+            elif failing_count:
+                overall_state = "failing"
+            elif successful_count == len(summary):
+                overall_state = "green"
+            else:
+                overall_state = "unknown"
+        else:
+            overall_state = "none"
+        return {
+            "has_checks": bool(summary),
+            "state": overall_state,
+            "all_green": bool(summary) and pending_count == 0 and failing_count == 0,
+            "pending_count": pending_count,
+            "failing_count": failing_count,
+            "summary": summary,
+        }
+
     def _build_review_snapshot(self, execution: dict[str, Any], detail: Optional[str]) -> dict[str, Any]:
         normalized = re.sub(r"\s+", " ", str(detail or "").strip())
         lowered = normalized.lower()
@@ -1786,6 +1863,7 @@ class GitHubToMEPBridgeService:
             "normalized": normalized,
             "lowered": lowered,
             "review_package": review_package,
+            "ci_checks": review_package.get("ci_checks") or {},
             "expected_paths": expected_paths,
             "expected_tests": expected_tests,
             "anchored_paths": anchored_paths,
@@ -1842,6 +1920,12 @@ class GitHubToMEPBridgeService:
         return score, reasons
 
     def _approval_quality_failure(self, snapshot: dict[str, Any], score: int) -> Optional[str]:
+        ci_checks = snapshot.get("ci_checks") or {}
+        if ci_checks.get("has_checks"):
+            if ci_checks.get("state") == "pending":
+                return "approval_checks_pending"
+            if not ci_checks.get("all_green"):
+                return "approval_checks_not_green"
         if snapshot.get("has_findings"):
             return "approval_contains_findings"
         if not snapshot.get("anchored_paths"):
@@ -1858,6 +1942,10 @@ class GitHubToMEPBridgeService:
         metrics = self.github_writeback_metrics
         metrics["last_quality_score"] = int(score)
         metrics["last_quality_reasons"] = list(reasons)
+
+    @staticmethod
+    def _suppression_reason_allows_retry(reason: Optional[str]) -> bool:
+        return reason not in {"approval_checks_pending", "approval_checks_not_green"}
 
     @classmethod
     def _verify_review_findings_against_patch(
@@ -2156,7 +2244,7 @@ class GitHubToMEPBridgeService:
             resolved_action, suppression_reason = self._write_back_to_github(refreshed, update)
             if resolved_action == "suppressed":
                 retry_count = int(refreshed.get("retry_count") or 0)
-                if retry_count < 2:  # MAX_RETRIES = 2
+                if retry_count < 2 and self._suppression_reason_allows_retry(suppression_reason):  # MAX_RETRIES = 2
                     retry_queued = await self._issue_retry_task(refreshed, suppression_reason)
                     if retry_queued:
                         resolved_action = "retrying"
@@ -2216,6 +2304,10 @@ class GitHubToMEPBridgeService:
             critique += "You attempted to approve the PR without acknowledging the relevant changed tests. Re-check the diff and mention the test coverage you relied on."
         elif reason == "approval_below_quality_bar":
             critique += "You attempted to approve the PR with insufficient evidence density. Add concrete changed-line evidence and test/risk coverage before approving."
+        elif reason == "approval_checks_pending":
+            critique += "You attempted to approve the PR before its GitHub checks finished. Do not approve while CI is still pending or running."
+        elif reason == "approval_checks_not_green":
+            critique += "You attempted to approve the PR even though one or more GitHub checks are failing. Do not approve until the checks are green."
         else:
             critique += "Please re-examine the PR diff and provide a higher-quality review anchored to the actual changes."
             

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -602,7 +602,6 @@ def _render_structured_review_with_task_data(
     if not isinstance(parsed, dict):
         return ""
     github_inputs = _review_github_inputs(task_data or {})
-    approval_mode = _task_is_approval_review(task_data or {})
     summary = _clean_review_text(parsed.get("summary"), max_chars=220)
     if _is_weak_review_text(summary):
         summary = ""
@@ -616,7 +615,6 @@ def _render_structured_review_with_task_data(
     if not tests_reviewed:
         tests_reviewed = _clean_review_list(github_inputs.get("touched_tests"), max_items=3, max_chars=120)
     verified_identifiers = _clean_review_list(parsed.get("verified_identifiers"), max_items=4, max_chars=80)
-    approval_recommendation = str(parsed.get("approval_recommendation") or "").strip().lower()
     findings_raw = parsed.get("findings")
     findings: list[str] = []
     if isinstance(findings_raw, list):

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -393,6 +393,18 @@ def _review_github_inputs(task_data: dict[str, Any]) -> dict[str, Any]:
     return github_inputs if isinstance(github_inputs, dict) else {}
 
 
+def _review_intent_type(task_data: dict[str, Any]) -> str:
+    interbot_message = _interbot_message_from_task_data(task_data)
+    intent: Any = task_data.get("intent")
+    if not isinstance(intent, dict) and isinstance(interbot_message, dict):
+        intent = interbot_message.get("intent")
+    return str(intent.get("type") or "").strip().lower() if isinstance(intent, dict) else ""
+
+
+def _task_is_approval_review(task_data: dict[str, Any]) -> bool:
+    return _review_intent_type(task_data) == "code.review.approve"
+
+
 def _clean_review_list(values: Any, *, max_items: int, max_chars: int) -> list[str]:
     if not isinstance(values, list):
         return []
@@ -420,6 +432,7 @@ def _system_prompt_for_task(
 ) -> str:
     if _task_requires_review_prompt(task_data):
         github_inputs = _review_github_inputs(task_data)
+        approval_mode = _task_is_approval_review(task_data)
         workspace_path = str(github_inputs.get("local_workspace_path") or "").strip()
         workspace_hint = ""
         if workspace_path:
@@ -427,19 +440,28 @@ def _system_prompt_for_task(
                 f" A checked-out local workspace is available at `{workspace_path}` and any embedded workspace excerpts "
                 "come from the PR head commit; treat that material as authoritative code context."
             )
+        approval_hint = ""
+        if approval_mode:
+            approval_hint = (
+                " Approval mode is active. Only use `approval_recommendation: \"approve\"` when you can cite at least two exact identifiers from changed lines "
+                "in `verified_identifiers`, mention the changed tests when any are provided, and explicitly state the scope is low-risk. "
+                "If you cannot satisfy that evidence bar, use `comment` instead of `approve`."
+            )
         return (
             "You are a senior code reviewer for the MEP (Miao Exchange Protocol) project. "
             "Review the provided GitHub PR context and return ONLY a JSON object with this schema: "
             '{"summary": string, "observation": string, "touched_paths": [string], "tests_reviewed": [string], '
+            '"verified_identifiers": [string], '
             '"findings": [{"file": string, "issue": string, "rationale": string}], '
             '"approval_recommendation": "approve" | "comment" | "request_changes" | "abstain"}. '
             "Use at most 2 findings. "
             "Use `observation` for one concrete non-blocking review note tied to the actual diff. "
+            "Use `verified_identifiers` for exact function/variable/class names copied from changed lines in the supplied diff or workspace excerpts. "
             "Prefer real touched files and tests from the supplied GitHub inputs for `touched_paths` and `tests_reviewed`. "
             "Only include a finding when it is directly supported by the provided diff, file list, PR description, or patch excerpts. "
             "Do not speculate about unseen code, do not ask for more context, and do not include chain-of-thought or any text outside the JSON object. "
             "If the change looks good, keep findings empty and use summary to say what you verified, keep observation concrete, and set approval_recommendation to approve or comment. Keep the "
-            f"response within {review_max_chars} characters.{workspace_hint}"
+            f"response within {review_max_chars} characters.{approval_hint}{workspace_hint}"
         )
     return (
         "You are a helpful MEP (Miao Exchange Protocol) bot. "
@@ -580,6 +602,7 @@ def _render_structured_review_with_task_data(
     if not isinstance(parsed, dict):
         return ""
     github_inputs = _review_github_inputs(task_data or {})
+    approval_mode = _task_is_approval_review(task_data or {})
     summary = _clean_review_text(parsed.get("summary"), max_chars=220)
     if _is_weak_review_text(summary):
         summary = ""
@@ -592,6 +615,8 @@ def _render_structured_review_with_task_data(
     tests_reviewed = _clean_review_list(parsed.get("tests_reviewed"), max_items=3, max_chars=120)
     if not tests_reviewed:
         tests_reviewed = _clean_review_list(github_inputs.get("touched_tests"), max_items=3, max_chars=120)
+    verified_identifiers = _clean_review_list(parsed.get("verified_identifiers"), max_items=4, max_chars=80)
+    approval_recommendation = str(parsed.get("approval_recommendation") or "").strip().lower()
     findings_raw = parsed.get("findings")
     findings: list[str] = []
     if isinstance(findings_raw, list):
@@ -621,6 +646,8 @@ def _render_structured_review_with_task_data(
             sections.append("Touched paths reviewed: " + ", ".join(f"`{path}`" for path in touched_paths))
         if tests_reviewed:
             sections.append("Tests reviewed: " + ", ".join(f"`{path}`" for path in tests_reviewed))
+        if verified_identifiers:
+            sections.append("Changed identifiers verified: " + ", ".join(f"`{name}`" for name in verified_identifiers))
         for index, finding in enumerate(findings, start=1):
             sections.append(f"{index}. {finding}")
     elif summary:
@@ -632,6 +659,8 @@ def _render_structured_review_with_task_data(
             sections.append("Touched paths reviewed: " + ", ".join(f"`{path}`" for path in touched_paths))
         if tests_reviewed:
             sections.append("Tests reviewed: " + ", ".join(f"`{path}`" for path in tests_reviewed))
+        if verified_identifiers:
+            sections.append("Changed identifiers verified: " + ", ".join(f"`{name}`" for name in verified_identifiers))
     else:
         sections.append("## Review Summary")
         sections.append(

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -445,6 +445,7 @@ def _system_prompt_for_task(
             approval_hint = (
                 " Approval mode is active. Only use `approval_recommendation: \"approve\"` when you can cite at least two exact identifiers from changed lines "
                 "in `verified_identifiers`, mention the changed tests when any are provided, and explicitly state the scope is low-risk. "
+                "If the supplied PR checks are pending or failing, use `comment` instead of `approve`. "
                 "If you cannot satisfy that evidence bar, use `comment` instead of `approve`."
             )
         return (

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -534,6 +534,132 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(self.service.github_writeback_metrics["suppressed_approvals"], 1)
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "generic_observation")
 
+    def test_status_callback_suppresses_approve_without_test_awareness(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 6,
+                    "deletions": 1,
+                    "changes": 7,
+                    "patch": (
+                        "@@ -945,0 +945,6 @@\n"
+                        "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                    ),
+                },
+                {
+                    "filename": "tests/test_node_runtime.py",
+                    "status": "modified",
+                    "additions": 8,
+                    "deletions": 0,
+                    "changes": 8,
+                    "patch": (
+                        "@@ -494,0 +494,8 @@\n"
+                        "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
+                        "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
+                    ),
+                },
+            ],
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel approve this PR", delivery_number=245),
+            delivery_id="delivery-approve-no-tests",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-approve-no-tests",
+                "action": "approved",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability in `node/mep_runtime.py`.\n\n"
+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, which makes the recovery metrics more actionable.\n\n"
+                    "Touched paths reviewed: `node/mep_runtime.py`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertIn("action: retrying", self.notifier.calls[-1]["text"])
+        self.assertEqual(self.service.github_writeback_metrics["suppressed_approvals"], 1)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "approval_without_test_awareness")
+        self.assertGreaterEqual(self.service.github_writeback_metrics["last_quality_score"], 2)
+
+    def test_status_callback_allows_approve_with_grounded_code_and_test_awareness(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 6,
+                    "deletions": 1,
+                    "changes": 7,
+                    "patch": (
+                        "@@ -945,0 +945,6 @@\n"
+                        "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                    ),
+                },
+                {
+                    "filename": "tests/test_node_runtime.py",
+                    "status": "modified",
+                    "additions": 8,
+                    "deletions": 0,
+                    "changes": 8,
+                    "patch": (
+                        "@@ -494,0 +494,8 @@\n"
+                        "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
+                        "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
+                    ),
+                },
+            ],
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel approve this PR", delivery_number=246),
+            delivery_id="delivery-approve-with-tests",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-approve-with-tests",
+                "action": "approved",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability in `node/mep_runtime.py` and keeps the verification path narrow.\n\n"
+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, and the changed test keeps the recovery behavior covered. No risky changes.\n\n"
+                    "Touched paths reviewed: `node/mep_runtime.py`, `tests/test_node_runtime.py`\n\n"
+                    "Tests reviewed: `tests/test_node_runtime.py`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 1)
+        self.assertEqual(self.github_session.posts[0]["json"]["event"], "APPROVE")
+        self.assertEqual(self.service.github_writeback_metrics["suppressed_approvals"], 0)
+        self.assertGreaterEqual(self.service.github_writeback_metrics["last_quality_score"], 4)
+
     def test_status_callback_suppresses_generic_pr_review_writeback(self):
         response = self._post_webhook(
             _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=231),

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -7,7 +7,7 @@ import tempfile
 import time
 import asyncio
 import unittest
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
@@ -182,7 +182,13 @@ class TestGitHubToMEPBridge(unittest.TestCase):
     def tearDown(self):
         self.client.close()
 
-    def _set_pr_review_package(self, changed_files: list[dict[str, Any]], *, pr_body: str = "Bridge review package") -> None:
+    def _set_pr_review_package(
+        self,
+        changed_files: list[dict[str, Any]],
+        *,
+        pr_body: str = "Bridge review package",
+        checks_payload: Optional[dict[str, Any]] = None,
+    ) -> None:
         additions = sum(int(item.get("additions") or 0) for item in changed_files)
         deletions = sum(int(item.get("deletions") or 0) for item in changed_files)
         pr_payload = {
@@ -201,11 +207,14 @@ class TestGitHubToMEPBridge(unittest.TestCase):
                 "ref": "baseref",
             },
         }
+        checks_response = checks_payload or {"total_count": 0, "check_runs": []}
         self.github_session.get_responses = [
             _FakeResponse(pr_payload),
             _FakeResponse(changed_files),
+            _FakeResponse(checks_response),
             _FakeResponse(pr_payload),
             _FakeResponse(changed_files),
+            _FakeResponse(checks_response),
         ]
 
     def _post_webhook(self, payload: dict, *, delivery_id: str, event_name: str = "issue_comment"):
@@ -364,7 +373,8 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(github_inputs["base_sha"], "def456base")
         self.assertEqual(github_inputs["pr_stats"]["changed_files"], 1)
         self.assertEqual(github_inputs["touched_paths"], ["bridge/github_to_mep.py"])
-        self.assertEqual(len(self.github_session.gets), 2)
+        self.assertEqual(github_inputs["ci_checks"]["state"], "none")
+        self.assertEqual(len(self.github_session.gets), 3)
 
     def test_pr_review_package_includes_revision_paths_tests_and_risk_tags(self):
         self.github_session.get_responses = [
@@ -422,6 +432,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
             ["hub/db.py", "tests/test_github_bridge.py"],
         )
         self.assertEqual(github_inputs["touched_tests"], ["tests/test_github_bridge.py"])
+        self.assertEqual(github_inputs["ci_checks"]["state"], "none")
         self.assertIn("persistence", github_inputs["risk_tags"])
         self.assertEqual(github_inputs["coalesced_delivery_ids"], ["delivery-package"])
         self.assertEqual(github_inputs["event_sequence"], 1)
@@ -597,6 +608,157 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "approval_without_test_awareness")
         self.assertGreaterEqual(self.service.github_writeback_metrics["last_quality_score"], 2)
 
+    def test_status_callback_suppresses_approve_when_checks_pending_without_retry(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 6,
+                    "deletions": 1,
+                    "changes": 7,
+                    "patch": (
+                        "@@ -945,0 +945,6 @@\n"
+                        "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                    ),
+                },
+                {
+                    "filename": "tests/test_node_runtime.py",
+                    "status": "modified",
+                    "additions": 8,
+                    "deletions": 0,
+                    "changes": 8,
+                    "patch": (
+                        "@@ -494,0 +494,8 @@\n"
+                        "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
+                        "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
+                    ),
+                },
+            ],
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+            checks_payload={
+                "total_count": 1,
+                "check_runs": [
+                    {
+                        "name": "test (windows-latest, 3.10)",
+                        "status": "in_progress",
+                        "conclusion": None,
+                    }
+                ],
+            },
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel approve this PR", delivery_number=247),
+            delivery_id="delivery-approve-checks-pending",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-approve-checks-pending",
+                "action": "approved",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability in `node/mep_runtime.py` and keeps the verification path narrow.\n\n"
+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, and the changed test keeps the recovery behavior covered. No risky changes.\n\n"
+                    "Touched paths reviewed: `node/mep_runtime.py`, `tests/test_node_runtime.py`\n\n"
+                    "Tests reviewed: `tests/test_node_runtime.py`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(len(self.submission.calls), 1)
+        self.assertIn("action: suppressed", self.notifier.calls[-1]["text"])
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "approval_checks_pending")
+
+    def test_status_callback_suppresses_approve_when_checks_fail_without_retry(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 6,
+                    "deletions": 1,
+                    "changes": 7,
+                    "patch": (
+                        "@@ -945,0 +945,6 @@\n"
+                        "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                    ),
+                },
+                {
+                    "filename": "tests/test_node_runtime.py",
+                    "status": "modified",
+                    "additions": 8,
+                    "deletions": 0,
+                    "changes": 8,
+                    "patch": (
+                        "@@ -494,0 +494,8 @@\n"
+                        "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
+                        "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
+                    ),
+                },
+            ],
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+            checks_payload={
+                "total_count": 2,
+                "check_runs": [
+                    {
+                        "name": "test (ubuntu-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                    {
+                        "name": "test (windows-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "failure",
+                    },
+                ],
+            },
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel approve this PR", delivery_number=248),
+            delivery_id="delivery-approve-checks-fail",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-approve-checks-fail",
+                "action": "approved",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability in `node/mep_runtime.py` and keeps the verification path narrow.\n\n"
+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, and the changed test keeps the recovery behavior covered. No risky changes.\n\n"
+                    "Touched paths reviewed: `node/mep_runtime.py`, `tests/test_node_runtime.py`\n\n"
+                    "Tests reviewed: `tests/test_node_runtime.py`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(len(self.submission.calls), 1)
+        self.assertIn("action: suppressed", self.notifier.calls[-1]["text"])
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "approval_checks_not_green")
+
     def test_status_callback_allows_approve_with_grounded_code_and_test_awareness(self):
         self._set_pr_review_package(
             [
@@ -626,6 +788,21 @@ class TestGitHubToMEPBridge(unittest.TestCase):
                 },
             ],
             pr_body="Adds pending-task recovery observability and focused runtime tests.",
+            checks_payload={
+                "total_count": 2,
+                "check_runs": [
+                    {
+                        "name": "test (ubuntu-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                    {
+                        "name": "test (windows-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                ],
+            },
         )
         response = self._post_webhook(
             _issue_comment_payload("@Hub-Sentinel approve this PR", delivery_number=246),

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -424,6 +424,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("at least two exact identifiers", prompt)
         self.assertIn("mention the changed tests", prompt)
         self.assertIn("state the scope is low-risk", prompt)
+        self.assertIn("checks are pending or failing", prompt)
 
     def test_deepseek_adapter_uses_reviewer_prompt_for_bridge_review_tasks(self):
         adapter = mep_runtime.DeepSeekAdapter(api_key="secret-key", model="deepseek-chat")

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -411,6 +411,20 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn('"tests_reviewed": [string]', prompt)
         self.assertIn('"approval_recommendation"', prompt)
 
+    def test_approval_review_prompt_requires_verified_identifiers_and_test_awareness(self):
+        task_data = self._bridge_review_task_data(intent_type="code.review.approve")
+        prompt = mep_runtime._system_prompt_for_task(  # noqa: SLF001
+            task_data,
+            generic_max_chars=300,
+            review_max_chars=1000,
+        )
+
+        self.assertIn('"verified_identifiers": [string]', prompt)
+        self.assertIn("Approval mode is active.", prompt)
+        self.assertIn("at least two exact identifiers", prompt)
+        self.assertIn("mention the changed tests", prompt)
+        self.assertIn("state the scope is low-risk", prompt)
+
     def test_deepseek_adapter_uses_reviewer_prompt_for_bridge_review_tasks(self):
         adapter = mep_runtime.DeepSeekAdapter(api_key="secret-key", model="deepseek-chat")
         task_data = self._bridge_review_task_data()
@@ -482,6 +496,24 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
 
         self.assertIn("Observation: The diff is small and scoped.", rendered)
         self.assertIn("Touched paths reviewed: `bridge/github_to_mep.py`", rendered)
+        self.assertIn("Tests reviewed: `tests/test_github_bridge.py`", rendered)
+
+    def test_structured_approval_review_renders_verified_identifiers(self):
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            (
+                '{"summary":"Verified the approval gate stays low-risk.",'
+                '"observation":"`_score_review_quality` and `_approval_quality_failure` now enforce changed-line and test-aware approvals.",'
+                '"touched_paths":["bridge/github_to_mep.py"],'
+                '"tests_reviewed":["tests/test_github_bridge.py"],'
+                '"verified_identifiers":["_score_review_quality","_approval_quality_failure"],'
+                '"findings":[],"approval_recommendation":"approve"}'
+            ),
+            max_chars=1000,
+            task_data=self._bridge_review_task_data(intent_type="code.review.approve"),
+        )
+
+        self.assertIn("## Review Summary", rendered)
+        self.assertIn("Changed identifiers verified: `_score_review_quality`, `_approval_quality_failure`", rendered)
         self.assertIn("Tests reviewed: `tests/test_github_bridge.py`", rendered)
 
 


### PR DESCRIPTION
## Summary
- add a bridge-side review snapshot and quality scorer for final writeback decisions
- require stronger changed-line and test-aware evidence before bot approvals can publish
- add regression coverage for weak vs evidence-backed approvals

## Testing
- python -m pytest tests/test_github_bridge.py tests/test_node_runtime.py -q