### PR TITLE
Phase 4E: Strengthen critical review contract

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1502,8 +1502,11 @@ class GitHubToMEPBridgeService:
             if review_context:
                 instructions += (
                     "\n\nReview guidance:\n"
-                    "Use the actual diff context below to review correctness, regressions, edge cases, "
-                    "security, and missing tests. Reference concrete files or patch excerpts when possible.\n\n"
+                    "Primary objective: identify the highest-value correctness, regression, edge-case, security, "
+                    "or missing-validation risk in the actual changed code before summarizing anything. "
+                    "If you do not find a concrete issue, explicitly state which risk areas you checked, which checks "
+                    "you performed against the diff/workspace/tests, and why no finding is warranted. "
+                    "Reference concrete files, changed identifiers, or patch excerpts when possible.\n\n"
                     f"{review_context}"
                 )
         if len(instructions) > 3800:
@@ -1741,6 +1744,27 @@ class GitHubToMEPBridgeService:
             return ""
         return str(match.group(1) or "").strip()
 
+    @staticmethod
+    def _extract_review_section_text(detail: str, label: str) -> str:
+        if not detail:
+            return ""
+        match = re.search(rf"{re.escape(label)}:\s*(.+)", detail, re.IGNORECASE)
+        if not match:
+            return ""
+        return str(match.group(1) or "").strip()
+
+    @classmethod
+    def _extract_review_section_list(cls, detail: str, label: str) -> list[str]:
+        text = cls._extract_review_section_text(detail, label)
+        if not text:
+            return []
+        values: list[str] = []
+        for part in text.split(","):
+            cleaned = re.sub(r"\s+", " ", str(part or "").strip(" `")).strip()
+            if cleaned and cleaned not in values:
+                values.append(cleaned)
+        return values
+
     @classmethod
     def _grounded_code_tokens(cls, text: str, patch_info: dict[str, str]) -> set[str]:
         if not text or not patch_info:
@@ -1908,6 +1932,9 @@ class GitHubToMEPBridgeService:
         }
         has_findings = "## review findings" in lowered or bool(self._extract_review_finding_entries(detail or ""))
         observation_text = self._extract_observation_text(detail or "")
+        risk_areas_checked = self._extract_review_section_list(detail or "", "Risk areas checked")
+        checks_performed = self._extract_review_section_list(detail or "", "Checks performed")
+        why_no_finding = self._extract_review_section_text(detail or "", "Why no finding")
         has_structured_sections = any(
             snippet in lowered
             for snippet in (
@@ -1916,6 +1943,9 @@ class GitHubToMEPBridgeService:
                 "observation:",
                 "touched paths reviewed:",
                 "tests reviewed:",
+                "risk areas checked:",
+                "checks performed:",
+                "why no finding:",
             )
         )
         grounded_tokens = self._grounded_code_tokens(detail or "", anchored_patch_info)
@@ -1936,6 +1966,9 @@ class GitHubToMEPBridgeService:
             "anchored_patch_info": anchored_patch_info,
             "has_findings": has_findings,
             "observation_text": observation_text,
+            "risk_areas_checked": risk_areas_checked,
+            "checks_performed": checks_performed,
+            "why_no_finding": why_no_finding,
             "has_structured_sections": has_structured_sections,
             "grounded_tokens": grounded_tokens,
             "changed_tokens": changed_tokens,
@@ -1950,6 +1983,9 @@ class GitHubToMEPBridgeService:
         grounded_tokens = snapshot.get("grounded_tokens") or set()
         has_findings = bool(snapshot.get("has_findings"))
         observation_text = str(snapshot.get("observation_text") or "").strip()
+        risk_areas_checked = snapshot.get("risk_areas_checked") or []
+        checks_performed = snapshot.get("checks_performed") or []
+        why_no_finding = str(snapshot.get("why_no_finding") or "").strip()
         expected_tests = snapshot.get("expected_tests") or []
         mentions_tests = bool(snapshot.get("mentions_tests"))
         lowered = str(snapshot.get("lowered") or "")
@@ -1972,6 +2008,15 @@ class GitHubToMEPBridgeService:
         elif observation_text and grounded_tokens:
             score += 1
             reasons.append("grounded_observation")
+        if risk_areas_checked:
+            score += 1
+            reasons.append("risk_coverage")
+        if checks_performed:
+            score += 1
+            reasons.append("explicit_checks")
+        if why_no_finding and not has_findings:
+            score += 1
+            reasons.append("why_no_finding")
         if mentions_tests:
             score += 1
             reasons.append("test_awareness")
@@ -2059,6 +2104,7 @@ class GitHubToMEPBridgeService:
         detail: Optional[str],
         *,
         snapshot: Optional[dict[str, Any]] = None,
+        action: Optional[str] = None,
     ) -> tuple[bool, str]:
         snapshot = snapshot or self._build_review_snapshot(execution, detail)
         normalized = str(snapshot.get("normalized") or "")
@@ -2071,7 +2117,10 @@ class GitHubToMEPBridgeService:
         anchored_patch_info = snapshot.get("anchored_patch_info") or {"full": "", "changes": ""}
         has_findings = bool(snapshot.get("has_findings"))
         observation_text = str(snapshot.get("observation_text") or "")
+        risk_areas_checked = snapshot.get("risk_areas_checked") or []
+        checks_performed = snapshot.get("checks_performed") or []
         has_structured_sections = bool(snapshot.get("has_structured_sections"))
+        why_no_finding = str(snapshot.get("why_no_finding") or "").strip()
         grounded_tokens = snapshot.get("grounded_tokens") or set()
         changed_tokens = snapshot.get("changed_tokens") or set()
         if has_findings and not anchored_paths:
@@ -2086,7 +2135,7 @@ class GitHubToMEPBridgeService:
             if self._finding_conflicts_with_patch(detail or "", anchored_patch_info["full"]):
                 return True, "ungrounded_finding"
         if has_structured_sections and not has_findings:
-            if not observation_text and not grounded_tokens:
+            if not observation_text and not grounded_tokens and not checks_performed and not risk_areas_checked:
                 return True, "summary_without_code_evidence"
             observation_tokens = self._extract_identifier_tokens(observation_text)
             
@@ -2096,12 +2145,18 @@ class GitHubToMEPBridgeService:
 
             if observation_text and not grounded_tokens and len(observation_tokens) < 2:
                 return True, "generic_observation"
+            why_tokens = self._extract_identifier_tokens(why_no_finding)
+            if why_tokens and not changed_tokens:
+                return True, "summary_without_changed_behavior_evidence"
         if len(normalized) < 90 and not anchored_paths:
             return True, "too_short"
         if any(re.search(pattern, lowered) for pattern in _WEAK_GITHUB_REVIEW_PATTERNS) and not anchored_paths:
             return True, "generic_summary"
         if has_structured_sections and not anchored_paths:
             return True, "no_touched_path_anchor"
+        if has_structured_sections and not has_findings and action != "approved":
+            if not risk_areas_checked and not checks_performed:
+                return True, "summary_without_risk_coverage"
         return False, "concrete"
 
     def _record_github_writeback_attempt(self, action: str, detail: Optional[str]) -> None:
@@ -2324,7 +2379,12 @@ class GitHubToMEPBridgeService:
         review_result: Optional[dict[str, Any]] = None
         if review_action:
             snapshot = self._build_review_snapshot(execution, update.detail)
-            suppress, reason = self._classify_review_writeback_detail(execution, update.detail, snapshot=snapshot)
+            suppress, reason = self._classify_review_writeback_detail(
+                execution,
+                update.detail,
+                snapshot=snapshot,
+                action=action,
+            )
             score, reasons = self._score_review_quality(snapshot, action=action)
             self._record_review_quality(score, reasons)
             if not suppress and action == "approved":
@@ -2461,6 +2521,10 @@ class GitHubToMEPBridgeService:
         critique = f"Your previous review was suppressed because: {reason or 'weak_output'}.\n"
         if reason == "summary_without_code_evidence":
             critique += "Please provide a more detailed review with concrete code identifiers (variables, functions) found in the actual PR diff."
+        elif reason == "summary_without_risk_coverage":
+            critique += "You summarized the diff without stating which risk areas or checks you actually covered. Re-review the PR and list the concrete risk areas checked and checks performed."
+        elif reason == "summary_without_changed_behavior_evidence":
+            critique += "Your why-no-finding explanation mentioned code behavior without grounding it in changed-line identifiers. Re-check the actual diff and cite the changed behavior you verified."
         elif reason in ("finding_in_context_only", "observation_in_context_only"):
             critique += "The code identifiers you mentioned are in the file context but NOT in the actual changed lines (+/-). Please focus your review on the actual changes."
         elif reason == "approval_without_changed_code_evidence":

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -450,18 +450,24 @@ def _system_prompt_for_task(
             )
         return (
             "You are a senior code reviewer for the MEP (Miao Exchange Protocol) project. "
+            "Your primary job is to find the highest-value correctness, regression, edge-case, or missing-validation risk in the supplied PR context before you summarize anything. "
             "Review the provided GitHub PR context and return ONLY a JSON object with this schema: "
             '{"summary": string, "observation": string, "touched_paths": [string], "tests_reviewed": [string], '
+            '"risk_areas_checked": [string], "checks_performed": [string], "why_no_finding": string, '
             '"verified_identifiers": [string], '
             '"findings": [{"file": string, "issue": string, "rationale": string}], '
             '"approval_recommendation": "approve" | "comment" | "request_changes" | "abstain"}. '
             "Use at most 2 findings. "
             "Use `observation` for one concrete non-blocking review note tied to the actual diff. "
+            "Use `risk_areas_checked` for 1-4 concrete risk themes you examined in the changed code. "
+            "Use `checks_performed` for 1-4 specific verification steps you actually performed against the diff, tests, or workspace excerpts. "
+            "When findings are empty, `why_no_finding` must explain why the changed behavior looks safe based on those checks; do not use it for generic praise. "
             "Use `verified_identifiers` for exact function/variable/class names copied from changed lines in the supplied diff or workspace excerpts. "
             "Prefer real touched files and tests from the supplied GitHub inputs for `touched_paths` and `tests_reviewed`. "
             "Only include a finding when it is directly supported by the provided diff, file list, PR description, or patch excerpts. "
             "Do not speculate about unseen code, do not ask for more context, and do not include chain-of-thought or any text outside the JSON object. "
-            "If the change looks good, keep findings empty and use summary to say what you verified, keep observation concrete, and set approval_recommendation to approve or comment. Keep the "
+            "If the change looks good, keep findings empty, use summary to state the overall conclusion, list the risk areas and checks you covered, explain why no finding is warranted, keep observation concrete, and set approval_recommendation to approve or comment. "
+            "Diff restatement without risk coverage is not a sufficient review. Keep the "
             f"response within {review_max_chars} characters.{approval_hint}{workspace_hint}"
         )
     return (
@@ -615,6 +621,11 @@ def _render_structured_review_with_task_data(
     tests_reviewed = _clean_review_list(parsed.get("tests_reviewed"), max_items=3, max_chars=120)
     if not tests_reviewed:
         tests_reviewed = _clean_review_list(github_inputs.get("touched_tests"), max_items=3, max_chars=120)
+    risk_areas_checked = _clean_review_list(parsed.get("risk_areas_checked"), max_items=4, max_chars=100)
+    checks_performed = _clean_review_list(parsed.get("checks_performed"), max_items=4, max_chars=120)
+    why_no_finding = _clean_review_text(parsed.get("why_no_finding"), max_chars=240)
+    if _is_weak_review_text(why_no_finding):
+        why_no_finding = ""
     verified_identifiers = _clean_review_list(parsed.get("verified_identifiers"), max_items=4, max_chars=80)
     findings_raw = parsed.get("findings")
     findings: list[str] = []
@@ -645,6 +656,12 @@ def _render_structured_review_with_task_data(
             sections.append("Touched paths reviewed: " + ", ".join(f"`{path}`" for path in touched_paths))
         if tests_reviewed:
             sections.append("Tests reviewed: " + ", ".join(f"`{path}`" for path in tests_reviewed))
+        if risk_areas_checked:
+            sections.append("Risk areas checked: " + ", ".join(risk_areas_checked))
+        if checks_performed:
+            sections.append("Checks performed: " + ", ".join(checks_performed))
+        if why_no_finding:
+            sections.append(f"Why no finding: {why_no_finding}")
         if verified_identifiers:
             sections.append("Changed identifiers verified: " + ", ".join(f"`{name}`" for name in verified_identifiers))
         for index, finding in enumerate(findings, start=1):
@@ -658,6 +675,12 @@ def _render_structured_review_with_task_data(
             sections.append("Touched paths reviewed: " + ", ".join(f"`{path}`" for path in touched_paths))
         if tests_reviewed:
             sections.append("Tests reviewed: " + ", ".join(f"`{path}`" for path in tests_reviewed))
+        if risk_areas_checked:
+            sections.append("Risk areas checked: " + ", ".join(risk_areas_checked))
+        if checks_performed:
+            sections.append("Checks performed: " + ", ".join(checks_performed))
+        if why_no_finding:
+            sections.append(f"Why no finding: {why_no_finding}")
         if verified_identifiers:
             sections.append("Changed identifiers verified: " + ", ".join(f"`{name}`" for name in verified_identifiers))
     else:
@@ -669,6 +692,12 @@ def _render_structured_review_with_task_data(
             sections.append("Touched paths reviewed: " + ", ".join(f"`{path}`" for path in touched_paths))
         if tests_reviewed:
             sections.append("Tests reviewed: " + ", ".join(f"`{path}`" for path in tests_reviewed))
+        if risk_areas_checked:
+            sections.append("Risk areas checked: " + ", ".join(risk_areas_checked))
+        if checks_performed:
+            sections.append("Checks performed: " + ", ".join(checks_performed))
+        if why_no_finding:
+            sections.append(f"Why no finding: {why_no_finding}")
     rendered = "\n\n".join(section for section in sections if section.strip())
     return _finalize_model_reply(rendered, max_chars=max_chars)
 

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1403,13 +1403,76 @@ class TestGitHubToMEPBridge(unittest.TestCase):
                 "detail": (
                     "## Review Summary\n\n"
                     "The PR adds pending-task recovery observability in `node/mep_runtime.py` and corresponding tests in `tests/test_node_runtime.py`.\n\n"
-                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, so malformed payloads will still surface `status=200` in the metrics."
+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, so malformed payloads will still surface `status=200` in the metrics.\n\n"
+                    "Risk areas checked: metrics correctness, test coverage\n\n"
+                    "Checks performed: verified `_record_pending_task_poll_failure` writes `last_poll_status`, checked `test_fetch_pending_tasks_uses_authenticated_get` covers the recovery path\n\n"
+                    "Why no finding: The new metrics write is narrowly scoped and the changed test covers the intended recovery behavior."
                 ),
             },
             headers={"Authorization": f"Bearer {token}"},
         )
         self.assertEqual(status_response.status_code, 200, status_response.text)
         self.assertEqual(len(self.github_session.posts), 1)
+
+    def test_status_callback_suppresses_summary_without_risk_coverage(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 40,
+                    "deletions": 2,
+                    "changes": 42,
+                    "patch": (
+                        "@@ -945,0 +945,29 @@\n"
+                        "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_failure_detail'] = detail\n"
+                    ),
+                },
+                {
+                    "filename": "tests/test_node_runtime.py",
+                    "status": "modified",
+                    "additions": 20,
+                    "deletions": 0,
+                    "changes": 20,
+                    "patch": (
+                        "@@ -494,0 +494,20 @@\n"
+                        "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
+                        "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
+                    ),
+                },
+            ],
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=244),
+            delivery_id="delivery-summary-without-risk-coverage",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-summary-without-risk-coverage",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability in `node/mep_runtime.py` and corresponding tests in `tests/test_node_runtime.py`.\n\n"
+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, so malformed payloads will still surface `status=200` in the metrics."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertIn("action: retrying", self.notifier.calls[-1]["text"])
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "summary_without_risk_coverage")
 
     def test_status_callback_suppresses_finding_grounded_only_to_context_lines(self):
         self._set_pr_review_package(

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -409,7 +409,11 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn('"observation": string', prompt)
         self.assertIn('"touched_paths": [string]', prompt)
         self.assertIn('"tests_reviewed": [string]', prompt)
+        self.assertIn('"risk_areas_checked": [string]', prompt)
+        self.assertIn('"checks_performed": [string]', prompt)
+        self.assertIn('"why_no_finding": string', prompt)
         self.assertIn('"approval_recommendation"', prompt)
+        self.assertIn("highest-value correctness, regression, edge-case", prompt)
 
     def test_approval_review_prompt_requires_verified_identifiers_and_test_awareness(self):
         task_data = self._bridge_review_task_data(intent_type="code.review.approve")
@@ -425,6 +429,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("mention the changed tests", prompt)
         self.assertIn("state the scope is low-risk", prompt)
         self.assertIn("checks are pending or failing", prompt)
+        self.assertIn("Diff restatement without risk coverage is not a sufficient review", prompt)
 
     def test_deepseek_adapter_uses_reviewer_prompt_for_bridge_review_tasks(self):
         adapter = mep_runtime.DeepSeekAdapter(api_key="secret-key", model="deepseek-chat")
@@ -516,6 +521,27 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("## Review Summary", rendered)
         self.assertIn("Changed identifiers verified: `_score_review_quality`, `_approval_quality_failure`", rendered)
         self.assertIn("Tests reviewed: `tests/test_github_bridge.py`", rendered)
+
+    def test_structured_review_renders_risk_coverage_for_no_finding_reviews(self):
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            (
+                '{"summary":"Checked the review trial ledger flow end to end.",'
+                '"observation":"`_build_review_trial_result` and `list_review_trials` stay aligned with the stored JSON payload.",'
+                '"touched_paths":["bridge/github_to_mep.py"],'
+                '"tests_reviewed":["tests/test_github_bridge.py"],'
+                '"risk_areas_checked":["trial persistence","endpoint decoding"],'
+                '"checks_performed":["verified suppression and publish paths mention `review_result_json`","checked `/bridge/review-trials` returns stored review metadata"],'
+                '"why_no_finding":"The new writes and reads stay consistent across both persistence paths, so the telemetry path looks low-risk.",'
+                '"verified_identifiers":["_build_review_trial_result","list_review_trials"],'
+                '"findings":[],"approval_recommendation":"comment"}'
+            ),
+            max_chars=1000,
+            task_data=self._bridge_review_task_data(),
+        )
+
+        self.assertIn("Risk areas checked: trial persistence, endpoint decoding", rendered)
+        self.assertIn("Checks performed: verified suppression and publish paths mention `review_result_json`, checked `/bridge/review-trials` returns stored review metadata", rendered)
+        self.assertIn("Why no finding: The new writes and reads stay consistent across both persistence paths, so the telemetry path looks low-risk.", rendered)
 
 
 class TestRuntimeWebSocketLoop(unittest.TestCase):


### PR DESCRIPTION
## Summary
- strengthen the loop review contract so bots must state risk areas checked, checks performed, and why no finding is warranted
- teach the bridge to parse and score risk coverage instead of accepting diff restatements as sufficient review quality
- add focused regression tests for stronger no-finding reviews and suppression of summary-only output without risk coverage

## Testing
- python -m pytest tests/test_github_bridge.py tests/test_node_runtime.py -q
