### PR TITLE
Phase 4F: Verify review observation claims

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1827,6 +1827,40 @@ class GitHubToMEPBridgeService:
             return any(token in lowered_patch for token in auth_evidence_tokens)
         return False
 
+    @classmethod
+    def _observation_conflicts_with_patch(cls, observation_text: str, patch_text: str) -> bool:
+        if not observation_text or not patch_text:
+            return False
+        lowered_observation = observation_text.lower()
+        lowered_patch = patch_text.lower()
+
+        placeholder_claim_patterns = (
+            r"\btruncat(?:e|es|ed|ing)\b",
+            r"\bplaceholder\b",
+            r"\bellipsis\b",
+            r"\bcut off\b",
+            r"\bclipp(?:ed|ing)\b",
+        )
+        placeholder_evidence_tokens = ("...", "…", "placeholder")
+        if any(re.search(pattern, lowered_observation) for pattern in placeholder_claim_patterns):
+            if not any(token in lowered_patch for token in placeholder_evidence_tokens):
+                return True
+
+        absence_claim_patterns = (
+            r"\bmissing\b",
+            r"\bomitted\b",
+            r"\babsent\b",
+            r"\bnot present\b",
+            r"\bnot included\b",
+            r"\bwithout\b",
+            r"\black(?:s|ing)?\b",
+        )
+        identifier_tokens = cls._extract_identifier_tokens(observation_text)
+        if identifier_tokens and any(re.search(pattern, lowered_observation) for pattern in absence_claim_patterns):
+            if any(token in lowered_patch for token in identifier_tokens):
+                return True
+        return False
+
     @staticmethod
     def _patch_text_by_path(review_package: dict[str, Any]) -> dict[str, dict[str, str]]:
         patches: dict[str, dict[str, str]] = {}
@@ -2134,6 +2168,9 @@ class GitHubToMEPBridgeService:
         if has_findings and anchored_paths and review_package:
             if self._finding_conflicts_with_patch(detail or "", anchored_patch_info["full"]):
                 return True, "ungrounded_finding"
+        if observation_text and anchored_paths and review_package:
+            if self._observation_conflicts_with_patch(observation_text, anchored_patch_info["full"]):
+                return True, "ungrounded_observation"
         if has_structured_sections and not has_findings:
             if not observation_text and not grounded_tokens and not checks_performed and not risk_areas_checked:
                 return True, "summary_without_code_evidence"
@@ -2525,6 +2562,8 @@ class GitHubToMEPBridgeService:
             critique += "You summarized the diff without stating which risk areas or checks you actually covered. Re-review the PR and list the concrete risk areas checked and checks performed."
         elif reason == "summary_without_changed_behavior_evidence":
             critique += "Your why-no-finding explanation mentioned code behavior without grounding it in changed-line identifiers. Re-check the actual diff and cite the changed behavior you verified."
+        elif reason == "ungrounded_observation":
+            critique += "Your observation makes a concrete claim that conflicts with the actual patch evidence. Re-check the diff and only mention placeholders, truncation, or missing items when the changed lines support that claim."
         elif reason in ("finding_in_context_only", "observation_in_context_only"):
             critique += "The code identifiers you mentioned are in the file context but NOT in the actual changed lines (+/-). Please focus your review on the actual changes."
         elif reason == "approval_without_changed_code_evidence":

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1554,6 +1554,94 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(len(self.github_session.posts), 0)
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "observation_in_context_only")
 
+    def test_status_callback_suppresses_observation_claiming_truncation_without_patch_evidence(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "bridge/github_to_mep.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -1504,0 +1504,6 @@\n"
+                        '+                    "Review guidance:\\n"\n'
+                        '+                    "Primary objective: identify the highest-value correctness, regression, edge-case, security, "\n'
+                        '+                    "or missing-validation risk in the actual changed code before summarizing anything. "\n'
+                    ),
+                },
+            ],
+            pr_body="Strengthens review guidance wording.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR"),
+            delivery_id="delivery-observation-truncation-claim",
+        )
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "Verified the review contract wording in `bridge/github_to_mep.py`.\n\n"
+                    "Observation: The patch in `bridge/github_to_mep.py` truncates the review guidance string at `Re...`, which could break the final instructions.\n\n"
+                    "Touched paths reviewed: `bridge/github_to_mep.py`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertIn("action: retrying", self.notifier.calls[-1]["text"])
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "ungrounded_observation")
+
+    def test_status_callback_suppresses_observation_claiming_placeholder_without_patch_evidence(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "tests/test_github_bridge.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -1403,0 +1403,6 @@\n"
+                        '+                    "## Review Summary\\n\\n"\n'
+                        '+                    "The PR adds pending-task recovery observability in `node/mep_runtime.py`.\\n\\n"\n'
+                        '+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`.\\n\\n"\n'
+                    ),
+                },
+            ],
+            pr_body="Adds stronger review-body assertions.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR"),
+            delivery_id="delivery-observation-placeholder-claim",
+        )
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "Verified the new test coverage in `tests/test_github_bridge.py`.\n\n"
+                    "Observation: The patch in `tests/test_github_bridge.py` replaces the review body with a placeholder `...`, so the risk coverage assertions might not really execute.\n\n"
+                    "Touched paths reviewed: `tests/test_github_bridge.py`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertIn("action: retrying", self.notifier.calls[-1]["text"])
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "ungrounded_observation")
+
     def test_status_callback_allows_finding_grounded_to_changed_lines(self):
         self._set_pr_review_package(
             [


### PR DESCRIPTION
## Summary
- add a bridge-side verifier for concrete observation claims that conflict with the actual patch
- suppress placeholder / truncation / missing-item observations when the anchored diff does not support them
- add focused regression tests for the false observation patterns seen in the Phase 4E live review

## Testing
- python -m pytest tests/test_github_bridge.py tests/test_node_runtime.py -q
- python -m ruff check bridge/github_to_mep.py tests/test_github_bridge.py
