### PR TITLE
Support polite and re-review GitHub triggers

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1139,6 +1139,24 @@ class GitHubToMEPBridgeService:
         """Re-extract multi-target triggers from a normalized event's trigger text."""
         return self._extract_triggers(event.raw_trigger_text)
 
+    @staticmethod
+    def _extract_trigger_verb(text: str) -> Optional[str]:
+        command_match = re.match(
+            r"""
+            (?:\s+|[,:]\s*)*
+            (?:(?:please|pls|kindly)\s+)*
+            (?P<verb>re(?:\s+|-)?review|rereview|[a-z][a-z_-]*)\b
+            """,
+            text,
+            re.IGNORECASE | re.VERBOSE,
+        )
+        if not command_match:
+            return None
+        verb = re.sub(r"[\s-]+", "", command_match.group("verb").strip().lower())
+        if verb == "rereview":
+            return "review"
+        return verb
+
     def _extract_triggers(self, text: str) -> list[TriggerMatch]:
         """Extract ALL actionable @alias verb mentions from text."""
         if not isinstance(text, str) or not text.strip():
@@ -1172,14 +1190,9 @@ class GitHubToMEPBridgeService:
                     mention_index += 1
                     continue
                 break
-            verb_match = re.match(
-                r"(?:\s+|[,:]\s*)(?P<verb>[a-z][a-z_-]*)\b",
-                text[cursor:],
-                re.IGNORECASE,
-            )
-            if not verb_match:
+            verb = self._extract_trigger_verb(text[cursor:])
+            if not verb:
                 continue
-            verb = verb_match.group("verb").strip().lower()
             intent_type = DEFAULT_TRIGGER_VERBS.get(verb)
             if not intent_type:
                 continue

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -259,6 +259,28 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertIn("/bridge/status", bridge_metadata["status_endpoint"])
         self.assertTrue(bridge_metadata["status_token"])
 
+    def test_extract_trigger_accepts_polite_review_prefixes(self):
+        self.assertEqual(
+            self.service._extract_trigger("@Hub-Sentinel please review this PR"),
+            ("review", "code.review.request"),
+        )
+        self.assertEqual(
+            self.service._extract_trigger("@Hub-Sentinel kindly review this PR"),
+            ("review", "code.review.request"),
+        )
+
+    def test_extract_trigger_accepts_rereview_variants(self):
+        for body in (
+            "@Hub-Sentinel re-review this PR",
+            "@Hub-Sentinel rereview this PR",
+            "@Hub-Sentinel re review this PR",
+            "@Hub-Sentinel please re-review this PR",
+        ):
+            self.assertEqual(
+                self.service._extract_trigger(body),
+                ("review", "code.review.request"),
+            )
+
     def test_duplicate_delivery_is_deduplicated(self):
         payload = _issue_comment_payload("@Hub-Sentinel review this PR")
         first = self._post_webhook(payload, delivery_id="delivery-dup")


### PR DESCRIPTION
## Summary
- accept polite review prefixes like please review and kindly review
- normalize e-review, ereview, and e review back to the existing eview trigger intent
- add focused bridge tests for the new trigger forms

## Validation
- python -m pytest tests/test_github_bridge.py -q
- python -m ruff check bridge/github_to_mep.py tests/test_github_bridge.py