### PR TITLE
Phase 6D: add review benchmark feedback scaffolding

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -9,6 +9,7 @@ import secrets
 import sqlite3
 import time
 import uuid
+from collections import Counter
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any, Optional
@@ -272,6 +273,12 @@ class BridgeStatusUpdate(BaseModel):
     detail: Optional[str] = None
 
 
+class BridgeReviewFeedbackUpdate(BaseModel):
+    benchmark_label: Optional[str] = Field(default=None, max_length=120)
+    verdict: Optional[str] = Field(default=None, max_length=64)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+
+
 class BridgeRegistrationPendingApprovalError(RuntimeError):
     def __init__(self, node_id: str):
         super().__init__(
@@ -343,6 +350,7 @@ class BridgeStore:
                 instructions TEXT NOT NULL DEFAULT '',
                 github_inputs_json TEXT NOT NULL DEFAULT '{}',
                 review_result_json TEXT NOT NULL DEFAULT '{}',
+                review_feedback_json TEXT NOT NULL DEFAULT '{}',
                 retry_count INTEGER NOT NULL DEFAULT 0,
                 created_at REAL NOT NULL,
                 updated_at REAL NOT NULL
@@ -398,6 +406,13 @@ class BridgeStore:
                 """
                 ALTER TABLE bridge_executions
                 ADD COLUMN review_result_json TEXT NOT NULL DEFAULT '{}'
+                """
+            )
+        if "review_feedback_json" not in execution_columns:
+            cursor.execute(
+                """
+                ALTER TABLE bridge_executions
+                ADD COLUMN review_feedback_json TEXT NOT NULL DEFAULT '{}'
                 """
             )
         conn.commit()
@@ -534,6 +549,7 @@ class BridgeStore:
         action: Optional[str] = None,
         telegram_message_id: Optional[str] = None,
         review_result: Optional[dict[str, Any]] = None,
+        review_feedback: Optional[dict[str, Any]] = None,
         retry_count: Optional[int] = None,
     ) -> None:
         assignments = []
@@ -553,6 +569,9 @@ class BridgeStore:
         if review_result is not None:
             assignments.append("review_result_json = ?")
             params.append(json.dumps(review_result, separators=(",", ":"), sort_keys=True))
+        if review_feedback is not None:
+            assignments.append("review_feedback_json = ?")
+            params.append(json.dumps(review_feedback, separators=(",", ":"), sort_keys=True))
         if retry_count is not None:
             assignments.append("retry_count = ?")
             params.append(retry_count)
@@ -579,6 +598,7 @@ class BridgeStore:
         record = dict(row)
         record["github_inputs"] = self._decode_json_dict(record.get("github_inputs_json"))
         record["review_result"] = self._decode_json_dict(record.get("review_result_json"))
+        record["review_feedback"] = self._decode_json_dict(record.get("review_feedback_json"))
         return record
 
     def list_recent_review_trials(self, *, limit: int = 20) -> list[dict[str, Any]]:
@@ -613,6 +633,7 @@ class BridgeStore:
                     "retry_count": int(record.get("retry_count") or 0),
                     "updated_at": float(record.get("updated_at") or 0),
                     "review_result": self._decode_json_dict(record.get("review_result_json")),
+                    "review_feedback": self._decode_json_dict(record.get("review_feedback_json")),
                 }
             )
         return items
@@ -1856,6 +1877,14 @@ class GitHubToMEPBridgeService:
             raise HTTPException(status_code=401, detail="Expired bridge status token")
         return claims
 
+    def _verify_feedback_token(self, token: str) -> None:
+        expected = str(self.config.status_secret or "").strip()
+        provided = str(token or "").strip()
+        if not expected:
+            raise HTTPException(status_code=500, detail="Bridge configuration missing: MEP_BRIDGE_STATUS_SECRET")
+        if not provided or not secrets.compare_digest(expected, provided):
+            raise HTTPException(status_code=403, detail="Invalid bridge feedback token")
+
     def _resolve_github_writeback_action(
         self,
         execution: dict[str, Any],
@@ -2755,9 +2784,137 @@ class GitHubToMEPBridgeService:
         )
         return {"status": "ok", "bridge_id": update.bridge_id}
 
-    def list_review_trials(self, *, limit: int = 20) -> dict[str, Any]:
-        items = self.store.list_recent_review_trials(limit=limit)
-        return {"status": "ok", "count": len(items), "items": items}
+    def list_review_trials(
+        self,
+        *,
+        limit: int = 20,
+        target_alias: Optional[str] = None,
+        benchmark_label: Optional[str] = None,
+        verdict: Optional[str] = None,
+    ) -> dict[str, Any]:
+        raw_limit = max(limit, 200) if any((target_alias, benchmark_label, verdict)) else limit
+        items = self.store.list_recent_review_trials(limit=raw_limit)
+        normalized_target = _normalize_alias_key(target_alias)
+        normalized_label = self._normalize_feedback_text(benchmark_label, max_chars=120)
+        normalized_verdict = self._normalize_feedback_verdict(verdict)
+        filtered: list[dict[str, Any]] = []
+        for item in items:
+            if normalized_target and _normalize_alias_key(str(item.get("target_alias") or "")) != normalized_target:
+                continue
+            feedback = item.get("review_feedback") or {}
+            if normalized_label and str(feedback.get("benchmark_label") or "").strip() != normalized_label:
+                continue
+            if normalized_verdict and str(feedback.get("verdict") or "").strip().lower() != normalized_verdict:
+                continue
+            filtered.append(item)
+        items = filtered[: max(1, min(int(limit), 200))]
+        return {"status": "ok", "count": len(items), "items": items, "summary": self._summarize_review_trials(items)}
+
+    @staticmethod
+    def _normalize_feedback_text(value: Optional[str], *, max_chars: int) -> str:
+        text = re.sub(r"\s+", " ", str(value or "")).strip()
+        return text[:max_chars]
+
+    @staticmethod
+    def _normalize_feedback_verdict(value: Optional[str]) -> str:
+        normalized = re.sub(r"[\s_-]+", "_", str(value or "")).strip().lower()
+        allowed = {"useful", "not_useful", "false_positive", "missed_issue"}
+        if not normalized:
+            return ""
+        if normalized not in allowed:
+            allowed_text = ", ".join(sorted(allowed))
+            raise HTTPException(status_code=400, detail=f"Unsupported review feedback verdict. Allowed: {allowed_text}")
+        return normalized
+
+    def record_review_feedback(self, bridge_id: str, update: BridgeReviewFeedbackUpdate, token: str) -> dict[str, Any]:
+        self._verify_feedback_token(token)
+        execution = self.store.get_execution(bridge_id)
+        if execution is None:
+            raise HTTPException(status_code=404, detail="Unknown bridge_id")
+        review_result = execution.get("review_result") or {}
+        if not review_result:
+            raise HTTPException(status_code=409, detail="Review trial result is not recorded yet")
+        existing = execution.get("review_feedback") or {}
+        benchmark_label = self._normalize_feedback_text(update.benchmark_label, max_chars=120)
+        verdict = self._normalize_feedback_verdict(update.verdict)
+        notes = self._normalize_feedback_text(update.notes, max_chars=2000)
+        if not any((benchmark_label, verdict, notes)):
+            raise HTTPException(status_code=400, detail="Feedback payload must include benchmark_label, verdict, or notes")
+        feedback: dict[str, Any] = {
+            "recorded_at": float(existing.get("recorded_at") or time.time()),
+            "updated_at": time.time(),
+        }
+        if benchmark_label:
+            feedback["benchmark_label"] = benchmark_label
+        elif existing.get("benchmark_label"):
+            feedback["benchmark_label"] = str(existing.get("benchmark_label"))
+        if verdict:
+            feedback["verdict"] = verdict
+        elif existing.get("verdict"):
+            feedback["verdict"] = str(existing.get("verdict"))
+        if notes:
+            feedback["notes"] = notes
+        elif existing.get("notes"):
+            feedback["notes"] = str(existing.get("notes"))
+        self.store.update_execution(bridge_id, review_feedback=feedback)
+        return {"status": "ok", "bridge_id": bridge_id, "review_feedback": feedback}
+
+    @staticmethod
+    def _summarize_review_trials(items: list[dict[str, Any]]) -> dict[str, Any]:
+        resolved_actions: Counter[str] = Counter()
+        suppression_reasons: Counter[str] = Counter()
+        feedback_verdicts: Counter[str] = Counter()
+        benchmark_labels: Counter[str] = Counter()
+        target_aliases: Counter[str] = Counter()
+        published_count = 0
+        suppressed_count = 0
+        retry_queued_count = 0
+        quality_scores: list[int] = []
+        for item in items:
+            target_alias = str(item.get("target_alias") or "").strip()
+            if target_alias:
+                target_aliases[target_alias] += 1
+            review_result = item.get("review_result") or {}
+            review_feedback = item.get("review_feedback") or {}
+            resolved_action = str(review_result.get("resolved_action") or "").strip()
+            if resolved_action:
+                resolved_actions[resolved_action] += 1
+            suppression_reason = str(review_result.get("suppression_reason") or "").strip()
+            if suppression_reason:
+                suppression_reasons[suppression_reason] += 1
+            if review_result.get("published"):
+                published_count += 1
+            if review_result.get("suppressed"):
+                suppressed_count += 1
+            if review_result.get("retry_queued"):
+                retry_queued_count += 1
+            quality_score = review_result.get("quality_score")
+            if isinstance(quality_score, (int, float)):
+                quality_scores.append(int(quality_score))
+            verdict = str(review_feedback.get("verdict") or "").strip().lower()
+            if verdict:
+                feedback_verdicts[verdict] += 1
+            benchmark_label = str(review_feedback.get("benchmark_label") or "").strip()
+            if benchmark_label:
+                benchmark_labels[benchmark_label] += 1
+        feedback_count = sum(feedback_verdicts.values())
+        useful_count = int(feedback_verdicts.get("useful") or 0)
+        avg_quality_score = round(sum(quality_scores) / len(quality_scores), 2) if quality_scores else 0.0
+        useful_rate = round(useful_count / feedback_count, 4) if feedback_count else None
+        return {
+            "total_trials": len(items),
+            "published_count": published_count,
+            "suppressed_count": suppressed_count,
+            "retry_queued_count": retry_queued_count,
+            "avg_quality_score": avg_quality_score,
+            "resolved_actions": dict(sorted(resolved_actions.items())),
+            "suppression_reasons": dict(sorted(suppression_reasons.items())),
+            "feedback_verdicts": dict(sorted(feedback_verdicts.items())),
+            "benchmark_labels": dict(sorted(benchmark_labels.items())),
+            "target_aliases": dict(sorted(target_aliases.items())),
+            "feedback_count": feedback_count,
+            "feedback_useful_rate": useful_rate,
+        }
 
     async def _issue_retry_task(self, execution: dict[str, Any], reason: Optional[str]) -> bool:
         bridge_id = str(execution["bridge_id"])
@@ -2948,8 +3105,30 @@ def create_app(
         return await bridge_service.handle_status_callback(update, token or "")
 
     @app.get("/bridge/review-trials")
-    async def bridge_review_trials(limit: int = 20) -> dict[str, Any]:
-        return bridge_service.list_review_trials(limit=limit)
+    async def bridge_review_trials(
+        limit: int = 20,
+        target_alias: Optional[str] = None,
+        benchmark_label: Optional[str] = None,
+        verdict: Optional[str] = None,
+    ) -> dict[str, Any]:
+        return bridge_service.list_review_trials(
+            limit=limit,
+            target_alias=target_alias,
+            benchmark_label=benchmark_label,
+            verdict=verdict,
+        )
+
+    @app.post("/bridge/review-trials/{bridge_id}/feedback")
+    async def bridge_review_feedback(
+        bridge_id: str,
+        update: BridgeReviewFeedbackUpdate,
+        authorization: Optional[str] = Header(default=None),
+        x_bridge_feedback_token: Optional[str] = Header(default=None),
+    ) -> dict[str, Any]:
+        token = x_bridge_feedback_token
+        if not token and authorization and authorization.lower().startswith("bearer "):
+            token = authorization.split(" ", 1)[1].strip()
+        return bridge_service.record_review_feedback(bridge_id, update, token or "")
 
     return app
 

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1033,6 +1033,224 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertTrue(item["review_result"]["published"])
         self.assertEqual(item["review_result"]["head_sha"], "headsha123")
         self.assertEqual(item["review_result"]["ci_state"], "green")
+        self.assertEqual(payload["summary"]["total_trials"], 1)
+        self.assertEqual(payload["summary"]["published_count"], 1)
+        self.assertEqual(payload["summary"]["resolved_actions"], {"approved": 1})
+
+    def test_review_trials_feedback_endpoint_records_feedback_and_summary(self):
+        checks_payload = {
+            "total_count": 2,
+            "check_runs": [
+                {
+                    "name": "test (ubuntu-latest, 3.10)",
+                    "status": "completed",
+                    "conclusion": "success",
+                },
+                {
+                    "name": "test (windows-latest, 3.10)",
+                    "status": "completed",
+                    "conclusion": "success",
+                },
+            ],
+        }
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 6,
+                    "deletions": 1,
+                    "changes": 7,
+                    "patch": (
+                        "@@ -945,0 +945,6 @@\n"
+                        "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                    ),
+                },
+                {
+                    "filename": "tests/test_node_runtime.py",
+                    "status": "modified",
+                    "additions": 8,
+                    "deletions": 0,
+                    "changes": 8,
+                    "patch": (
+                        "@@ -494,0 +494,8 @@\n"
+                        "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
+                        "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
+                    ),
+                },
+            ],
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+            checks_payload=checks_payload,
+        )
+        approved_response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel approve this PR", delivery_number=270),
+            delivery_id="delivery-feedback-approved",
+        )
+        self.assertEqual(approved_response.status_code, 200)
+        approved_bridge_id = approved_response.json()["bridge_id"]
+        self._flush_context(approved_response.json()["context_id"])
+
+        approved_token = self.service._generate_status_token(approved_bridge_id, "node_target")
+        approved_status = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": approved_bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-feedback-approved",
+                "action": "approved",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability in `node/mep_runtime.py` and keeps the verification path narrow.\n\n"
+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, and the changed test keeps the recovery behavior covered. No risky changes.\n\n"
+                    "Touched paths reviewed: `node/mep_runtime.py`, `tests/test_node_runtime.py`\n\n"
+                    "Tests reviewed: `tests/test_node_runtime.py`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {approved_token}"},
+        )
+        self.assertEqual(approved_status.status_code, 200, approved_status.text)
+
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "README.md",
+                    "status": "modified",
+                    "additions": 8,
+                    "deletions": 3,
+                    "changes": 11,
+                    "patch": "@@ -1,3 +1,8 @@\n+# Reviewer docs\n+Updated wording.\n",
+                },
+                {
+                    "filename": "docs/external-bridge/README.md",
+                    "status": "modified",
+                    "additions": 6,
+                    "deletions": 1,
+                    "changes": 7,
+                    "patch": "@@ -40,1 +40,6 @@\n+Added trigger examples.\n",
+                },
+            ],
+            pr_body="Docs-only clarification for reviewer trigger examples.",
+        )
+        suppressed_response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=271),
+            delivery_id="delivery-feedback-suppressed",
+        )
+        self.assertEqual(suppressed_response.status_code, 200)
+        suppressed_bridge_id = suppressed_response.json()["bridge_id"]
+        self._flush_context(suppressed_response.json()["context_id"])
+
+        suppressed_token = self.service._generate_status_token(suppressed_bridge_id, "node_target")
+        suppressed_status = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": suppressed_bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-feedback-suppressed",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The docs update keeps the trigger examples aligned with the current reviewer behavior.\n\n"
+                    "Touched paths reviewed: `README.md`, `docs/external-bridge/README.md`\n\n"
+                    "Risk areas checked: operator guidance\n\n"
+                    "Checks performed: compared the two README updates for consistency\n\n"
+                    "Why no finding: The patch only changes documentation text and does not alter runtime behavior."
+                ),
+            },
+            headers={"Authorization": f"Bearer {suppressed_token}"},
+        )
+        self.assertEqual(suppressed_status.status_code, 200, suppressed_status.text)
+
+        feedback_response = self.client.post(
+            f"/bridge/review-trials/{approved_bridge_id}/feedback",
+            json={
+                "benchmark_label": "phase6c",
+                "verdict": "useful",
+                "notes": "Two-pass review was more concrete than the earlier baseline.",
+            },
+            headers={"Authorization": f"Bearer {self.config.status_secret}"},
+        )
+        self.assertEqual(feedback_response.status_code, 200, feedback_response.text)
+        feedback_payload = feedback_response.json()
+        self.assertEqual(feedback_payload["review_feedback"]["benchmark_label"], "phase6c")
+        self.assertEqual(feedback_payload["review_feedback"]["verdict"], "useful")
+
+        trials_response = self.client.get("/bridge/review-trials?limit=5")
+        self.assertEqual(trials_response.status_code, 200, trials_response.text)
+        payload = trials_response.json()
+        self.assertEqual(payload["count"], 2)
+        self.assertEqual(payload["summary"]["total_trials"], 2)
+        self.assertEqual(payload["summary"]["published_count"], 1)
+        self.assertEqual(payload["summary"]["suppressed_count"], 1)
+        self.assertEqual(payload["summary"]["resolved_actions"]["approved"], 1)
+        self.assertEqual(payload["summary"]["resolved_actions"]["suppressed"], 1)
+        self.assertEqual(payload["summary"]["suppression_reasons"]["low_signal_no_finding"], 1)
+        self.assertEqual(payload["summary"]["feedback_verdicts"]["useful"], 1)
+        self.assertEqual(payload["summary"]["benchmark_labels"]["phase6c"], 1)
+        self.assertEqual(payload["summary"]["feedback_count"], 1)
+        self.assertEqual(payload["summary"]["feedback_useful_rate"], 1.0)
+
+        filtered_response = self.client.get(
+            "/bridge/review-trials?limit=5&target_alias=Hub-Sentinel&benchmark_label=phase6c&verdict=useful"
+        )
+        self.assertEqual(filtered_response.status_code, 200, filtered_response.text)
+        filtered = filtered_response.json()
+        self.assertEqual(filtered["count"], 1)
+        self.assertEqual(filtered["items"][0]["bridge_id"], approved_bridge_id)
+        self.assertEqual(filtered["items"][0]["review_feedback"]["verdict"], "useful")
+
+    def test_review_feedback_endpoint_requires_valid_feedback_token(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 6,
+                    "deletions": 1,
+                    "changes": 7,
+                    "patch": (
+                        "@@ -945,0 +945,6 @@\n"
+                        "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                    ),
+                }
+            ],
+            pr_body="Adds pending-task recovery observability.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=272),
+            delivery_id="delivery-feedback-auth",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-feedback-auth",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability.\n\n"
+                    "Observation: `_record_pending_task_poll_failure` records the latest poll status.\n\n"
+                    "Touched paths reviewed: `node/mep_runtime.py`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+
+        feedback_response = self.client.post(
+            f"/bridge/review-trials/{bridge_id}/feedback",
+            json={"verdict": "useful"},
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        self.assertEqual(feedback_response.status_code, 403, feedback_response.text)
 
     def test_status_callback_suppresses_generic_pr_review_writeback(self):
         response = self._post_webhook(


### PR DESCRIPTION
## Summary
- persist structured operator feedback for recorded review trials behind the bridge feedback token
- add trial summary aggregation for published, suppressed, retry, and feedback verdict baseline tracking
- extend bridge tests to cover summary reporting, filters, and feedback auth

## Testing
- python -m pytest tests/test_github_bridge.py -q
- python -m ruff check bridge/github_to_mep.py tests/test_github_bridge.py