### PR TITLE
Phase 6E: harden verifier evidence requirements

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -454,6 +454,24 @@ def _clean_review_list(values: Any, *, max_items: int, max_chars: int) -> list[s
     return cleaned
 
 
+def _filter_review_list_to_allowed(values: list[str], allowed: list[str]) -> list[str]:
+    if not values:
+        return []
+    if not allowed:
+        return values
+    allowed_map = {item.lower(): item for item in allowed if item}
+    filtered: list[str] = []
+    seen: set[str] = set()
+    for item in values:
+        normalized = item.lower()
+        matched = allowed_map.get(normalized)
+        if not matched or normalized in seen:
+            continue
+        filtered.append(matched)
+        seen.add(normalized)
+    return filtered
+
+
 def _system_prompt_for_task(
     task_data: dict[str, Any],
     *,
@@ -531,6 +549,8 @@ def _verification_system_prompt_for_task(task_data: dict[str, Any], *, review_ma
     return (
         f"{base} This is the verification pass. The user message may include provisional candidate risks from an earlier pass. "
         "Treat those candidates as hypotheses only. Promote a candidate into `findings` only when the supplied diff, workspace context, tests, or verification output directly support it. "
+        "For every published finding, set `file` to one of the supplied touched paths and include at least one exact changed-line identifier in `verified_identifiers` that supports the claim. "
+        "Reject any candidate that relies only on nearby file context, naming similarity, or speculation. "
         "If no candidate survives verification, keep `findings` empty, explain the checks you performed, and explicitly state why no finding is warranted."
     )
 
@@ -724,6 +744,18 @@ def _render_structured_review_with_task_data(
     if not isinstance(parsed, dict):
         return ""
     github_inputs = _review_github_inputs(task_data or {})
+    allowed_paths = _clean_review_list(github_inputs.get("touched_paths"), max_items=4, max_chars=120)
+    allowed_tests = _clean_review_list(github_inputs.get("touched_tests"), max_items=3, max_chars=120)
+    risk_pack = github_inputs.get("risk_pack")
+    allowed_identifiers = (
+        _clean_review_list(
+            risk_pack.get("changed_identifiers"),
+            max_items=8,
+            max_chars=80,
+        )
+        if isinstance(risk_pack, dict)
+        else []
+    )
     summary = _clean_review_text(parsed.get("summary"), max_chars=500)
     if _is_weak_review_text(summary):
         summary = ""
@@ -731,19 +763,23 @@ def _render_structured_review_with_task_data(
     if _is_weak_review_text(observation):
         observation = ""
     touched_paths = _clean_review_list(parsed.get("touched_paths"), max_items=4, max_chars=120)
+    touched_paths = _filter_review_list_to_allowed(touched_paths, allowed_paths)
     if not touched_paths:
-        touched_paths = _clean_review_list(github_inputs.get("touched_paths"), max_items=4, max_chars=120)
+        touched_paths = allowed_paths
     tests_reviewed = _clean_review_list(parsed.get("tests_reviewed"), max_items=3, max_chars=120)
+    tests_reviewed = _filter_review_list_to_allowed(tests_reviewed, allowed_tests)
     if not tests_reviewed:
-        tests_reviewed = _clean_review_list(github_inputs.get("touched_tests"), max_items=3, max_chars=120)
+        tests_reviewed = allowed_tests
     risk_areas_checked = _clean_review_list(parsed.get("risk_areas_checked"), max_items=4, max_chars=100)
     checks_performed = _clean_review_list(parsed.get("checks_performed"), max_items=4, max_chars=120)
     why_no_finding = _clean_review_text(parsed.get("why_no_finding"), max_chars=400)
     if _is_weak_review_text(why_no_finding):
         why_no_finding = ""
     verified_identifiers = _clean_review_list(parsed.get("verified_identifiers"), max_items=4, max_chars=80)
+    verified_identifiers = _filter_review_list_to_allowed(verified_identifiers, allowed_identifiers)
     findings_raw = parsed.get("findings")
     findings: list[str] = []
+    allowed_path_keys = {item.lower(): item for item in allowed_paths}
     if isinstance(findings_raw, list):
         for item in findings_raw[:2]:
             if not isinstance(item, dict):
@@ -756,10 +792,17 @@ def _render_structured_review_with_task_data(
             if _is_weak_review_text(combined):
                 continue
             file_name = _clean_review_label(item.get("file"), max_chars=80)
+            if file_name and allowed_path_keys:
+                matched = allowed_path_keys.get(file_name.lower())
+                if not matched:
+                    continue
+                file_name = matched
             if file_name:
                 findings.append(f"**{issue}** (`{file_name}`): {rationale or 'Check this path.'}")
             else:
                 findings.append(f"**{issue}**: {rationale or 'Check this logic.'}")
+    if findings and allowed_identifiers and not verified_identifiers:
+        findings = []
     sections: list[str] = []
     if findings:
         sections.append("## Review Findings")

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -4,6 +4,7 @@ import json
 import os
 import tempfile
 import unittest
+from typing import Optional
 from unittest.mock import AsyncMock, patch
 
 from node.identity import MEPIdentity
@@ -337,7 +338,15 @@ class TestRuntimeBidPolicy(unittest.TestCase):
 
 class TestRuntimeReviewPrompts(unittest.TestCase):
     @staticmethod
-    def _bridge_review_task_data(intent_type: str = "code.review.request") -> dict:
+    def _bridge_review_task_data(
+        intent_type: str = "code.review.request",
+        *,
+        changed_identifiers: Optional[list[str]] = None,
+    ) -> dict:
+        identifiers = changed_identifiers or [
+            "_record_pending_task_poll_failure",
+            "last_poll_status",
+        ]
         return {
             "id": "task_bridge_review",
             "bounty": 0.0,
@@ -365,6 +374,9 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
                                 "number": 246,
                                 "touched_paths": ["bridge/github_to_mep.py"],
                                 "touched_tests": ["tests/test_github_bridge.py"],
+                                "risk_pack": {
+                                    "changed_identifiers": identifiers
+                                },
                             },
                         },
                     },
@@ -433,7 +445,9 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
 
     def test_deepseek_adapter_uses_reviewer_prompt_for_bridge_review_tasks(self):
         adapter = mep_runtime.DeepSeekAdapter(api_key="secret-key", model="deepseek-chat")
-        task_data = self._bridge_review_task_data()
+        task_data = self._bridge_review_task_data(
+            changed_identifiers=["preserve_coalesced_targets", "coalesced_targets"]
+        )
         fake_responses = [
             _FakeResponse(
                 200,
@@ -462,6 +476,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
                                     '{"summary":"Checked the bridge diff.","observation":"The metadata wiring stays backward-compatible.",'
                                     '"touched_paths":["bridge/github_to_mep.py"],'
                                     '"tests_reviewed":["tests/test_github_bridge.py"],'
+                                    '"verified_identifiers":["preserve_coalesced_targets"],'
                                     '"findings":'
                                     '[{"file":"bridge/github_to_mep.py","issue":"Preserve coalesced targets",'
                                     '"rationale":"Otherwise the second mention can overwrite the first target during the coalesce window."}],'
@@ -488,6 +503,8 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("candidate-generation pass", first_system_prompt)
         self.assertIn("return ONLY a JSON object", second_system_prompt)
         self.assertIn("This is the verification pass.", second_system_prompt)
+        self.assertIn("set `file` to one of the supplied touched paths", second_system_prompt)
+        self.assertIn("exact changed-line identifier in `verified_identifiers`", second_system_prompt)
         self.assertIn("Candidate risks to verify before publishing any finding", second_user_payload)
 
     def test_deepseek_adapter_filters_weak_review_findings(self):
@@ -540,7 +557,10 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
                 '"findings":[],"approval_recommendation":"approve"}'
             ),
             max_chars=1000,
-            task_data=self._bridge_review_task_data(intent_type="code.review.approve"),
+            task_data=self._bridge_review_task_data(
+                intent_type="code.review.approve",
+                changed_identifiers=["_score_review_quality", "_approval_quality_failure"],
+            ),
         )
 
         self.assertIn("## Review Summary", rendered)
@@ -567,6 +587,47 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("Risk areas checked: trial persistence, endpoint decoding", rendered)
         self.assertIn("Checks performed: verified suppression and publish paths mention `review_result_json`, checked `/bridge/review-trials` returns stored review metadata", rendered)
         self.assertIn("Why no finding: The new writes and reads stay consistent across both persistence paths, so the telemetry path looks low-risk.", rendered)
+
+    def test_structured_review_drops_findings_without_allowed_changed_identifiers(self):
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            (
+                '{"summary":"Checked the bridge diff.","observation":"The coalesce path still needs a concrete proof point.",'
+                '"touched_paths":["bridge/github_to_mep.py"],'
+                '"tests_reviewed":["tests/test_github_bridge.py"],'
+                '"verified_identifiers":["imagined_guard"],'
+                '"findings":[{"file":"bridge/github_to_mep.py","issue":"Preserve coalesced targets",'
+                '"rationale":"Otherwise the second mention can overwrite the first target during the coalesce window."}],'
+                '"approval_recommendation":"comment"}'
+            ),
+            max_chars=1000,
+            task_data=self._bridge_review_task_data(),
+        )
+
+        self.assertIn("## Review Summary", rendered)
+        self.assertNotIn("## Review Findings", rendered)
+        self.assertNotIn("Preserve coalesced targets", rendered)
+        self.assertNotIn("Changed identifiers verified:", rendered)
+
+    def test_structured_review_drops_findings_for_untouched_files(self):
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            (
+                '{"summary":"Checked the bridge diff.","observation":"The real change stays scoped to the bridge entrypoint.",'
+                '"touched_paths":["bridge/other_file.py"],'
+                '"tests_reviewed":["tests/test_other_file.py"],'
+                '"verified_identifiers":["_record_pending_task_poll_failure"],'
+                '"findings":[{"file":"bridge/not_touched.py","issue":"Unexpected side effect",'
+                '"rationale":"This claim points at a file that is not part of the supplied diff."}],'
+                '"approval_recommendation":"comment"}'
+            ),
+            max_chars=1000,
+            task_data=self._bridge_review_task_data(),
+        )
+
+        self.assertIn("## Review Summary", rendered)
+        self.assertNotIn("## Review Findings", rendered)
+        self.assertNotIn("Unexpected side effect", rendered)
+        self.assertIn("Touched paths reviewed: `bridge/github_to_mep.py`", rendered)
+        self.assertIn("Tests reviewed: `tests/test_github_bridge.py`", rendered)
 
     def test_extract_review_candidates_deduplicates_and_cleans_items(self):
         candidates = mep_runtime._extract_review_candidates(  # noqa: SLF001


### PR DESCRIPTION
## Summary
- require verification-pass findings to stay on supplied touched paths and be backed by exact changed identifiers
- filter structured review output so unsupported findings are downgraded instead of being published
- extend runtime tests to cover both accepted and rejected verifier evidence paths

## Testing
- python -m pytest tests/test_node_runtime.py -q
- python -m ruff check node/mep_runtime.py tests/test_node_runtime.py