### PR TITLE
Phase 6F: hunk-centered retrieval

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1281,6 +1281,7 @@ class GitHubToMEPBridgeService:
             "risk_tags",
             "reviewability",
             "risk_pack",
+            "hunk_contexts",
         ):
             value = review_package.get(key)
             if value not in (None, "", [], {}):
@@ -1316,6 +1317,42 @@ class GitHubToMEPBridgeService:
         if compact_files:
             compact["changed_files"] = compact_files
         return compact
+
+    @staticmethod
+    def _build_hunk_contexts(changed_file_entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        contexts: list[dict[str, Any]] = []
+        for entry in changed_file_entries:
+            if not isinstance(entry, dict):
+                continue
+            filename = str(entry.get("filename") or "").strip()
+            patch_text = str(entry.get("patch") or "").strip()
+            if not filename or not patch_text:
+                continue
+            hunk_header = ""
+            changed_lines: list[str] = []
+            for line in patch_text.splitlines():
+                if line.startswith("@@") and not hunk_header:
+                    hunk_header = line.strip()
+                    continue
+                if line.startswith(("+++", "---")):
+                    continue
+                if line.startswith(("+", "-")):
+                    clipped = line[:160].rstrip()
+                    changed_lines.append(clipped)
+                if len(changed_lines) >= 3:
+                    break
+            if not hunk_header and not changed_lines:
+                continue
+            contexts.append(
+                {
+                    "filename": filename,
+                    "hunk_header": hunk_header,
+                    "changed_lines": changed_lines,
+                }
+            )
+            if len(contexts) >= 8:
+                break
+        return contexts
 
     @staticmethod
     def _is_test_path(path: str) -> bool:
@@ -1647,6 +1684,7 @@ class GitHubToMEPBridgeService:
                 touched_tests=touched_tests,
                 risk_tags=risk_tags,
             )
+            hunk_contexts = self._build_hunk_contexts(changed_file_entries)
             if touched_paths:
                 sections.append("Touched paths:\n" + "\n".join(f"- {path}" for path in touched_paths[:8]))
             if touched_tests:
@@ -1672,6 +1710,27 @@ class GitHubToMEPBridgeService:
                 )
             if risk_pack_lines:
                 sections.append("Deterministic risk pack:\n" + "\n".join(risk_pack_lines))
+            hunk_lines: list[str] = []
+            for context in hunk_contexts:
+                if not isinstance(context, dict):
+                    continue
+                filename = str(context.get("filename") or "").strip()
+                if not filename:
+                    continue
+                line = f"- {filename}"
+                header = str(context.get("hunk_header") or "").strip()
+                if header:
+                    line += f" {header}"
+                changed_lines = [
+                    str(item).strip()
+                    for item in (context.get("changed_lines") or [])
+                    if str(item).strip()
+                ]
+                if changed_lines:
+                    line += "\n  " + "\n  ".join(changed_lines)
+                hunk_lines.append(line)
+            if hunk_lines:
+                sections.append("Hunk-centered context pack:\n" + "\n".join(hunk_lines))
             reviewability = self._classify_reviewability(
                 touched_paths=touched_paths,
                 touched_tests=touched_tests,
@@ -1726,6 +1785,7 @@ class GitHubToMEPBridgeService:
             "touched_tests": touched_tests,
             "risk_tags": risk_tags,
             "risk_pack": risk_pack,
+            "hunk_contexts": hunk_contexts,
             "reviewability": reviewability,
             "changed_files": changed_file_entries,
             "instructions_context": "\n\n".join(section for section in sections if section.strip()),

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -58,6 +58,11 @@ def _review_run_checks_enabled() -> bool:
     return _env_truthy("MEP_REVIEW_RUN_CHECKS", "0")
 
 
+def _review_trusted_associations() -> set[str]:
+    raw = os.getenv("MEP_REVIEW_TRUSTED_ASSOCIATIONS", "OWNER,MEMBER,COLLABORATOR")
+    return {item.strip().upper() for item in raw.split(",") if item.strip()}
+
+
 def _is_adapter_error(text: str) -> bool:
     """Detect adapter failures that must never be published as a real review.
 
@@ -1038,33 +1043,147 @@ class WorkspaceManager:
             return None
         return candidate
 
+    @staticmethod
+    def _is_test_path(path: str) -> bool:
+        lowered = str(path or "").replace("\\", "/").strip().lower()
+        if not lowered:
+            return False
+        basename = lowered.rsplit("/", 1)[-1]
+        return (
+            lowered.startswith("tests/")
+            or lowered.startswith("test/")
+            or "/tests/" in lowered
+            or "/test/" in lowered
+            or basename.startswith("test_")
+            or basename.endswith("_test.py")
+            or ".test." in basename
+            or ".spec." in basename
+        )
+
+    @staticmethod
+    def _line_numbered_snippet(
+        content: str,
+        focus_terms: list[str],
+        *,
+        max_snippets: int = 3,
+        context_radius: int = 3,
+    ) -> list[str]:
+        if not content.strip():
+            return []
+        lines = content.splitlines()
+        normalized_terms = [term.strip() for term in focus_terms if term and term.strip()]
+        if not normalized_terms:
+            return []
+        windows: list[tuple[int, int]] = []
+        for idx, raw_line in enumerate(lines):
+            line = raw_line.strip()
+            if not line:
+                continue
+            lowered = raw_line.lower()
+            matched = any(term.lower() in lowered for term in normalized_terms)
+            if not matched:
+                continue
+            start = max(0, idx - context_radius)
+            end = min(len(lines), idx + context_radius + 1)
+            if windows and start <= windows[-1][1]:
+                windows[-1] = (windows[-1][0], max(windows[-1][1], end))
+            else:
+                windows.append((start, end))
+            if len(windows) >= max_snippets:
+                break
+        snippets: list[str] = []
+        for start, end in windows:
+            block_lines = [f"{line_no + 1}: {lines[line_no]}" for line_no in range(start, end)]
+            snippets.append("\n".join(block_lines).rstrip())
+        return snippets
+
+    @classmethod
+    def _focused_context_terms(
+        cls,
+        path: str,
+        *,
+        touched_tests: list[str],
+        risk_pack: Optional[dict[str, Any]],
+    ) -> list[str]:
+        risk_pack = risk_pack if isinstance(risk_pack, dict) else {}
+        identifiers = [
+            str(item).strip()
+            for item in (risk_pack.get("changed_identifiers") or [])
+            if str(item).strip()
+        ]
+        if cls._is_test_path(path):
+            basename = os.path.basename(path)
+            candidates = identifiers + [basename, basename.replace(".py", "")]
+            return [item for item in candidates if item]
+        primary = [
+            str(item).strip()
+            for item in (risk_pack.get("touched_non_test_paths") or [])
+            if str(item).strip()
+        ]
+        candidates = identifiers + primary + list(touched_tests[:2])
+        return [item for item in candidates if item]
+
     def build_review_context(
         self,
         workspace_path: str,
         touched_paths: list[str],
         *,
+        touched_tests: Optional[list[str]] = None,
+        risk_pack: Optional[dict[str, Any]] = None,
         max_files: int = 12,
         max_file_chars: int = 20000,
         max_chars: int = 60000,
     ) -> str:
-        """Embed the full contents of changed files from the checked-out PR head.
-
-        Earlier revisions only embedded ~700 chars per file across 3 files, which
-        starved the reviewer of context and caused it to mistake its own
-        truncated input for defects in the code. Providing whole files (within a
-        generous budget) lets the model reason about the real change.
-        """
+        """Build a ranked local context pack around the changed hunks, then fall back to full files."""
         if not workspace_path or not isinstance(touched_paths, list):
             return ""
+        touched_tests = touched_tests if isinstance(touched_tests, list) else []
+        review_targets: list[str] = []
+        for item in [*touched_paths, *touched_tests]:
+            text = str(item or "").strip()
+            if text and text not in review_targets:
+                review_targets.append(text)
         sections = [
             f"Local workspace path: {workspace_path}",
-            "Full contents of changed files at the PR head commit (authoritative source for your review):",
+            "Hunk-centered local context pack from the PR head commit (authoritative source for your review):",
         ]
         remaining = max_chars
         added = 0
-        for path in touched_paths:
+        snippet_paths: set[str] = set()
+        for path in review_targets:
             if added >= max_files or remaining <= 400:
                 break
+            resolved = self._resolve_repo_file(workspace_path, str(path or ""))
+            if not resolved or not os.path.isfile(resolved):
+                continue
+            try:
+                with open(resolved, "r", encoding="utf-8", errors="replace") as handle:
+                    content = handle.read()
+            except OSError:
+                continue
+            if not content.strip():
+                continue
+            focus_terms = self._focused_context_terms(
+                str(path or ""),
+                touched_tests=touched_tests,
+                risk_pack=risk_pack,
+            )
+            snippets = self._line_numbered_snippet(content, focus_terms)
+            if snippets:
+                block = f"### {path}\n" + "\n\n".join(f"```text\n{snippet}\n```" for snippet in snippets)
+                if len(block) <= remaining:
+                    sections.append(block)
+                    remaining -= len(block) + 2
+                    added += 1
+                    snippet_paths.add(str(path))
+                    continue
+        if remaining > 400:
+            sections.append("Full contents fallback for changed files at the PR head commit:")
+        for path in review_targets:
+            if added >= max_files or remaining <= 400:
+                break
+            if str(path) in snippet_paths:
+                continue
             resolved = self._resolve_repo_file(workspace_path, str(path or ""))
             if not resolved or not os.path.isfile(resolved):
                 continue
@@ -1149,6 +1268,19 @@ class WorkspaceManager:
             if path and os.path.isfile(path):
                 resolved.append(text)
         return resolved
+
+    def verification_policy_note(self, task_data: dict[str, Any]) -> str:
+        github_inputs = _review_github_inputs(task_data)
+        association = str(github_inputs.get("author_association") or "").strip().upper()
+        if not association:
+            return ""
+        if association in _review_trusted_associations():
+            return ""
+        return (
+            "Automated verification checks were skipped because this PR was triggered by an "
+            f"untrusted contributor association (`{association}`). Treat the diff and workspace "
+            "context as read-only evidence unless a trusted maintainer reruns the review."
+        )
 
     def build_verification_report(
         self,
@@ -1897,17 +2029,23 @@ class RuntimeNode:
                         self.workspace.build_review_context,
                         workspace_path,
                         touched_paths,
+                        touched_tests=touched_tests,
+                        risk_pack=github_inputs.get("risk_pack"),
                     )
                     if workspace_context:
                         instructions = f"{instructions}\n\nAdditional local workspace context:\n{workspace_context}"
-                    verification_report = await asyncio.to_thread(
-                        self.workspace.build_verification_report,
-                        workspace_path,
-                        touched_paths,
-                        touched_tests,
-                    )
-                    if verification_report:
-                        instructions = f"{instructions}\n\n{verification_report}"
+                    verification_note = self.workspace.verification_policy_note(adapter_task_data)
+                    if verification_note:
+                        instructions = f"{instructions}\n\n{verification_note}"
+                    else:
+                        verification_report = await asyncio.to_thread(
+                            self.workspace.build_verification_report,
+                            workspace_path,
+                            touched_paths,
+                            touched_tests,
+                        )
+                        if verification_report:
+                            instructions = f"{instructions}\n\n{verification_report}"
                 else:
                     print(f"[mep workspace] sync failed: {path_or_err}")
                     # We continue anyway, but the adapter might be working on stale code

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -459,6 +459,9 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(github_inputs["risk_pack"]["changed_identifiers"], ["write_state", "test_review_package"])
         self.assertIn("persistence", github_inputs["risk_pack"]["risk_tags"])
         self.assertEqual(github_inputs["risk_pack"]["deleted_tests"], [])
+        self.assertEqual(github_inputs["hunk_contexts"][0]["filename"], "hub/db.py")
+        self.assertEqual(github_inputs["hunk_contexts"][0]["hunk_header"], "@@ -1,3 +1,8 @@")
+        self.assertIn("+def write_state()", github_inputs["hunk_contexts"][0]["changed_lines"][0])
         self.assertEqual(github_inputs["coalesced_delivery_ids"], ["delivery-package"])
         self.assertEqual(github_inputs["event_sequence"], 1)
         self.assertEqual(github_inputs["changed_files"][0]["filename"], "hub/db.py")
@@ -469,6 +472,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertIn("Touched tests:", instructions)
         self.assertIn("Risk tags: persistence", instructions)
         self.assertIn("Deterministic risk pack:", instructions)
+        self.assertIn("Hunk-centered context pack:", instructions)
         self.assertIn("Changed identifiers: write_state, test_review_package", instructions)
 
     def test_pr_review_package_detects_singular_test_path_and_security_tag(self):

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -863,7 +863,13 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             os.makedirs(os.path.join(tmpdir, "bridge"), exist_ok=True)
             with open(os.path.join(tmpdir, "bridge", "github_to_mep.py"), "w", encoding="utf-8") as handle:
-                handle.write("def live_sync_context():\n    return True\n")
+                handle.write(
+                    "def untouched_helper():\n    return False\n\n"
+                    "def live_sync_context():\n    state_value = True\n    return state_value\n"
+                )
+            os.makedirs(os.path.join(tmpdir, "tests"), exist_ok=True)
+            with open(os.path.join(tmpdir, "tests", "test_bridge_sync.py"), "w", encoding="utf-8") as handle:
+                handle.write("def test_live_sync_context():\n    assert True\n")
 
             task_data = TestRuntimeReviewPrompts._bridge_review_task_data()
             payload = json.loads(task_data["payload"])
@@ -872,6 +878,11 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
                     "repo_clone_url": "https://github.com/example/repo.git",
                     "head_sha": "abc12345",
                     "head_ref": "feature/test",
+                    "touched_tests": ["tests/test_bridge_sync.py"],
+                    "risk_pack": {
+                        "changed_identifiers": ["live_sync_context", "state_value"],
+                        "touched_non_test_paths": ["bridge/github_to_mep.py"],
+                    },
                 }
             )
             task_data["payload"] = json.dumps(payload)
@@ -892,7 +903,9 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         instructions, adapter_task_data = adapter_mock.call_args.args
         self.assertIn("Additional local workspace context:", instructions)
         self.assertIn("Local workspace path:", instructions)
+        self.assertIn("Hunk-centered local context pack", instructions)
         self.assertIn("live_sync_context", instructions)
+        self.assertIn("test_live_sync_context", instructions)
         self.assertEqual(
             adapter_task_data["task"]["inputs"]["github"]["local_workspace_path"],
             tmpdir,
@@ -1274,10 +1287,38 @@ class TestWorkspaceReviewContext(unittest.TestCase):
             wm = mep_runtime.WorkspaceManager(tmp)
             ctx = wm.build_review_context(tmp, ["bridge/big.py"])
 
-        self.assertIn("Full contents of changed files", ctx)
+        self.assertIn("Full contents fallback for changed files", ctx)
         self.assertIn("line_0 = 0", ctx)
         # The tail of a >700 char file must be present: earlier excerpt logic clipped it.
         self.assertIn("line_199 = 199", ctx)
+
+    def test_build_review_context_prioritizes_changed_identifiers_and_tests(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "bridge"), exist_ok=True)
+            os.makedirs(os.path.join(tmp, "tests"), exist_ok=True)
+            with open(os.path.join(tmp, "bridge", "github_to_mep.py"), "w", encoding="utf-8") as handle:
+                handle.write(
+                    "def untouched_helper():\n    return False\n\n"
+                    "def build_review_context():\n    focus_value = 'ready'\n    return focus_value\n"
+                )
+            with open(os.path.join(tmp, "tests", "test_bridge_review.py"), "w", encoding="utf-8") as handle:
+                handle.write("def test_build_review_context():\n    assert True\n")
+
+            wm = mep_runtime.WorkspaceManager(tmp)
+            ctx = wm.build_review_context(
+                tmp,
+                ["bridge/github_to_mep.py", "tests/test_bridge_review.py"],
+                touched_tests=["tests/test_bridge_review.py"],
+                risk_pack={
+                    "changed_identifiers": ["build_review_context", "focus_value"],
+                    "touched_non_test_paths": ["bridge/github_to_mep.py"],
+                },
+            )
+
+        self.assertIn("Hunk-centered local context pack", ctx)
+        self.assertIn("build_review_context", ctx)
+        self.assertIn("focus_value", ctx)
+        self.assertIn("test_build_review_context", ctx)
 
     def test_build_verification_report_disabled_by_default(self):
         with (


### PR DESCRIPTION
## Summary
- add compact hunk-centered context to GitHub review task inputs
- build a ranked local workspace context pack around changed identifiers and touched tests
- keep full-file fallback while preserving trusted-only verification policy seams

## Validation
- python -m pytest tests/test_node_runtime.py tests/test_github_bridge.py -q
- python -m ruff check node/mep_runtime.py tests/test_node_runtime.py bridge/github_to_mep.py tests/test_github_bridge.py