### PR TITLE
Phase 6G: operationalize review benchmarks

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -33,6 +33,43 @@ DEFAULT_TRIGGER_VERBS = {
 }
 DEFAULT_ALLOWED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 BRIDGE_OUTPUT_MARKER = "<!-- mep-bridge:output"
+REVIEW_BENCHMARK_SCENARIOS = [
+    {
+        "id": "docs_only_precision",
+        "suite": "phase6_precision",
+        "title": "Docs-only suppression precision",
+        "goal": "Verify that docs-only PRs are suppressed unless the reviewer cites a concrete behavioral issue.",
+        "expected_focus": ["low_signal", "suppression", "no_finding"],
+    },
+    {
+        "id": "config_env_precision",
+        "suite": "phase6_precision",
+        "title": "Config/env change grounding",
+        "goal": "Verify that config or workflow changes produce grounded risk analysis tied to the actual changed files.",
+        "expected_focus": ["env_config", "workflow", "grounding"],
+    },
+    {
+        "id": "false_positive_guard",
+        "suite": "phase6_precision",
+        "title": "Plausible-but-wrong false positive guard",
+        "goal": "Catch reviews that sound right but cite the wrong file, wrong identifier, or wrong causal explanation.",
+        "expected_focus": ["false_positive", "verifier", "identifier_anchor"],
+    },
+    {
+        "id": "approval_safety",
+        "suite": "phase6_approval",
+        "title": "Approval evidence safety",
+        "goal": "Require approvals to cite changed-line identifiers, touched tests, and green CI before publishing APPROVE.",
+        "expected_focus": ["approval", "ci_gate", "changed_identifiers"],
+    },
+    {
+        "id": "missed_issue_recall",
+        "suite": "phase6_recall",
+        "title": "Known-risk recall",
+        "goal": "Track PRs seeded with known regressions so missed findings are labeled and measured against baseline.",
+        "expected_focus": ["missed_issue", "recall", "risk_pack"],
+    },
+]
 _WEAK_GITHUB_REVIEW_PATTERNS = [
     r"\blooks good\b",
     r"\blooks correct\b",
@@ -2851,24 +2888,51 @@ class GitHubToMEPBridgeService:
         target_alias: Optional[str] = None,
         benchmark_label: Optional[str] = None,
         verdict: Optional[str] = None,
+        needs_feedback: Optional[bool] = None,
     ) -> dict[str, Any]:
-        raw_limit = max(limit, 200) if any((target_alias, benchmark_label, verdict)) else limit
+        raw_limit = max(limit, 200) if any((target_alias, benchmark_label, verdict, needs_feedback is not None)) else limit
         items = self.store.list_recent_review_trials(limit=raw_limit)
         normalized_target = _normalize_alias_key(target_alias)
         normalized_label = self._normalize_feedback_text(benchmark_label, max_chars=120)
         normalized_verdict = self._normalize_feedback_verdict(verdict)
         filtered: list[dict[str, Any]] = []
         for item in items:
+            review_result = item.get("review_result") or {}
+            feedback = item.get("review_feedback") or {}
+            feedback_recorded = bool(str(feedback.get("verdict") or "").strip())
+            feedback_required = bool(review_result)
             if normalized_target and _normalize_alias_key(str(item.get("target_alias") or "")) != normalized_target:
                 continue
-            feedback = item.get("review_feedback") or {}
             if normalized_label and str(feedback.get("benchmark_label") or "").strip() != normalized_label:
                 continue
             if normalized_verdict and str(feedback.get("verdict") or "").strip().lower() != normalized_verdict:
                 continue
-            filtered.append(item)
+            if needs_feedback is True and (not feedback_required or feedback_recorded):
+                continue
+            if needs_feedback is False and not feedback_recorded:
+                continue
+            materialized = dict(item)
+            materialized["feedback_required"] = feedback_required
+            materialized["feedback_recorded"] = feedback_recorded
+            materialized["feedback_status"] = "labeled" if feedback_recorded else ("pending" if feedback_required else "not_applicable")
+            filtered.append(materialized)
         items = filtered[: max(1, min(int(limit), 200))]
         return {"status": "ok", "count": len(items), "items": items, "summary": self._summarize_review_trials(items)}
+
+    def list_review_benchmarks(self, *, suite: Optional[str] = None) -> dict[str, Any]:
+        normalized_suite = self._normalize_feedback_text(suite, max_chars=120)
+        items = [
+            item
+            for item in REVIEW_BENCHMARK_SCENARIOS
+            if not normalized_suite or str(item.get("suite") or "").strip() == normalized_suite
+        ]
+        suites = Counter(str(item.get("suite") or "").strip() for item in items if str(item.get("suite") or "").strip())
+        return {
+            "status": "ok",
+            "count": len(items),
+            "items": items,
+            "suites": dict(sorted(suites.items())),
+        }
 
     @staticmethod
     def _normalize_feedback_text(value: Optional[str], *, max_chars: int) -> str:
@@ -2929,6 +2993,7 @@ class GitHubToMEPBridgeService:
         published_count = 0
         suppressed_count = 0
         retry_queued_count = 0
+        feedback_pending_count = 0
         quality_scores: list[int] = []
         for item in items:
             target_alias = str(item.get("target_alias") or "").strip()
@@ -2954,6 +3019,8 @@ class GitHubToMEPBridgeService:
             verdict = str(review_feedback.get("verdict") or "").strip().lower()
             if verdict:
                 feedback_verdicts[verdict] += 1
+            elif review_result:
+                feedback_pending_count += 1
             benchmark_label = str(review_feedback.get("benchmark_label") or "").strip()
             if benchmark_label:
                 benchmark_labels[benchmark_label] += 1
@@ -2961,6 +3028,7 @@ class GitHubToMEPBridgeService:
         useful_count = int(feedback_verdicts.get("useful") or 0)
         avg_quality_score = round(sum(quality_scores) / len(quality_scores), 2) if quality_scores else 0.0
         useful_rate = round(useful_count / feedback_count, 4) if feedback_count else None
+        label_coverage = round(feedback_count / (feedback_count + feedback_pending_count), 4) if (feedback_count + feedback_pending_count) else None
         return {
             "total_trials": len(items),
             "published_count": published_count,
@@ -2973,6 +3041,8 @@ class GitHubToMEPBridgeService:
             "benchmark_labels": dict(sorted(benchmark_labels.items())),
             "target_aliases": dict(sorted(target_aliases.items())),
             "feedback_count": feedback_count,
+            "feedback_pending_count": feedback_pending_count,
+            "feedback_label_coverage": label_coverage,
             "feedback_useful_rate": useful_rate,
         }
 
@@ -3170,13 +3240,21 @@ def create_app(
         target_alias: Optional[str] = None,
         benchmark_label: Optional[str] = None,
         verdict: Optional[str] = None,
+        needs_feedback: Optional[bool] = None,
     ) -> dict[str, Any]:
         return bridge_service.list_review_trials(
             limit=limit,
             target_alias=target_alias,
             benchmark_label=benchmark_label,
             verdict=verdict,
+            needs_feedback=needs_feedback,
         )
+
+    @app.get("/bridge/review-benchmarks")
+    async def bridge_review_benchmarks(
+        suite: Optional[str] = None,
+    ) -> dict[str, Any]:
+        return bridge_service.list_review_benchmarks(suite=suite)
 
     @app.post("/bridge/review-trials/{bridge_id}/feedback")
     async def bridge_review_feedback(

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1035,11 +1035,33 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(item["action"], "approved")
         self.assertEqual(item["review_result"]["resolved_action"], "approved")
         self.assertTrue(item["review_result"]["published"])
+        self.assertTrue(item["feedback_required"])
+        self.assertFalse(item["feedback_recorded"])
+        self.assertEqual(item["feedback_status"], "pending")
         self.assertEqual(item["review_result"]["head_sha"], "headsha123")
         self.assertEqual(item["review_result"]["ci_state"], "green")
         self.assertEqual(payload["summary"]["total_trials"], 1)
         self.assertEqual(payload["summary"]["published_count"], 1)
         self.assertEqual(payload["summary"]["resolved_actions"], {"approved": 1})
+        self.assertEqual(payload["summary"]["feedback_pending_count"], 1)
+        self.assertEqual(payload["summary"]["feedback_label_coverage"], 0.0)
+
+    def test_review_benchmarks_endpoint_returns_seeded_catalog(self):
+        response = self.client.get("/bridge/review-benchmarks")
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        self.assertGreaterEqual(payload["count"], 5)
+        self.assertIn("phase6_precision", payload["suites"])
+        first_ids = {item["id"] for item in payload["items"]}
+        self.assertIn("docs_only_precision", first_ids)
+
+        filtered_response = self.client.get("/bridge/review-benchmarks?suite=phase6_precision")
+        self.assertEqual(filtered_response.status_code, 200, filtered_response.text)
+        filtered = filtered_response.json()
+        self.assertEqual(
+            {item["suite"] for item in filtered["items"]},
+            {"phase6_precision"},
+        )
 
     def test_review_trials_feedback_endpoint_records_feedback_and_summary(self):
         checks_payload = {
@@ -1193,6 +1215,8 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(payload["summary"]["feedback_verdicts"]["useful"], 1)
         self.assertEqual(payload["summary"]["benchmark_labels"]["phase6c"], 1)
         self.assertEqual(payload["summary"]["feedback_count"], 1)
+        self.assertEqual(payload["summary"]["feedback_pending_count"], 1)
+        self.assertEqual(payload["summary"]["feedback_label_coverage"], 0.5)
         self.assertEqual(payload["summary"]["feedback_useful_rate"], 1.0)
 
         filtered_response = self.client.get(
@@ -1203,6 +1227,13 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(filtered["count"], 1)
         self.assertEqual(filtered["items"][0]["bridge_id"], approved_bridge_id)
         self.assertEqual(filtered["items"][0]["review_feedback"]["verdict"], "useful")
+
+        pending_response = self.client.get("/bridge/review-trials?limit=5&needs_feedback=true")
+        self.assertEqual(pending_response.status_code, 200, pending_response.text)
+        pending_payload = pending_response.json()
+        self.assertEqual(pending_payload["count"], 1)
+        self.assertEqual(pending_payload["items"][0]["bridge_id"], suppressed_bridge_id)
+        self.assertEqual(pending_payload["items"][0]["feedback_status"], "pending")
 
     def test_review_feedback_endpoint_requires_valid_feedback_token(self):
         self._set_pr_review_package(


### PR DESCRIPTION
## Summary
- add a seeded review benchmark catalog endpoint
- surface pending vs labeled feedback state on review trials
- add filters and summary metrics for unlabeled production trials

## Validation
- python -m pytest tests/test_github_bridge.py -q
- python -m ruff check bridge/github_to_mep.py tests/test_github_bridge.py