### PR TITLE
Phase 6H: ground review writeback and external checks

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -2662,6 +2662,94 @@ class GitHubToMEPBridgeService:
             return {}
         return decoded if isinstance(decoded, dict) else {}
 
+    @classmethod
+    def _extract_structured_findings(cls, detail: Optional[str]) -> list[dict[str, str]]:
+        findings: list[dict[str, str]] = []
+        if not detail:
+            return findings
+        pattern = re.compile(
+            r"^\s*\d+\.\s+\*\*(?P<issue>.+?)\*\*(?:\s+\(`(?P<file>[^`]+)`\))?:\s*(?P<rationale>.+?)\s*$"
+        )
+        for line in str(detail).splitlines():
+            match = pattern.match(line)
+            if not match:
+                continue
+            issue = cls._normalize_feedback_text(match.group("issue"), max_chars=200)
+            rationale = cls._normalize_feedback_text(match.group("rationale"), max_chars=500)
+            file_name = cls._normalize_feedback_text(match.group("file"), max_chars=160)
+            if not issue:
+                continue
+            findings.append({"issue": issue, "rationale": rationale, "file": file_name})
+            if len(findings) >= 2:
+                break
+        return findings
+
+    @staticmethod
+    def _patch_added_line_number(patch_text: str, finding_text: str) -> Optional[int]:
+        current_right: Optional[int] = None
+        fallback_line: Optional[int] = None
+        focus_terms = [term.lower() for term in re.findall(r"`([^`]+)`", finding_text or "") if term.strip()]
+        for raw_line in str(patch_text or "").splitlines():
+            if raw_line.startswith("@@"):
+                match = re.search(r"\+(\d+)", raw_line)
+                current_right = int(match.group(1)) if match else None
+                continue
+            if current_right is None or raw_line.startswith(("+++", "---")):
+                continue
+            if raw_line.startswith("+"):
+                line_text = raw_line[1:].lower()
+                if fallback_line is None:
+                    fallback_line = current_right
+                if focus_terms and any(term in line_text for term in focus_terms):
+                    return current_right
+                current_right += 1
+                continue
+            if raw_line.startswith("-"):
+                continue
+            current_right += 1
+        return fallback_line
+
+    def _inline_review_comments(self, detail: Optional[str], review_package: dict[str, Any]) -> list[dict[str, Any]]:
+        findings = self._extract_structured_findings(detail)
+        if not findings:
+            return []
+        expected_paths = [
+            str(item).strip()
+            for item in (review_package.get("touched_paths") or [])
+            if str(item).strip()
+        ]
+        patches_by_path = self._patch_text_by_path(review_package)
+        comments: list[dict[str, Any]] = []
+        for finding in findings:
+            file_hint = str(finding.get("file") or "").strip()
+            if not file_hint:
+                continue
+            matched_paths = self._match_path_reference(file_hint, expected_paths)
+            if not matched_paths:
+                continue
+            target_path = sorted(matched_paths)[0]
+            patch_text = str((patches_by_path.get(target_path) or {}).get("full") or "")
+            line_number = self._patch_added_line_number(
+                patch_text,
+                f"{finding.get('issue') or ''} {finding.get('rationale') or ''}",
+            )
+            if not line_number:
+                continue
+            body_lines = [f"**{finding['issue']}**"]
+            rationale = str(finding.get("rationale") or "").strip()
+            if rationale:
+                body_lines.append("")
+                body_lines.append(rationale)
+            comments.append(
+                {
+                    "path": target_path,
+                    "line": int(line_number),
+                    "side": "RIGHT",
+                    "body": "\n".join(body_lines).strip(),
+                }
+            )
+        return comments[:2]
+
     def _target_alias_for_execution(self, execution: dict[str, Any]) -> str:
         return str(execution.get("target_alias") or self.config.target_alias or "").strip()
 
@@ -2696,13 +2784,23 @@ class GitHubToMEPBridgeService:
         response.raise_for_status()
 
     def _submit_github_review(
-        self, repo_full_name: str, number: int, event: str, body: str, github_token: str
+        self,
+        repo_full_name: str,
+        number: int,
+        event: str,
+        body: str,
+        github_token: str,
+        *,
+        comments: Optional[list[dict[str, Any]]] = None,
     ) -> None:
         if not github_token:
             raise HTTPException(status_code=500, detail="Bridge configuration missing: GitHub writeback token")
+        payload: dict[str, Any] = {"event": event, "body": body}
+        if comments:
+            payload["comments"] = comments
         response = self.github_session.post(
             f"https://api.github.com/repos/{repo_full_name}/pulls/{number}/reviews",
-            json={"event": event, "body": body},
+            json=payload,
             headers={
                 "Accept": "application/vnd.github+json",
                 "Authorization": f"Bearer {github_token}",
@@ -2792,7 +2890,17 @@ class GitHubToMEPBridgeService:
             target_alias=str(execution.get("target_alias") or "").strip() or None,
         )
         if review_action:
-            self._submit_github_review(repo_full_name, number, review_events[action], body, github_token)
+            inline_comments: list[dict[str, Any]] = []
+            if action != "approved":
+                inline_comments = self._inline_review_comments(update.detail, snapshot.get("review_package") or {})
+            self._submit_github_review(
+                repo_full_name,
+                number,
+                review_events[action],
+                body,
+                github_token,
+                comments=inline_comments,
+            )
             self._record_github_writeback_publish(action, review_action=True)
             review_result = self._build_review_trial_result(
                 execution,

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -63,6 +63,10 @@ def _review_trusted_associations() -> set[str]:
     return {item.strip().upper() for item in raw.split(",") if item.strip()}
 
 
+def _review_allow_external_checks() -> bool:
+    return _env_truthy("MEP_REVIEW_ALLOW_EXTERNAL_CHECKS", "0")
+
+
 def _is_adapter_error(text: str) -> bool:
     """Detect adapter failures that must never be published as a real review.
 
@@ -1273,6 +1277,8 @@ class WorkspaceManager:
         github_inputs = _review_github_inputs(task_data)
         association = str(github_inputs.get("author_association") or "").strip().upper()
         if not association:
+            return ""
+        if _review_allow_external_checks():
             return ""
         if association in _review_trusted_associations():
             return ""

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1736,6 +1736,12 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(status_response.status_code, 200, status_response.text)
         self.assertEqual(len(self.github_session.posts), 1)
         self.assertTrue(self.github_session.posts[0]["url"].endswith("/repos/WUAIBING/MEP/pulls/149/reviews"))
+        review_payload = self.github_session.posts[0]["json"]
+        self.assertEqual(review_payload["event"], "COMMENT")
+        self.assertEqual(review_payload["comments"][0]["path"], "node/mep_runtime.py")
+        self.assertEqual(review_payload["comments"][0]["line"], 226)
+        self.assertEqual(review_payload["comments"][0]["side"], "RIGHT")
+        self.assertIn("Import guard using `find_spec` may be redundant.", review_payload["comments"][0]["body"])
 
     def test_status_callback_suppresses_summary_with_paths_but_no_code_evidence(self):
         self._set_pr_review_package(

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -912,6 +912,75 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         )
         complete_mock.assert_called_once_with("task_bridge_review", "reply")
 
+    def test_process_task_skips_verification_for_untrusted_contributor_by_default(self):
+        node = _runtime_node()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "bridge"), exist_ok=True)
+            with open(os.path.join(tmpdir, "bridge", "github_to_mep.py"), "w", encoding="utf-8") as handle:
+                handle.write("def live_sync_context():\n    return True\n")
+
+            task_data = TestRuntimeReviewPrompts._bridge_review_task_data()
+            payload = json.loads(task_data["payload"])
+            payload["task"]["inputs"]["github"].update(
+                {
+                    "repo_clone_url": "https://github.com/example/repo.git",
+                    "head_sha": "abc12345",
+                    "head_ref": "feature/test",
+                    "author_association": "CONTRIBUTOR",
+                }
+            )
+            task_data["payload"] = json.dumps(payload)
+
+            with (
+                patch.object(node.workspace, "sync_pr_workspace", return_value=(True, tmpdir)),
+                patch.object(node.workspace, "build_review_context", return_value="Local workspace path: tmpdir"),
+                patch.object(node.workspace, "build_verification_report", return_value="should not run") as verify_mock,
+                patch.object(node.adapter, "generate_reply", return_value="reply") as adapter_mock,
+                patch.object(node, "complete"),
+            ):
+                asyncio.run(node.process_task(task_data))
+
+        self.assertFalse(verify_mock.called)
+        instructions = adapter_mock.call_args.args[0]
+        self.assertIn("Automated verification checks were skipped", instructions)
+        self.assertIn("CONTRIBUTOR", instructions)
+
+    def test_process_task_allows_external_verification_when_explicitly_enabled(self):
+        node = _runtime_node()
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch.dict(os.environ, {"MEP_REVIEW_ALLOW_EXTERNAL_CHECKS": "1"}),
+        ):
+            os.makedirs(os.path.join(tmpdir, "bridge"), exist_ok=True)
+            with open(os.path.join(tmpdir, "bridge", "github_to_mep.py"), "w", encoding="utf-8") as handle:
+                handle.write("def live_sync_context():\n    return True\n")
+
+            task_data = TestRuntimeReviewPrompts._bridge_review_task_data()
+            payload = json.loads(task_data["payload"])
+            payload["task"]["inputs"]["github"].update(
+                {
+                    "repo_clone_url": "https://github.com/example/repo.git",
+                    "head_sha": "abc12345",
+                    "head_ref": "feature/test",
+                    "author_association": "CONTRIBUTOR",
+                }
+            )
+            task_data["payload"] = json.dumps(payload)
+
+            with (
+                patch.object(node.workspace, "sync_pr_workspace", return_value=(True, tmpdir)),
+                patch.object(node.workspace, "build_review_context", return_value="Local workspace path: tmpdir"),
+                patch.object(node.workspace, "build_verification_report", return_value="Automated verification run") as verify_mock,
+                patch.object(node.adapter, "generate_reply", return_value="reply") as adapter_mock,
+                patch.object(node, "complete"),
+            ):
+                asyncio.run(node.process_task(task_data))
+
+        self.assertTrue(verify_mock.called)
+        instructions = adapter_mock.call_args.args[0]
+        self.assertIn("Automated verification run", instructions)
+        self.assertNotIn("Automated verification checks were skipped", instructions)
+
     def test_process_task_live_bridge_sends_frame_and_settles_when_call_is_accepted(self):
         node = _runtime_node()
         node.live_call_enabled = True


### PR DESCRIPTION
## Summary
- add grounded inline PR review comments when the bridge can map structured findings to changed lines
- keep approval writebacks summary-only while turning review/comment writebacks into more developer-useful line annotations
- skip automated verification for untrusted contributor PRs by default unless `MEP_REVIEW_ALLOW_EXTERNAL_CHECKS=1`

## Why
Phase 6F added hunk-centered retrieval and Phase 6G operationalized review benchmarks. This Phase 6H step closes the writeback loop by making non-approval reviews land closer to the changed code while tightening the safety default for external-contributor verification.

## Validation
- python -m pytest tests/test_node_runtime.py tests/test_github_bridge.py -q
- 109 passed
