### PR TITLE
Phase 6I: harden inline comment grounding

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -766,6 +766,11 @@ class TelegramNotifier:
 
 class GitHubToMEPBridgeService:
     MAX_RETRIES = 2
+    INLINE_REVIEW_MAX_FINDINGS = 2
+    INLINE_REVIEW_MAX_COMMENTS = 2
+    INLINE_REVIEW_ISSUE_MAX_CHARS = 200
+    INLINE_REVIEW_RATIONALE_MAX_CHARS = 500
+    INLINE_REVIEW_FILE_MAX_CHARS = 160
 
     def __init__(
         self,
@@ -789,6 +794,9 @@ class GitHubToMEPBridgeService:
             "comments_published": 0,
             "suppressed_weak_reviews": 0,
             "suppressed_approvals": 0,
+            "inline_comment_parse_misses": 0,
+            "inline_comment_ambiguous_paths": 0,
+            "inline_comment_unmapped_lines": 0,
             "last_action": None,
             "last_detail_preview": None,
             "last_suppressed_reason": None,
@@ -2674,21 +2682,43 @@ class GitHubToMEPBridgeService:
             match = pattern.match(line)
             if not match:
                 continue
-            issue = cls._normalize_feedback_text(match.group("issue"), max_chars=200)
-            rationale = cls._normalize_feedback_text(match.group("rationale"), max_chars=500)
-            file_name = cls._normalize_feedback_text(match.group("file"), max_chars=160)
+            issue = cls._normalize_feedback_text(match.group("issue"), max_chars=cls.INLINE_REVIEW_ISSUE_MAX_CHARS)
+            rationale = cls._normalize_feedback_text(
+                match.group("rationale"),
+                max_chars=cls.INLINE_REVIEW_RATIONALE_MAX_CHARS,
+            )
+            file_name = cls._normalize_feedback_text(match.group("file"), max_chars=cls.INLINE_REVIEW_FILE_MAX_CHARS)
             if not issue:
                 continue
             findings.append({"issue": issue, "rationale": rationale, "file": file_name})
-            if len(findings) >= 2:
+            if len(findings) >= cls.INLINE_REVIEW_MAX_FINDINGS:
                 break
         return findings
 
     @staticmethod
-    def _patch_added_line_number(patch_text: str, finding_text: str) -> Optional[int]:
+    def _detail_expects_structured_findings(detail: Optional[str]) -> bool:
+        text = str(detail or "").strip()
+        if not text:
+            return False
+        if "## Review Findings" in text:
+            return True
+        return bool(re.search(r"^\s*\d+\.\s+\*\*", text, re.MULTILINE))
+
+    @staticmethod
+    def _line_matches_focus_term(line_text: str, term: str) -> bool:
+        normalized_term = str(term or "").strip().lower()
+        if not normalized_term:
+            return False
+        if re.fullmatch(r"[a-z0-9_]+", normalized_term):
+            pattern = rf"(?<![a-z0-9_]){re.escape(normalized_term)}(?![a-z0-9_])"
+            return re.search(pattern, line_text) is not None
+        return normalized_term in line_text
+    @classmethod
+    def _patch_added_line_number(cls, patch_text: str, finding_text: str) -> Optional[int]:
         current_right: Optional[int] = None
-        fallback_line: Optional[int] = None
         focus_terms = [term.lower() for term in re.findall(r"`([^`]+)`", finding_text or "") if term.strip()]
+        if not focus_terms:
+            return None
         for raw_line in str(patch_text or "").splitlines():
             if raw_line.startswith("@@"):
                 match = re.search(r"\+(\d+)", raw_line)
@@ -2698,20 +2728,24 @@ class GitHubToMEPBridgeService:
                 continue
             if raw_line.startswith("+"):
                 line_text = raw_line[1:].lower()
-                if fallback_line is None:
-                    fallback_line = current_right
-                if focus_terms and any(term in line_text for term in focus_terms):
+                if any(cls._line_matches_focus_term(line_text, term) for term in focus_terms):
                     return current_right
                 current_right += 1
                 continue
             if raw_line.startswith("-"):
                 continue
             current_right += 1
-        return fallback_line
+        return None
 
     def _inline_review_comments(self, detail: Optional[str], review_package: dict[str, Any]) -> list[dict[str, Any]]:
         findings = self._extract_structured_findings(detail)
         if not findings:
+            if self._detail_expects_structured_findings(detail):
+                self.github_writeback_metrics["inline_comment_parse_misses"] += 1
+                print(
+                    "[bridge] inline comment extraction produced no structured findings "
+                    f"detail={self._detail_preview(detail) or '<empty>'}"
+                )
             return []
         expected_paths = [
             str(item).strip()
@@ -2727,13 +2761,25 @@ class GitHubToMEPBridgeService:
             matched_paths = self._match_path_reference(file_hint, expected_paths)
             if not matched_paths:
                 continue
-            target_path = sorted(matched_paths)[0]
+            if len(matched_paths) != 1:
+                self.github_writeback_metrics["inline_comment_ambiguous_paths"] += 1
+                print(
+                    "[bridge] skipped inline comment due to ambiguous path reference "
+                    f"file_hint={file_hint!r} matched_paths={sorted(matched_paths)!r}"
+                )
+                continue
+            target_path = next(iter(matched_paths))
             patch_text = str((patches_by_path.get(target_path) or {}).get("full") or "")
             line_number = self._patch_added_line_number(
                 patch_text,
                 f"{finding.get('issue') or ''} {finding.get('rationale') or ''}",
             )
             if not line_number:
+                self.github_writeback_metrics["inline_comment_unmapped_lines"] += 1
+                print(
+                    "[bridge] skipped inline comment because no changed line matched the finding "
+                    f"path={target_path!r} finding={finding.get('issue')!r}"
+                )
                 continue
             body_lines = [f"**{finding['issue']}**"]
             rationale = str(finding.get("rationale") or "").strip()
@@ -2748,7 +2794,7 @@ class GitHubToMEPBridgeService:
                     "body": "\n".join(body_lines).strip(),
                 }
             )
-        return comments[:2]
+        return comments[: self.INLINE_REVIEW_MAX_COMMENTS]
 
     def _target_alias_for_execution(self, execution: dict[str, Any]) -> str:
         return str(execution.get("target_alias") or self.config.target_alias or "").strip()

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1743,6 +1743,112 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(review_payload["comments"][0]["side"], "RIGHT")
         self.assertIn("Import guard using `find_spec` may be redundant.", review_payload["comments"][0]["body"])
 
+    def test_patch_added_line_number_requires_focus_term_match(self):
+        patch = (
+            "@@ -10,2 +10,3 @@\n"
+            " context\n"
+            "-old_call()\n"
+            "+new_call()\n"
+            "+other_line()\n"
+        )
+
+        self.assertEqual(
+            self.service._patch_added_line_number(patch, "The `new_call` check is wrong"),
+            11,
+        )
+        self.assertIsNone(
+            self.service._patch_added_line_number(patch, "The `missing_identifier` check is wrong")
+        )
+        self.assertIsNone(
+            self.service._patch_added_line_number(patch, "This finding has no backticked identifier")
+        )
+
+    def test_status_callback_skips_inline_comment_when_identifier_does_not_match_patch(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 4,
+                    "deletions": 1,
+                    "changes": 5,
+                    "patch": (
+                        "@@ -221,1 +221,4 @@\n"
+                        "-    from ws_connect import ws_connect\n"
+                        "+    from importlib.util import find_spec\n"
+                        '+    if find_spec("websockets") is None:\n'
+                        '+        raise ImportError("websockets not available")\n'
+                        "+    from ws_connect import ws_connect\n"
+                    ),
+                },
+            ],
+            pr_body="Adds an import guard before wiring the shared websocket helper.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=150),
+            delivery_id="delivery-unmapped-inline-finding",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-unmapped-inline-finding",
+                "detail": (
+                    "## Review Findings\n\n"
+                    "1. **Missing identifier mapping is unsafe.** (`node/mep_runtime.py`): "
+                    "The `missing_identifier` check is wrong and should not land on an unrelated added line.\n\n"
+                    "Touched paths reviewed: `node/mep_runtime.py`"
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "ungrounded_finding")
+
+    def test_inline_review_comments_skips_ambiguous_path_reference(self):
+        review_package = {
+            "touched_paths": ["pkg_one/helpers.py", "pkg_two/helpers.py"],
+            "changed_files": [
+                {
+                    "filename": "pkg_one/helpers.py",
+                    "patch": "@@ -1,0 +1,2 @@\n+def missing_call():\n+    return 1\n",
+                },
+                {
+                    "filename": "pkg_two/helpers.py",
+                    "patch": "@@ -1,0 +1,2 @@\n+def missing_call():\n+    return 2\n",
+                },
+            ],
+        }
+
+        comments = self.service._inline_review_comments(
+            (
+                "## Review Findings\n\n"
+                "1. **Helper path may be wrong.** (`helpers.py`): "
+                "The `missing_call` symbol changes semantics across both helper modules."
+            ),
+            review_package,
+        )
+
+        self.assertEqual(comments, [])
+        self.assertEqual(self.service.github_writeback_metrics["inline_comment_ambiguous_paths"], 1)
+
+    def test_inline_review_comments_records_parse_miss_for_unparseable_findings_heading(self):
+        comments = self.service._inline_review_comments(
+            "## Review Findings\n\n- malformed finding that does not follow the numbered markdown contract",
+            {},
+        )
+
+        self.assertEqual(comments, [])
+        self.assertEqual(self.service.github_writeback_metrics["inline_comment_parse_misses"], 1)
+
     def test_status_callback_suppresses_summary_with_paths_but_no_code_evidence(self):
         self._set_pr_review_package(
             [


### PR DESCRIPTION
## Summary
- require explicit focus-term matches before mapping a finding to a changed line
- skip inline placement when a file reference is ambiguous instead of guessing alphabetically
- record observability signals when structured findings fail to parse or line mapping cannot be grounded
- add regression tests for positive grounding, unmatched identifiers, ambiguous paths, and malformed finding payloads

## Why
This follow-up hardens the new inline writeback feature from Phase 6H. A wrong inline anchor is worse than no anchor, so the bridge now fails closed for uncertain path/line mapping.

## Validation
- python -m pytest tests/test_github_bridge.py -q
- python -m pytest tests/test_node_runtime.py tests/test_github_bridge.py -q
