### PR TITLE
Phase 7C: salvage weak review writeback

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -2540,6 +2540,66 @@ class GitHubToMEPBridgeService:
                 return True, "summary_without_risk_coverage"
         return False, "concrete"
 
+    @staticmethod
+    def _cleanup_review_detail(detail: str) -> str:
+        cleaned = str(detail or "").replace("\r\n", "\n").strip()
+        cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+        return cleaned.strip()
+
+    @classmethod
+    def _sanitize_review_detail_for_reason(cls, detail: Optional[str], reason: Optional[str]) -> str:
+        text = str(detail or "").strip()
+        if not text or not reason:
+            return text
+        sanitized = text
+        if reason in {"generic_observation", "observation_in_context_only"}:
+            sanitized = re.sub(r"(?im)^\s*Observation:\s*.+(?:\n|$)", "", sanitized)
+        elif reason in {"ungrounded_finding", "finding_in_context_only", "speculative_finding"}:
+            sanitized = re.sub(r"(?im)^\s*\d+\.\s+\*\*.+(?:\n|$)", "", sanitized)
+            sanitized = re.sub(r"(?im)^##\s*Review Findings\b", "## Review Summary", sanitized, count=1)
+        elif reason == "summary_without_changed_behavior_evidence":
+            sanitized = re.sub(r"(?im)^\s*Why no finding:\s*.+(?:\n|$)", "", sanitized)
+        return cls._cleanup_review_detail(sanitized)
+
+    def _attempt_review_writeback_salvage(
+        self,
+        execution: dict[str, Any],
+        detail: Optional[str],
+        *,
+        action: str,
+        suppression_reason: Optional[str],
+    ) -> Optional[tuple[str, dict[str, Any], int, list[str]]]:
+        if action == "approved":
+            return None
+        sanitized = self._sanitize_review_detail_for_reason(detail, suppression_reason)
+        if not sanitized or sanitized == str(detail or "").strip():
+            return None
+        snapshot = self._build_review_snapshot(execution, sanitized)
+        suppress, reason = self._classify_review_writeback_detail(
+            execution,
+            sanitized,
+            snapshot=snapshot,
+            action=action,
+        )
+        score, reasons = self._score_review_quality(snapshot, action=action)
+        if suppress:
+            reviewability = snapshot.get("reviewability") or {}
+            reviewability_bucket = str(reviewability.get("bucket") or "standard").strip().lower()
+            anchored_paths = snapshot.get("anchored_paths") or set()
+            has_findings = bool(snapshot.get("has_findings"))
+            checks_performed = snapshot.get("checks_performed") or []
+            risk_areas_checked = snapshot.get("risk_areas_checked") or []
+            why_no_finding = str(snapshot.get("why_no_finding") or "").strip()
+            if (
+                reviewability_bucket == "standard"
+                and anchored_paths
+                and not has_findings
+                and (checks_performed or risk_areas_checked or why_no_finding)
+            ):
+                return sanitized, snapshot, score, reasons
+            return None
+        return sanitized, snapshot, score, reasons
+
     def _record_github_writeback_attempt(self, action: str, detail: Optional[str]) -> None:
         metrics = self.github_writeback_metrics
         metrics["attempts"] += 1
@@ -2897,11 +2957,12 @@ class GitHubToMEPBridgeService:
         review_action = entity_type == "pr" and action in review_events
         self._record_github_writeback_attempt(action, update.detail)
         review_result: Optional[dict[str, Any]] = None
+        detail_to_publish = update.detail
         if review_action:
-            snapshot = self._build_review_snapshot(execution, update.detail)
+            snapshot = self._build_review_snapshot(execution, detail_to_publish)
             suppress, reason = self._classify_review_writeback_detail(
                 execution,
-                update.detail,
+                detail_to_publish,
                 snapshot=snapshot,
                 action=action,
             )
@@ -2910,6 +2971,18 @@ class GitHubToMEPBridgeService:
             if not suppress and action == "approved":
                 reason = self._approval_quality_failure(snapshot, score)
                 suppress = reason is not None
+            if suppress:
+                salvaged = self._attempt_review_writeback_salvage(
+                    execution,
+                    detail_to_publish,
+                    action=action,
+                    suppression_reason=reason,
+                )
+                if salvaged is not None:
+                    detail_to_publish, snapshot, score, reasons = salvaged
+                    suppress = False
+                    reason = None
+                    self._record_review_quality(score, reasons)
             if suppress:
                 review_result = self._build_review_trial_result(
                     execution,
@@ -2932,13 +3005,13 @@ class GitHubToMEPBridgeService:
         body = self._render_github_writeback_body(
             str(execution.get("bridge_id") or update.bridge_id),
             action,
-            update.detail,
+            detail_to_publish,
             target_alias=str(execution.get("target_alias") or "").strip() or None,
         )
         if review_action:
             inline_comments: list[dict[str, Any]] = []
             if action != "approved":
-                inline_comments = self._inline_review_comments(update.detail, snapshot.get("review_package") or {})
+                inline_comments = self._inline_review_comments(detail_to_publish, snapshot.get("review_package") or {})
             self._submit_github_review(
                 repo_full_name,
                 number,

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1613,6 +1613,65 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(len(self.github_session.posts), 0)
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "generic_observation")
 
+    def test_status_callback_salvages_generic_observation_into_publishable_summary(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "hub/auth.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -88,0 +88,7 @@\n"
+                        "+def verify_signature(payload: str, signature: str) -> bool:\n"
+                        "+    nonce = _evict_expired_nonces()\n"
+                    ),
+                },
+                {
+                    "filename": "hub/models.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -10,0 +10,5 @@\n"
+                        "+class NodeRegistration(BaseModel):\n"
+                        "+    validator = field_validator('callback_url')\n"
+                    ),
+                },
+            ],
+            pr_body="Adds replay protection and validator hardening.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=245),
+            delivery_id="delivery-salvage-generic-observation",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-salvage-generic-observation",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds replay-protection and validation hardening across the authentication and model layers.\n\n"
+                    "Observation: The change looks coherent and follows the surrounding style.\n\n"
+                    "Touched paths reviewed: `hub/auth.py`, `hub/models.py`\n\n"
+                    "Risk areas checked: replay protection, validator coverage\n\n"
+                    "Checks performed: reviewed the changed diff for `hub/auth.py` and `hub/models.py`, checked the new `verify_signature` and `NodeRegistration` paths\n\n"
+                    "Why no finding: The added `verify_signature` and `NodeRegistration` validation paths look internally consistent with the changed behavior."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 1)
+        review_payload = self.github_session.posts[0]["json"]
+        self.assertEqual(review_payload["event"], "COMMENT")
+        self.assertIn("## Review Summary", review_payload["body"])
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], None)
+
     def test_status_callback_suppresses_finding_conflicting_with_patch_evidence(self):
         self._set_pr_review_package(
             [
@@ -1673,6 +1732,68 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(status_response.status_code, 200, status_response.text)
         self.assertEqual(len(self.github_session.posts), 0)
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "ungrounded_finding")
+
+    def test_status_callback_salvages_ungrounded_finding_into_publishable_summary(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "hub/db.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -120,0 +120,8 @@\n"
+                        "+def get_pending_tasks_for_provider(provider: str):\n"
+                        "+    conn = _get_conn()\n"
+                        "+    return _select_pending(conn, provider)\n"
+                    ),
+                },
+                {
+                    "filename": "tests/test_hub_api.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -779,0 +779,6 @@\n"
+                        '+response = client.get("/tasks/pending/provider")\n'
+                        "+self.assertEqual(response.status_code, 200)\n"
+                    ),
+                },
+            ],
+            pr_body="Adds provider pending-task retrieval and focused endpoint coverage.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=246),
+            delivery_id="delivery-salvage-ungrounded-finding",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-salvage-ungrounded-finding",
+                "detail": (
+                    "## Review Findings\n\n"
+                    "The PR adds provider pending-task retrieval and endpoint coverage.\n\n"
+                    "Touched paths reviewed: `hub/db.py`, `tests/test_hub_api.py`\n\n"
+                    "Risk areas checked: connection lifecycle, endpoint coverage\n\n"
+                    "Checks performed: reviewed the changed diff for `hub/db.py`, checked the new `get_pending_tasks_for_provider` path and test coverage\n\n"
+                    "Why no finding: The changed `get_pending_tasks_for_provider` flow and coverage look consistent aside from the unsupported claim below.\n\n"
+                    "1. **Authentication is missing from the provider endpoint.** (`hub/db.py`): The patch adds a provider helper without any `verify_request` dependency."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 1)
+        review_payload = self.github_session.posts[0]["json"]
+        self.assertEqual(review_payload["event"], "COMMENT")
+        self.assertIn("## Review Summary", review_payload["body"])
+        self.assertNotIn("## Review Findings", review_payload["body"])
+        self.assertNotIn("1. **Authentication is missing", review_payload["body"])
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], None)
 
     def test_status_callback_allows_finding_grounded_to_touched_path_and_patch(self):
         self._set_pr_review_package(


### PR DESCRIPTION
## Summary
- salvage standard review outputs by stripping generic observations or downgrading unsupported findings into safe summaries before suppression
- keep approval-mode behavior strict while preventing a single weak section from killing an otherwise grounded review
- add focused bridge tests covering generic-observation salvage and ungrounded-finding downgrade paths

## Validation
- python -m pytest tests/test_github_bridge.py -q