### PR TITLE
Add scenario-aware benchmark batch labeling

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -12,6 +12,7 @@ import uuid
 from collections import Counter
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 import requests
@@ -40,6 +41,7 @@ REVIEW_BENCHMARK_SCENARIOS = [
         "title": "Docs-only suppression precision",
         "goal": "Verify that docs-only PRs are suppressed unless the reviewer cites a concrete behavioral issue.",
         "expected_focus": ["low_signal", "suppression", "no_finding"],
+        "fixture_issue_numbers": [131],
     },
     {
         "id": "config_env_precision",
@@ -61,6 +63,7 @@ REVIEW_BENCHMARK_SCENARIOS = [
         "title": "Approval evidence safety",
         "goal": "Require approvals to cite changed-line identifiers, touched tests, and green CI before publishing APPROVE.",
         "expected_focus": ["approval", "ci_gate", "changed_identifiers"],
+        "fixture_issue_numbers": [109, 123],
     },
     {
         "id": "missed_issue_recall",
@@ -68,6 +71,7 @@ REVIEW_BENCHMARK_SCENARIOS = [
         "title": "Known-risk recall",
         "goal": "Track PRs seeded with known regressions so missed findings are labeled and measured against baseline.",
         "expected_focus": ["missed_issue", "recall", "risk_pack"],
+        "fixture_issue_numbers": [101, 244],
     },
     {
         "id": "stability_guardrails",
@@ -75,6 +79,7 @@ REVIEW_BENCHMARK_SCENARIOS = [
         "title": "Behavior stability guardrails",
         "goal": "Keep standard reviews publishable, docs-only reviews suppressible, and approval behavior stable across green vs non-green CI.",
         "expected_focus": ["stability", "consistency", "approval_safety", "suppression_precision"],
+        "fixture_issue_numbers": [101, 244, 131, 109, 123],
     },
 ]
 PHASE8_STABILITY_TARGETS = {
@@ -330,6 +335,16 @@ class BridgeReviewFeedbackUpdate(BaseModel):
     benchmark_label: Optional[str] = Field(default=None, max_length=120)
     verdict: Optional[str] = Field(default=None, max_length=64)
     notes: Optional[str] = Field(default=None, max_length=2000)
+
+
+class BridgeReviewBatchLabelUpdate(BaseModel):
+    scenario_id: Optional[str] = Field(default=None, max_length=120)
+    label_prefix: Optional[str] = Field(default=None, max_length=80)
+    issue_numbers: Optional[list[int]] = Field(default=None, min_length=1, max_length=50)
+    target_alias: Optional[str] = Field(default=None, max_length=120)
+    verdict: Optional[str] = Field(default=None, max_length=64)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+    search_limit: int = Field(default=100, ge=1, le=200)
 
 
 class BridgeRegistrationPendingApprovalError(RuntimeError):
@@ -3154,13 +3169,17 @@ class GitHubToMEPBridgeService:
                 continue
             if needs_feedback is False and not feedback_recorded:
                 continue
-            materialized = dict(item)
-            materialized["feedback_required"] = feedback_required
-            materialized["feedback_recorded"] = feedback_recorded
-            materialized["feedback_status"] = "labeled" if feedback_recorded else ("pending" if feedback_required else "not_applicable")
-            filtered.append(materialized)
+            filtered.append(self._materialize_review_trial(item))
+        total_count = len(filtered)
         items = filtered[: max(1, min(int(limit), 200))]
-        return {"status": "ok", "count": len(items), "items": items, "summary": self._summarize_review_trials(items)}
+        summary_items = filtered if normalized_label else items
+        return {
+            "status": "ok",
+            "count": len(items),
+            "total_count": total_count,
+            "items": items,
+            "summary": self._summarize_review_trials(summary_items),
+        }
 
     def list_review_benchmarks(self, *, suite: Optional[str] = None) -> dict[str, Any]:
         normalized_suite = self._normalize_feedback_text(suite, max_chars=120)
@@ -3184,6 +3203,13 @@ class GitHubToMEPBridgeService:
         return text[:max_chars]
 
     @staticmethod
+    def _normalize_benchmark_label_prefix(value: Optional[str], *, max_chars: int) -> str:
+        lowered = str(value or "").strip().lower()
+        normalized = re.sub(r"[^a-z0-9._-]+", "_", lowered)
+        normalized = re.sub(r"_+", "_", normalized).strip("._-")
+        return normalized[:max_chars]
+
+    @staticmethod
     def _normalize_feedback_verdict(value: Optional[str]) -> str:
         normalized = re.sub(r"[\s_-]+", "_", str(value or "")).strip().lower()
         allowed = {"useful", "not_useful", "false_positive", "missed_issue"}
@@ -3193,6 +3219,36 @@ class GitHubToMEPBridgeService:
             allowed_text = ", ".join(sorted(allowed))
             raise HTTPException(status_code=400, detail=f"Unsupported review feedback verdict. Allowed: {allowed_text}")
         return normalized
+
+    @classmethod
+    def _build_benchmark_run_label(cls, prefix: str) -> str:
+        normalized_prefix = cls._normalize_benchmark_label_prefix(prefix, max_chars=80)
+        if not normalized_prefix:
+            raise HTTPException(status_code=400, detail="Benchmark label prefix must include letters or numbers")
+        suffix = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        max_prefix_chars = max(1, 120 - len(suffix) - 1)
+        trimmed_prefix = normalized_prefix[:max_prefix_chars].rstrip("._-") or "benchmark_run"
+        return f"{trimmed_prefix}_{suffix}"
+
+    @staticmethod
+    def _materialize_review_trial(item: dict[str, Any]) -> dict[str, Any]:
+        materialized = dict(item)
+        review_result = materialized.get("review_result") or {}
+        feedback = materialized.get("review_feedback") or {}
+        feedback_recorded = bool(str(feedback.get("verdict") or "").strip())
+        feedback_required = bool(review_result)
+        materialized["feedback_required"] = feedback_required
+        materialized["feedback_recorded"] = feedback_recorded
+        materialized["feedback_status"] = "labeled" if feedback_recorded else ("pending" if feedback_required else "not_applicable")
+        return materialized
+
+    @classmethod
+    def _get_benchmark_scenario(cls, scenario_id: str) -> dict[str, Any]:
+        normalized_scenario_id = cls._normalize_feedback_text(scenario_id, max_chars=120)
+        for scenario in REVIEW_BENCHMARK_SCENARIOS:
+            if str(scenario.get("id") or "").strip() == normalized_scenario_id:
+                return dict(scenario)
+        raise HTTPException(status_code=404, detail=f"Unknown benchmark scenario: {normalized_scenario_id}")
 
     def record_review_feedback(self, bridge_id: str, update: BridgeReviewFeedbackUpdate, token: str) -> dict[str, Any]:
         self._verify_feedback_token(token)
@@ -3226,6 +3282,82 @@ class GitHubToMEPBridgeService:
             feedback["notes"] = str(existing.get("notes"))
         self.store.update_execution(bridge_id, review_feedback=feedback)
         return {"status": "ok", "bridge_id": bridge_id, "review_feedback": feedback}
+
+    def label_review_trials_batch(self, update: BridgeReviewBatchLabelUpdate, token: str) -> dict[str, Any]:
+        self._verify_feedback_token(token)
+        scenario_id = self._normalize_feedback_text(update.scenario_id, max_chars=120)
+        manual_issue_numbers = sorted({int(issue) for issue in (update.issue_numbers or []) if int(issue) > 0})
+        if scenario_id and manual_issue_numbers:
+            raise HTTPException(status_code=400, detail="Specify either scenario_id or issue_numbers, not both")
+        scenario: Optional[dict[str, Any]] = None
+        if scenario_id:
+            scenario = self._get_benchmark_scenario(scenario_id)
+            issue_numbers = [
+                int(issue)
+                for issue in scenario.get("fixture_issue_numbers") or []
+                if isinstance(issue, int) and issue > 0
+            ]
+            if not issue_numbers:
+                raise HTTPException(status_code=409, detail=f"Benchmark scenario {scenario_id} has no configured fixture issues")
+            label_prefix = self._normalize_feedback_text(update.label_prefix, max_chars=80) or scenario_id
+        else:
+            issue_numbers = manual_issue_numbers
+            label_prefix = self._normalize_feedback_text(update.label_prefix, max_chars=80)
+            if not label_prefix:
+                raise HTTPException(status_code=400, detail="label_prefix is required when scenario_id is not provided")
+        if not issue_numbers:
+            raise HTTPException(status_code=400, detail="issue_numbers must include at least one positive PR number")
+        normalized_target = _normalize_alias_key(update.target_alias)
+        verdict = self._normalize_feedback_verdict(update.verdict)
+        notes = self._normalize_feedback_text(update.notes, max_chars=2000)
+        benchmark_label = self._build_benchmark_run_label(label_prefix)
+        items = self.store.list_recent_review_trials(limit=update.search_limit)
+        latest_by_issue: dict[int, dict[str, Any]] = {}
+        for item in items:
+            issue_number = int(item.get("issue_number") or 0)
+            if issue_number not in issue_numbers or issue_number in latest_by_issue:
+                continue
+            if normalized_target and _normalize_alias_key(str(item.get("target_alias") or "")) != normalized_target:
+                continue
+            latest_by_issue[issue_number] = item
+        missing_issue_numbers = [issue for issue in issue_numbers if issue not in latest_by_issue]
+        if not latest_by_issue:
+            raise HTTPException(status_code=404, detail="No matching review trials found for the requested issues")
+
+        labeled_items: list[dict[str, Any]] = []
+        for issue_number in issue_numbers:
+            item = latest_by_issue.get(issue_number)
+            if item is None:
+                continue
+            existing = item.get("review_feedback") or {}
+            feedback: dict[str, Any] = {
+                "recorded_at": float(existing.get("recorded_at") or time.time()),
+                "updated_at": time.time(),
+                "benchmark_label": benchmark_label,
+            }
+            if verdict:
+                feedback["verdict"] = verdict
+            elif existing.get("verdict"):
+                feedback["verdict"] = str(existing.get("verdict"))
+            if notes:
+                feedback["notes"] = notes
+            elif existing.get("notes"):
+                feedback["notes"] = str(existing.get("notes"))
+            self.store.update_execution(str(item.get("bridge_id") or ""), review_feedback=feedback)
+            labeled_item = dict(item)
+            labeled_item["review_feedback"] = feedback
+            labeled_items.append(self._materialize_review_trial(labeled_item))
+
+        return {
+            "status": "ok",
+            "scenario_id": scenario_id or None,
+            "benchmark_label": benchmark_label,
+            "count": len(labeled_items),
+            "resolved_issue_numbers": issue_numbers,
+            "missing_issue_numbers": missing_issue_numbers,
+            "items": labeled_items,
+            "summary": self._summarize_review_trials(labeled_items),
+        }
 
     @staticmethod
     def _summarize_review_trials(items: list[dict[str, Any]]) -> dict[str, Any]:
@@ -3605,6 +3737,17 @@ def create_app(
         if not token and authorization and authorization.lower().startswith("bearer "):
             token = authorization.split(" ", 1)[1].strip()
         return bridge_service.record_review_feedback(bridge_id, update, token or "")
+
+    @app.post("/bridge/review-trials/batch-label")
+    async def bridge_review_batch_label(
+        update: BridgeReviewBatchLabelUpdate,
+        authorization: Optional[str] = Header(default=None),
+        x_bridge_feedback_token: Optional[str] = Header(default=None),
+    ) -> dict[str, Any]:
+        token = x_bridge_feedback_token
+        if not token and authorization and authorization.lower().startswith("bearer "):
+            token = authorization.split(" ", 1)[1].strip()
+        return bridge_service.label_review_trials_batch(update, token or "")
 
     return app
 

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -21,6 +21,7 @@ from bridge.github_to_mep import (  # noqa: E402
     BridgeStore,
     DefaultMEPSubmissionClient,
     GitHubToMEPBridgeService,
+    NormalizedGitHubEvent,
     create_app,
 )
 
@@ -1057,6 +1058,8 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         first_ids = {item["id"] for item in payload["items"]}
         self.assertIn("docs_only_precision", first_ids)
         self.assertIn("stability_guardrails", first_ids)
+        phase8_item = next(item for item in payload["items"] if item["id"] == "stability_guardrails")
+        self.assertEqual(phase8_item["fixture_issue_numbers"], [101, 244, 131, 109, 123])
 
         filtered_response = self.client.get("/bridge/review-benchmarks?suite=phase6_precision")
         self.assertEqual(filtered_response.status_code, 200, filtered_response.text)
@@ -1324,10 +1327,22 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(feedback_payload["review_feedback"]["benchmark_label"], "phase6c")
         self.assertEqual(feedback_payload["review_feedback"]["verdict"], "useful")
 
+        suppressed_feedback_response = self.client.post(
+            f"/bridge/review-trials/{suppressed_bridge_id}/feedback",
+            json={
+                "benchmark_label": "phase6c",
+                "verdict": "not_useful",
+                "notes": "Docs-only suppression stayed correctly fail-closed.",
+            },
+            headers={"Authorization": f"Bearer {self.config.status_secret}"},
+        )
+        self.assertEqual(suppressed_feedback_response.status_code, 200, suppressed_feedback_response.text)
+
         trials_response = self.client.get("/bridge/review-trials?limit=5")
         self.assertEqual(trials_response.status_code, 200, trials_response.text)
         payload = trials_response.json()
         self.assertEqual(payload["count"], 2)
+        self.assertEqual(payload["total_count"], 2)
         self.assertEqual(payload["summary"]["total_trials"], 2)
         self.assertEqual(payload["summary"]["published_count"], 1)
         self.assertEqual(payload["summary"]["suppressed_count"], 1)
@@ -1335,11 +1350,22 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(payload["summary"]["resolved_actions"]["suppressed"], 1)
         self.assertEqual(payload["summary"]["suppression_reasons"]["low_signal_no_finding"], 1)
         self.assertEqual(payload["summary"]["feedback_verdicts"]["useful"], 1)
-        self.assertEqual(payload["summary"]["benchmark_labels"]["phase6c"], 1)
-        self.assertEqual(payload["summary"]["feedback_count"], 1)
-        self.assertEqual(payload["summary"]["feedback_pending_count"], 1)
-        self.assertEqual(payload["summary"]["feedback_label_coverage"], 0.5)
-        self.assertEqual(payload["summary"]["feedback_useful_rate"], 1.0)
+        self.assertEqual(payload["summary"]["feedback_verdicts"]["not_useful"], 1)
+        self.assertEqual(payload["summary"]["benchmark_labels"]["phase6c"], 2)
+        self.assertEqual(payload["summary"]["feedback_count"], 2)
+        self.assertEqual(payload["summary"]["feedback_pending_count"], 0)
+        self.assertEqual(payload["summary"]["feedback_label_coverage"], 1.0)
+        self.assertEqual(payload["summary"]["feedback_useful_rate"], 0.5)
+
+        label_filtered_response = self.client.get("/bridge/review-trials?limit=1&benchmark_label=phase6c")
+        self.assertEqual(label_filtered_response.status_code, 200, label_filtered_response.text)
+        label_filtered = label_filtered_response.json()
+        self.assertEqual(label_filtered["count"], 1)
+        self.assertEqual(label_filtered["total_count"], 2)
+        self.assertEqual(label_filtered["summary"]["total_trials"], 2)
+        self.assertEqual(label_filtered["summary"]["published_count"], 1)
+        self.assertEqual(label_filtered["summary"]["suppressed_count"], 1)
+        self.assertEqual(label_filtered["summary"]["benchmark_labels"]["phase6c"], 2)
 
         filtered_response = self.client.get(
             "/bridge/review-trials?limit=5&target_alias=Hub-Sentinel&benchmark_label=phase6c&verdict=useful"
@@ -1347,15 +1373,133 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(filtered_response.status_code, 200, filtered_response.text)
         filtered = filtered_response.json()
         self.assertEqual(filtered["count"], 1)
+        self.assertEqual(filtered["total_count"], 1)
         self.assertEqual(filtered["items"][0]["bridge_id"], approved_bridge_id)
         self.assertEqual(filtered["items"][0]["review_feedback"]["verdict"], "useful")
 
         pending_response = self.client.get("/bridge/review-trials?limit=5&needs_feedback=true")
         self.assertEqual(pending_response.status_code, 200, pending_response.text)
         pending_payload = pending_response.json()
-        self.assertEqual(pending_payload["count"], 1)
-        self.assertEqual(pending_payload["items"][0]["bridge_id"], suppressed_bridge_id)
-        self.assertEqual(pending_payload["items"][0]["feedback_status"], "pending")
+        self.assertEqual(pending_payload["count"], 0)
+        self.assertEqual(pending_payload["total_count"], 0)
+
+    def test_review_trials_batch_label_endpoint_labels_latest_trial_per_issue(self):
+        def _seed_trial(
+            *,
+            bridge_id: str,
+            issue_number: int,
+            intent_type: str,
+            action: str,
+            published: bool,
+            suppressed: bool,
+            quality_score: int,
+            suppression_reason: Optional[str] = None,
+        ) -> None:
+            event = NormalizedGitHubEvent(
+                delivery_id=f"delivery-{bridge_id}",
+                source_event="issue_comment",
+                source_action="created",
+                repo_full_name="WUAIBING/MEP",
+                entity_type="pr",
+                number=issue_number,
+                title=f"PR {issue_number}",
+                url=f"https://example.test/pr/{issue_number}",
+                actor_login="moltbot",
+                author_association="COLLABORATOR",
+                context_id=f"github-WUAIBING-MEP-pr-{issue_number}-{bridge_id}",
+                imperative_verb="review" if intent_type == "code.review.request" else "approve",
+                intent_type=intent_type,
+                instructions="seeded test execution",
+                raw_trigger_text="@Hub-Sentinel review this PR",
+                github_inputs={"pull_request": {"number": issue_number}},
+            )
+            self.store.create_execution(
+                event,
+                bridge_id,
+                "node_target",
+                target_alias="Hub-Sentinel",
+                instructions=event.instructions,
+            )
+            self.store.update_execution(
+                bridge_id,
+                status="completed",
+                action=action,
+                review_result={
+                    "resolved_action": action,
+                    "published": published,
+                    "suppressed": suppressed,
+                    "retry_queued": False,
+                    "quality_score": quality_score,
+                    "suppression_reason": suppression_reason,
+                },
+            )
+
+        _seed_trial(
+            bridge_id="br-old-101",
+            issue_number=101,
+            intent_type="code.review.request",
+            action="suppressed",
+            published=False,
+            suppressed=True,
+            quality_score=6,
+            suppression_reason="generic_observation",
+        )
+        time.sleep(0.01)
+        _seed_trial(
+            bridge_id="br-new-101",
+            issue_number=101,
+            intent_type="code.review.request",
+            action="reviewed",
+            published=True,
+            suppressed=False,
+            quality_score=9,
+        )
+        time.sleep(0.01)
+        _seed_trial(
+            bridge_id="br-131",
+            issue_number=131,
+            intent_type="code.review.request",
+            action="suppressed",
+            published=False,
+            suppressed=True,
+            quality_score=7,
+            suppression_reason="low_signal_no_finding",
+        )
+
+        response = self.client.post(
+            "/bridge/review-trials/batch-label",
+            json={
+                "scenario_id": "stability_guardrails",
+                "target_alias": "Hub-Sentinel",
+            },
+            headers={"Authorization": f"Bearer {self.config.status_secret}"},
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        self.assertEqual(payload["count"], 2)
+        self.assertEqual(payload["scenario_id"], "stability_guardrails")
+        self.assertEqual(payload["resolved_issue_numbers"], [101, 244, 131, 109, 123])
+        self.assertEqual(payload["missing_issue_numbers"], [244, 109, 123])
+        self.assertTrue(payload["benchmark_label"].startswith("stability_guardrails_"))
+        self.assertEqual(payload["summary"]["total_trials"], 2)
+        self.assertEqual(payload["summary"]["published_count"], 1)
+        self.assertEqual(payload["summary"]["suppressed_count"], 1)
+        self.assertEqual(payload["summary"]["benchmark_labels"][payload["benchmark_label"]], 2)
+        self.assertEqual({item["bridge_id"] for item in payload["items"]}, {"br-new-101", "br-131"})
+
+        old_execution = self.store.get_execution("br-old-101")
+        self.assertEqual(old_execution["review_feedback"], {})
+        new_execution = self.store.get_execution("br-new-101")
+        self.assertEqual(new_execution["review_feedback"]["benchmark_label"], payload["benchmark_label"])
+
+        filtered_response = self.client.get(f"/bridge/review-trials?limit=1&benchmark_label={payload['benchmark_label']}")
+        self.assertEqual(filtered_response.status_code, 200, filtered_response.text)
+        filtered = filtered_response.json()
+        self.assertEqual(filtered["count"], 1)
+        self.assertEqual(filtered["total_count"], 2)
+        self.assertEqual(filtered["summary"]["total_trials"], 2)
+        self.assertEqual(filtered["summary"]["published_count"], 1)
+        self.assertEqual(filtered["summary"]["suppressed_count"], 1)
 
     def test_review_feedback_endpoint_requires_valid_feedback_token(self):
         self._set_pr_review_package(


### PR DESCRIPTION
## Summary
- add scenario-owned fixture PR mappings to the review benchmark catalog
- add a batch-label API that resolves fixture PRs from scenario_id and labels only the latest trial per issue
- keep filtered review-trial summaries clean by returning full label-scoped aggregates with pagination metadata

## Testing
- python -m pytest tests/test_github_bridge.py -q