### PR TITLE
Add repo audit V1 task contract flow

### DIFF
--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -52,13 +52,23 @@ class MEPClient:
         *,
         payload_uri: Optional[str] = None,
         secret_data: Optional[str] = None,
+        expected_output: Optional[dict[str, Any]] = None,
+        intent_type: str = "analysis.request",
+        intent_priority: Optional[str] = None,
+        task_title: Optional[str] = None,
+        task_inputs: Optional[dict[str, Any]] = None,
     ) -> dict:
         body = build_task_envelope(
             self.node_id,
             payload,
             bounty,
+            intent_type=intent_type,
+            intent_priority=intent_priority,
             target_node=target_node,
             target_capability=model_requirement,
+            expected_output=expected_output,
+            task_title=task_title,
+            task_inputs=task_inputs,
             payload_uri=payload_uri,
             secret_data=secret_data,
         )
@@ -72,6 +82,92 @@ class MEPClient:
             timeout=20,
         )
         return {"status_code": response.status_code, "json": response.json()}
+
+    @staticmethod
+    def _repo_audit_instructions(
+        repo_url: str,
+        *,
+        audit_type: str,
+        ref: Optional[str],
+        max_findings: int,
+        artifact_preference: str,
+    ) -> str:
+        lines = [
+            f"Run a {audit_type} repo audit for {repo_url}.",
+            f"Return at most {max_findings} high-signal findings ranked by developer impact.",
+            "Keep the inline summary concise and evidence-backed.",
+        ]
+        if ref:
+            lines.insert(1, f"Audit the repo state at ref {ref}.")
+        if artifact_preference == "inline_only":
+            lines.append("Return the audit inline without relying on external artifacts.")
+        elif artifact_preference == "artifact_preferred":
+            lines.append("Use an external artifact for the full report when needed and include its URI.")
+        else:
+            lines.append("Return an inline summary first and include a result URI only when the report is large.")
+        return " ".join(lines)
+
+    async def submit_repo_audit(
+        self,
+        repo_url: str,
+        *,
+        audit_type: str = "full_repo_audit",
+        ref: Optional[str] = None,
+        max_findings: int = 5,
+        inline_summary_max_chars: int = 6000,
+        artifact_preference: str = "inline_first",
+        bounty: float = 0.0,
+        target_node: Optional[str] = None,
+        target_capability: str = "repo_audit",
+    ) -> dict:
+        normalized_repo_url = str(repo_url or "").strip()
+        if not normalized_repo_url:
+            raise ValueError("repo_url must be a non-empty string")
+        normalized_audit_type = str(audit_type or "").strip() or "full_repo_audit"
+        if max_findings < 1:
+            raise ValueError("max_findings must be at least 1")
+        if inline_summary_max_chars < 500:
+            raise ValueError("inline_summary_max_chars must be at least 500")
+        normalized_artifact_preference = str(artifact_preference or "").strip().lower() or "inline_first"
+        if normalized_artifact_preference not in {"inline_only", "inline_first", "artifact_preferred"}:
+            raise ValueError("artifact_preference must be inline_only, inline_first, or artifact_preferred")
+
+        instructions = self._repo_audit_instructions(
+            normalized_repo_url,
+            audit_type=normalized_audit_type,
+            ref=ref,
+            max_findings=max_findings,
+            artifact_preference=normalized_artifact_preference,
+        )
+        task_inputs = {
+            "repo_audit": {
+                "repo_url": normalized_repo_url,
+                "audit_type": normalized_audit_type,
+                "max_findings": max_findings,
+                "artifact_preference": normalized_artifact_preference,
+                "inline_summary_max_chars": inline_summary_max_chars,
+            }
+        }
+        if ref:
+            task_inputs["repo_audit"]["ref"] = str(ref).strip()
+        expected_output = {
+            "result_type": "repo_audit_result",
+            "format": "json",
+            "artifact_allowed": normalized_artifact_preference != "inline_only",
+            "inline_summary_max_chars": inline_summary_max_chars,
+        }
+        task_title = f"Repo audit: {normalized_repo_url}"
+        return await self.submit_task(
+            instructions,
+            bounty,
+            model_requirement=target_capability,
+            target_node=target_node,
+            expected_output=expected_output,
+            intent_type="repo_audit.request",
+            intent_priority="high",
+            task_title=task_title,
+            task_inputs=task_inputs,
+        )
 
     async def cancel_task(self, task_id: str) -> dict:
         body = {"task_id": task_id}

--- a/hub/main.py
+++ b/hub/main.py
@@ -586,6 +586,84 @@ def _task_expected_output(task: TaskCreate) -> dict:
     return {}
 
 
+def _task_source(task: TaskCreate, consumer_id: str) -> dict:
+    if isinstance(task.source, dict):
+        source = dict(task.source)
+        source_node_id = source.get("node_id")
+        if not isinstance(source_node_id, str) or not source_node_id.strip():
+            source["node_id"] = consumer_id
+        else:
+            source["node_id"] = source_node_id.strip()
+        return source
+    return {"node_id": consumer_id}
+
+
+def _task_intent(task: TaskCreate) -> dict:
+    if isinstance(task.intent, dict) and task.intent:
+        return dict(task.intent)
+    return {"type": "analysis.request"}
+
+
+def _task_structured_body(task: TaskCreate, payload: str) -> dict:
+    task_body = dict(task.task) if isinstance(task.task, dict) else {}
+    task_body["instructions"] = payload
+    task_body["expected_output"] = _task_expected_output(task)
+    return task_body
+
+
+def _task_data_from_row(task_row: dict, *, status: Optional[str] = None, provider_id: Optional[str] = None) -> dict:
+    payload = str(task_row.get("payload") or "")
+    consumer_id = str(task_row.get("consumer_id") or "")
+    hydrated: dict[str, Any] = {}
+    envelope_raw = task_row.get("envelope_json")
+    if isinstance(envelope_raw, str) and envelope_raw.strip():
+        try:
+            parsed = json.loads(envelope_raw)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict):
+            hydrated = dict(parsed)
+
+    hydrated["id"] = task_row["task_id"]
+    hydrated["consumer_id"] = consumer_id
+    hydrated["payload"] = payload
+    hydrated["bounty"] = task_row.get("bounty")
+    hydrated["status"] = status or task_row.get("status") or "bidding"
+    hydrated["target_node"] = task_row.get("target_node")
+    hydrated["model_requirement"] = task_row.get("model_requirement")
+    hydrated["verifier_type"] = task_row.get("verifier_type")
+    hydrated["expires_in_seconds"] = task_row.get("expires_in_seconds")
+    hydrated["payload_uri"] = task_row.get("payload_uri")
+    hydrated["secret_data"] = task_row.get("result_payload")
+    effective_provider_id = provider_id if provider_id is not None else task_row.get("provider_id")
+    if effective_provider_id:
+        hydrated["provider_id"] = effective_provider_id
+    else:
+        hydrated.pop("provider_id", None)
+
+    source = hydrated.get("source")
+    if not isinstance(source, dict):
+        hydrated["source"] = {"node_id": consumer_id}
+    else:
+        source_node_id = source.get("node_id")
+        if not isinstance(source_node_id, str) or not source_node_id.strip():
+            source["node_id"] = consumer_id
+
+    intent = hydrated.get("intent")
+    if not isinstance(intent, dict) or not intent:
+        hydrated["intent"] = {"type": "analysis.request"}
+
+    task_body = hydrated.get("task")
+    if not isinstance(task_body, dict):
+        task_body = {}
+    task_body["instructions"] = payload
+    expected_output = task_body.get("expected_output")
+    if not isinstance(expected_output, dict):
+        task_body["expected_output"] = {}
+    hydrated["task"] = task_body
+    return hydrated
+
+
 def _task_economics(task: TaskCreate) -> dict:
     if isinstance(task.economics, dict):
         economics = dict(task.economics)
@@ -1446,19 +1524,7 @@ async def _sweep_assigned_timeouts():
                         log_audit("DATA_TIMEOUT_REFUND", buyer_id, refunded, new_balance, task["task_id"])
                 if not db.requeue_task_if_assigned(task["task_id"], now):
                     continue
-                task_data = {
-                    "id": task["task_id"],
-                    "consumer_id": task["consumer_id"],
-                    "payload": task["payload"],
-                    "bounty": task["bounty"],
-                    "status": "bidding",
-                    "target_node": task["target_node"],
-                    "model_requirement": task["model_requirement"],
-                    "verifier_type": task.get("verifier_type"),
-                    "expires_in_seconds": task.get("expires_in_seconds"),
-                    "payload_uri": task.get("payload_uri"),
-                    "secret_data": task.get("result_payload")
-                }
+                task_data = _task_data_from_row(task, status="bidding", provider_id=None)
                 async with task_lock:
                     active_tasks[task["task_id"]] = task_data
                 model_requirement = _normalize_model_requirement(task["model_requirement"])
@@ -2231,12 +2297,9 @@ async def submit_task(
         "payload": payload,
         "bounty": bounty,
         "status": "bidding",
-        "source": task.source or {"node_id": consumer_id},
-        "intent": task.intent or {"type": "analysis.request"},
-        "task": {
-            "instructions": payload,
-            "expected_output": _task_expected_output(task),
-        },
+        "source": _task_source(task, consumer_id),
+        "intent": _task_intent(task),
+        "task": _task_structured_body(task, payload),
         "economics": economics,
         "target_node": target_node,
         "model_requirement": target_capability,
@@ -2259,6 +2322,10 @@ async def submit_task(
         expires_in_seconds=task.expires_in_seconds,
         verifier_type=verifier_type,
     )
+    try:
+        db.set_task_envelope(task_id, json.dumps(task_data))
+    except Exception as exc:
+        log_event("task_envelope_error", f"Failed to persist task envelope {task_id[:8]}: {exc}", task_id=task_id)
     async with task_lock:
         active_tasks[task_id] = task_data
 
@@ -2476,6 +2543,10 @@ async def place_bid(bid: TaskBid, authenticated_node: str = Depends(verify_reque
         consumer_id = task["consumer_id"]
         model_requirement = task.get("model_requirement")
         payload_uri = task.get("payload_uri")
+        task_body = dict(task["task"]) if isinstance(task.get("task"), dict) else {"instructions": payload, "expected_output": {}}
+        source = dict(task["source"]) if isinstance(task.get("source"), dict) else {"node_id": consumer_id}
+        intent = dict(task["intent"]) if isinstance(task.get("intent"), dict) else {"type": "analysis.request"}
+        economics = dict(task["economics"]) if isinstance(task.get("economics"), dict) else {}
 
     log_event("bid_accepted", f"Task {bid.task_id[:8]} assigned to {bid.provider_id}", task_id=bid.task_id, provider_id=bid.provider_id, bounty=bounty)
 
@@ -2486,6 +2557,10 @@ async def place_bid(bid: TaskBid, authenticated_node: str = Depends(verify_reque
         "model_requirement": model_requirement,
         "payload_uri": payload_uri,
         "secret_data": task.get("secret_data", task.get("result_payload")),
+        "source": source,
+        "intent": intent,
+        "task": task_body,
+        "economics": economics,
         "assignment_score": assignment_profile["assignment_score"]
     }
 
@@ -2621,7 +2696,11 @@ async def complete_task(
 async def get_pending_tasks(node_id: str, authenticated_node: str = Depends(verify_request)):
     if authenticated_node != node_id:
         raise HTTPException(status_code=403, detail="Cannot view pending tasks for another node")
-    tasks = db.get_pending_tasks_for_provider(node_id)
+    tasks = []
+    for row in db.get_pending_tasks_for_provider(node_id):
+        task_data = _task_data_from_row(row)
+        task_data["task_id"] = task_data["id"]
+        tasks.append(task_data)
     return {"node_id": node_id, "tasks": tasks, "count": len(tasks)}
 
 
@@ -3449,36 +3528,9 @@ def _build_queued_dm_event(row: dict, node_id: str, payload: str) -> dict:
     delivery shape. Prefers the persisted full envelope (byte-identical to live);
     falls back to reconstruction for legacy rows queued before envelope capture.
     """
-    envelope_raw = row.get("envelope_json")
-    if envelope_raw:
-        try:
-            data = json.loads(envelope_raw)
-            if isinstance(data, dict):
-                data["status"] = "assigned"
-                data["provider_id"] = node_id
-                return data
-        except (ValueError, TypeError):
-            pass
-    # Fallback: reconstruct the live-shaped envelope from the stored columns and
-    # the same defaults the submit path applies for a zero-bounty DM.
-    consumer_id = row.get("consumer_id")
-    return {
-        "id": row["task_id"],
-        "consumer_id": consumer_id,
-        "payload": payload,
-        "bounty": row.get("bounty"),
-        "status": "assigned",
-        "source": {"node_id": consumer_id},
-        "intent": {"type": "analysis.request"},
-        "task": {"instructions": payload, "expected_output": {}},
-        "economics": {},
-        "target_node": node_id,
-        "provider_id": node_id,
-        "model_requirement": row.get("model_requirement"),
-        "expires_in_seconds": row.get("expires_in_seconds"),
-        "payload_uri": row.get("payload_uri"),
-        "secret_data": row.get("result_payload"),
-    }
+    hydrated_row = dict(row)
+    hydrated_row["payload"] = payload
+    return _task_data_from_row(hydrated_row, status="assigned", provider_id=node_id)
 
 async def _flush_queued_dms(node_id: str, websocket: WebSocket) -> None:
     """Deliver store-and-forward DMs queued while node_id was offline.

--- a/hub/main.py
+++ b/hub/main.py
@@ -611,6 +611,32 @@ def _task_structured_body(task: TaskCreate, payload: str) -> dict:
     return task_body
 
 
+def _task_requires_envelope_persistence(task: TaskCreate) -> bool:
+    source = task.source if isinstance(task.source, dict) else {}
+    if any(str(key) != "node_id" for key in source.keys()):
+        return True
+
+    intent = task.intent if isinstance(task.intent, dict) else {}
+    if intent:
+        if str(intent.get("type") or "").strip() != "analysis.request":
+            return True
+        if any(str(key) != "type" for key in intent.keys()):
+            return True
+
+    task_body = task.task if isinstance(task.task, dict) else {}
+    if task_body:
+        if any(str(key) not in {"instructions", "expected_output"} for key in task_body.keys()):
+            return True
+        expected_output = task_body.get("expected_output")
+        if isinstance(expected_output, dict) and expected_output:
+            return True
+
+    if isinstance(task.economics, dict) and task.economics:
+        return True
+
+    return False
+
+
 def _task_data_from_row(task_row: dict, *, status: Optional[str] = None, provider_id: Optional[str] = None) -> dict:
     payload = str(task_row.get("payload") or "")
     consumer_id = str(task_row.get("consumer_id") or "")
@@ -2322,9 +2348,28 @@ async def submit_task(
         expires_in_seconds=task.expires_in_seconds,
         verifier_type=verifier_type,
     )
+    require_envelope_persistence = _task_requires_envelope_persistence(task)
     try:
         db.set_task_envelope(task_id, json.dumps(task_data))
     except Exception as exc:
+        if require_envelope_persistence:
+            cancel_time = time.time()
+            cancelled = db.cancel_task_if_open(task_id, cancel_time)
+            refunded = None
+            if bounty > 0:
+                refunded = db.refund_escrow(task_id, cancel_time)
+                if refunded:
+                    refund_balance = db.get_balance(consumer_id)
+                    log_audit("ESCROW_REFUND", consumer_id, refunded, refund_balance, task_id)
+            log_event(
+                "task_envelope_error",
+                f"Failed to persist structured task envelope {task_id[:8]}: {exc}",
+                task_id=task_id,
+                fail_closed=True,
+                cancelled=cancelled,
+                refunded=refunded,
+            )
+            raise HTTPException(status_code=500, detail="Failed to persist structured task envelope")
         log_event("task_envelope_error", f"Failed to persist task envelope {task_id[:8]}: {exc}", task_id=task_id)
     async with task_lock:
         active_tasks[task_id] = task_data

--- a/hub/main.py
+++ b/hub/main.py
@@ -3042,7 +3042,7 @@ async def health_check():
 
 
 # ---------------------------------------------------------------------------
-# Diagnostic Endpoint 鈥?tiered approach (per Hermes DM discussion)
+# Diagnostic Endpoint — tiered approach (per Hermes DM discussion)
 # ---------------------------------------------------------------------------
 class DiagnosticResponse(BaseModel):
     node_id: Optional[str] = None
@@ -3207,11 +3207,11 @@ async def diagnostic(
     """
     Tiered diagnostic endpoint.
 
-    Tier 1 (public, no auth) 鈥?specify node_id as query param:
+    Tier 1 (public, no auth) — specify node_id as query param:
         GET /diagnostic?node_id=node_xxx
         Returns: {node_id, registered, availability, last_heartbeat}
 
-    Tier 2 (authenticated) 鈥?no query param, uses auth headers:
+    Tier 2 (authenticated) — no query param, uses auth headers:
         GET /diagnostic (with X-MEP-NodeID, X-MEP-Timestamp, X-MEP-Signature)
         Returns: full health report including ws_connected, last_ws_activity, auth_ok
 

--- a/hub/main.py
+++ b/hub/main.py
@@ -3042,7 +3042,7 @@ async def health_check():
 
 
 # ---------------------------------------------------------------------------
-# Diagnostic Endpoint — tiered approach (per Hermes DM discussion)
+# Diagnostic Endpoint 鈥?tiered approach (per Hermes DM discussion)
 # ---------------------------------------------------------------------------
 class DiagnosticResponse(BaseModel):
     node_id: Optional[str] = None
@@ -3207,11 +3207,11 @@ async def diagnostic(
     """
     Tiered diagnostic endpoint.
 
-    Tier 1 (public, no auth) — specify node_id as query param:
+    Tier 1 (public, no auth) 鈥?specify node_id as query param:
         GET /diagnostic?node_id=node_xxx
         Returns: {node_id, registered, availability, last_heartbeat}
 
-    Tier 2 (authenticated) — no query param, uses auth headers:
+    Tier 2 (authenticated) 鈥?no query param, uses auth headers:
         GET /diagnostic (with X-MEP-NodeID, X-MEP-Timestamp, X-MEP-Signature)
         Returns: full health report including ws_connected, last_ws_activity, auth_ok
 

--- a/node/task_envelope.py
+++ b/node/task_envelope.py
@@ -7,9 +7,12 @@ def build_task_envelope(
     bounty: float,
     *,
     intent_type: str = "analysis.request",
+    intent_priority: Optional[str] = None,
     target_node: Optional[str] = None,
     target_capability: Optional[str] = None,
     expected_output: Optional[dict] = None,
+    task_title: Optional[str] = None,
+    task_inputs: Optional[dict] = None,
     payload_uri: Optional[str] = None,
     secret_data: Optional[str] = None,
 ) -> dict:
@@ -38,6 +41,12 @@ def build_task_envelope(
             "payment_direction": payment_direction,
         },
     }
+    if intent_priority:
+        body["intent"]["priority"] = intent_priority
+    if task_title:
+        body["task"]["title"] = task_title
+    if task_inputs:
+        body["task"]["inputs"] = task_inputs
     if target_node or target_capability:
         body["routing"] = {}
         if target_node:

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -564,13 +564,17 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         target_node: str | None = None,
         target_capability: str | None = None,
         secret_data: str | None = None,
+        intent_type: str = "conformance.request",
+        expected_output: dict | None = None,
+        task_title: str | None = None,
+        task_inputs: dict | None = None,
     ) -> str:
         payload = {
             "source": {"node_id": node_id},
-            "intent": {"type": "conformance.request"},
+            "intent": {"type": intent_type},
             "task": {
                 "instructions": instructions,
-                "expected_output": {"result_type": "text"},
+                "expected_output": expected_output or {"result_type": "text"},
             },
             "economics": {
                 "bounty_ns": bounty_ns,
@@ -579,6 +583,10 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
                 "payment_direction": payment_direction,
             },
         }
+        if task_title:
+            payload["task"]["title"] = task_title
+        if task_inputs:
+            payload["task"]["inputs"] = task_inputs
         routing = {}
         if target_node:
             routing["target_node_id"] = target_node
@@ -681,6 +689,63 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
         self.assertEqual(client.get(f"/balance/{sender_id}").json()["balance_seconds"], sender_before)
 
+    def test_targeted_task_delivery_preserves_structured_task_metadata(self):
+        sender_priv, sender_pub, sender_id = _make_identity()
+        _, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+
+        fake_ws = _FakeWebSocket()
+        main.connected_nodes[target_id] = fake_ws
+        try:
+            task_id = self._submit_spec_task(
+                sender_priv,
+                sender_id,
+                instructions="Audit github.com/WUAIBING/MEP.",
+                bounty_ns=0,
+                market="chat",
+                payment_direction="none",
+                target_node=target_id,
+                target_capability="repo_audit",
+                intent_type="repo_audit.request",
+                expected_output={
+                    "result_type": "repo_audit_result",
+                    "format": "json",
+                    "artifact_allowed": True,
+                    "inline_summary_max_chars": 6000,
+                },
+                task_title="Repo audit: github.com/WUAIBING/MEP",
+                task_inputs={
+                    "repo_audit": {
+                        "repo_url": "github.com/WUAIBING/MEP",
+                        "audit_type": "full_repo_audit",
+                        "max_findings": 5,
+                    }
+                },
+            )
+        finally:
+            main.connected_nodes.pop(target_id, None)
+
+        event_data = fake_ws.sent[0]["data"]
+        self.assertEqual(event_data["id"], task_id)
+        self.assertEqual(event_data["intent"], {"type": "repo_audit.request"})
+        self.assertEqual(event_data["task"]["title"], "Repo audit: github.com/WUAIBING/MEP")
+        self.assertEqual(
+            event_data["task"]["inputs"],
+            {
+                "repo_audit": {
+                    "repo_url": "github.com/WUAIBING/MEP",
+                    "audit_type": "full_repo_audit",
+                    "max_findings": 5,
+                }
+            },
+        )
+        self.assertEqual(event_data["task"]["expected_output"]["result_type"], "repo_audit_result")
+        stored = db.get_task(task_id)
+        persisted_envelope = json.loads(stored["envelope_json"])
+        self.assertEqual(persisted_envelope["task"]["title"], "Repo audit: github.com/WUAIBING/MEP")
+        self.assertEqual(persisted_envelope["model_requirement"], "repo_audit")
+
     def test_spec_data_market_receiver_pays_sender_for_secret_data(self):
         seller_priv, seller_pub, seller_id = _make_identity()
         buyer_priv, buyer_pub, buyer_id = _make_identity()
@@ -805,6 +870,71 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(body["tasks"][0]["provider_id"], target_id)
         self.assertEqual(body["tasks"][0]["status"], "assigned")
 
+    def test_pending_tasks_endpoint_preserves_structured_task_metadata(self):
+        sender_priv, sender_pub, sender_id = _make_identity()
+        target_priv, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+
+        live_ws = _FakeWebSocket()
+        main.connected_nodes[target_id] = live_ws
+        try:
+            resp = self._submit_spec_task(
+                sender_priv,
+                sender_id,
+                instructions="Audit github.com/WUAIBING/MEP.",
+                bounty_ns=0,
+                market="chat",
+                payment_direction="none",
+                target_node=target_id,
+                target_capability="repo_audit",
+                intent_type="repo_audit.request",
+                expected_output={"result_type": "repo_audit_result", "format": "json"},
+                task_title="Repo audit: github.com/WUAIBING/MEP",
+                task_inputs={"repo_audit": {"repo_url": "github.com/WUAIBING/MEP", "max_findings": 5}},
+            )
+        finally:
+            main.connected_nodes.pop(target_id, None)
+
+        pending = client.get(f"/tasks/pending/{target_id}", headers=_auth_headers(target_priv, target_id, ""))
+        self.assertEqual(pending.status_code, 200, pending.text)
+        body = pending.json()
+        self.assertEqual(body["count"], 1)
+        task = body["tasks"][0]
+        self.assertEqual(task["task_id"], resp)
+        self.assertEqual(task["task"]["title"], "Repo audit: github.com/WUAIBING/MEP")
+        self.assertEqual(task["task"]["inputs"]["repo_audit"]["repo_url"], "github.com/WUAIBING/MEP")
+        self.assertEqual(task["task"]["expected_output"]["result_type"], "repo_audit_result")
+        self.assertEqual(task["intent"], {"type": "repo_audit.request"})
+
+    def test_bid_response_preserves_structured_task_metadata(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        task_id = self._submit_spec_task(
+            consumer_priv,
+            consumer_id,
+            instructions="Audit github.com/WUAIBING/MEP.",
+            bounty_ns=1_000_000_000,
+            market="compute",
+            payment_direction="sender_to_receiver",
+            target_capability="repo_audit",
+            intent_type="repo_audit.request",
+            expected_output={"result_type": "repo_audit_result", "format": "json"},
+            task_title="Repo audit: github.com/WUAIBING/MEP",
+            task_inputs={"repo_audit": {"repo_url": "github.com/WUAIBING/MEP", "audit_type": "full_repo_audit"}},
+        )
+
+        bid_data = self._bid(provider_priv, provider_id, task_id)
+        self.assertEqual(bid_data["task"]["title"], "Repo audit: github.com/WUAIBING/MEP")
+        self.assertEqual(bid_data["task"]["inputs"]["repo_audit"]["audit_type"], "full_repo_audit")
+        self.assertEqual(bid_data["task"]["expected_output"]["result_type"], "repo_audit_result")
+        self.assertEqual(bid_data["intent"], {"type": "repo_audit.request"})
+        self.assertEqual(bid_data["source"], {"node_id": consumer_id})
+        self.assertEqual(bid_data["economics"]["market"], "compute")
+
     def test_queued_dm_flush_matches_live_targeted_shape(self):
         """A queued DM must be flushed with the same new_task event contract as a
         live targeted delivery, so offline recipients are not handed a thinner
@@ -848,6 +978,58 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         # source.node_id (used for reply routing) must survive store-and-forward.
         self.assertEqual(flushed_data["source"]["node_id"], sender_id)
         self.assertEqual(flushed_data["task"]["expected_output"], live_data["task"]["expected_output"])
+
+    def test_queued_dm_flush_preserves_structured_task_metadata(self):
+        import asyncio
+
+        sender_priv, sender_pub, sender_id = _make_identity()
+        _, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+        main.connected_nodes.pop(target_id, None)
+
+        task_payload = json.dumps(
+            {
+                "source": {"node_id": sender_id},
+                "intent": {"type": "repo_audit.request"},
+                "task": {
+                    "instructions": "Audit github.com/WUAIBING/MEP.",
+                    "title": "Repo audit: github.com/WUAIBING/MEP",
+                    "inputs": {
+                        "repo_audit": {
+                            "repo_url": "github.com/WUAIBING/MEP",
+                            "audit_type": "architecture_audit",
+                            "max_findings": 5,
+                        }
+                    },
+                    "expected_output": {
+                        "result_type": "repo_audit_result",
+                        "format": "json",
+                    },
+                },
+                "economics": {
+                    "bounty_ns": 0,
+                    "currency": "MEP_NS",
+                    "market": "chat",
+                    "payment_direction": "none",
+                },
+                "routing": {"target_node_id": target_id, "target_capability": "repo_audit"},
+            }
+        )
+        headers = _auth_headers(sender_priv, sender_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertEqual(resp.json()["status"], "queued")
+
+        flush_ws = _FakeWebSocket()
+        asyncio.run(main._flush_queued_dms(target_id, flush_ws))
+
+        flushed_data = flush_ws.sent[0]["data"]
+        self.assertEqual(flushed_data["intent"], {"type": "repo_audit.request"})
+        self.assertEqual(flushed_data["task"]["title"], "Repo audit: github.com/WUAIBING/MEP")
+        self.assertEqual(flushed_data["task"]["inputs"]["repo_audit"]["audit_type"], "architecture_audit")
+        self.assertEqual(flushed_data["task"]["expected_output"]["result_type"], "repo_audit_result")
+        self.assertEqual(flushed_data["model_requirement"], "repo_audit")
 
     def test_dm_queue_full_rejected(self):
         sender_priv, sender_pub, sender_id = _make_identity()

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -1,6 +1,6 @@
 """
 
-Hub API smoke tests — exercises the full task lifecycle using FastAPI TestClient.
+Hub API smoke tests 鈥?exercises the full task lifecycle using FastAPI TestClient.
 
 No running server or Postgres needed; uses SQLite backend automatically.
 
@@ -49,7 +49,7 @@ from cryptography.hazmat.primitives import serialization  # noqa: E402
 
 
 
-# Import hub app AFTER env vars are set — db import triggers init_db()
+# Import hub app AFTER env vars are set 鈥?db import triggers init_db()
 
 import db  # noqa: E402, F401
 

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -1,330 +1,167 @@
-"""
-
-Hub API smoke tests 鈥?exercises the full task lifecycle using FastAPI TestClient.
-
-No running server or Postgres needed; uses SQLite backend automatically.
-
-"""
-
-import base64
-
-from contextlib import contextmanager
-
-from concurrent.futures import ThreadPoolExecutor
-
-import json
-
-import os
-
-import sys
-
-import time
-
-import tempfile
-
-import unittest
-
+"""
+Hub API smoke tests — exercises the full task lifecycle using FastAPI TestClient.
+No running server or Postgres needed; uses SQLite backend automatically.
+"""
+import base64
+from contextlib import contextmanager
+from concurrent.futures import ThreadPoolExecutor
+import json
+import os
+import sys
+import time
+import tempfile
+import unittest
 from unittest import mock
-
-
-# Point hub DB at a temp file so tests don't pollute anything
-
-_test_db = os.path.join(tempfile.gettempdir(), "mep_test_hub.db")
-
-os.environ["MEP_SQLITE_PATH"] = _test_db
-
-os.environ.setdefault("MEP_DATABASE_URL", "")  # force SQLite
-
-os.environ.setdefault("MEP_ADMIN_KEY", "test-admin-key")  # for admin endpoint tests
-
-
-
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "hub"))
-
-
-
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: E402
-
-from cryptography.hazmat.primitives import serialization  # noqa: E402
-
-
-
-# Import hub app AFTER env vars are set 鈥?db import triggers init_db()
-
-import db  # noqa: E402, F401
-
-import main  # noqa: E402
-
-from main import app  # noqa: E402
-
-
-
-from fastapi.testclient import TestClient  # noqa: E402
-
-
-
-client = TestClient(app)
-
-
-
-
-
-class _FakeWebSocket:
-
-    def __init__(self):
-
-        self.sent = []
-
-
-
-    async def send_json(self, payload):
-
-        self.sent.append(payload)
-
-
-
-
-
-# ---------------------------------------------------------------------------
-
-# Auth helpers (mirrors node/identity.py crypto)
-
-# ---------------------------------------------------------------------------
-
-def _make_identity():
-
-    """Generate a keypair and return (private_key, pub_pem, node_id)."""
-
-    private_key = Ed25519PrivateKey.generate()
-
-    pub_pem = private_key.public_key().public_bytes(
-
-        serialization.Encoding.PEM,
-
-        serialization.PublicFormat.SubjectPublicKeyInfo,
-
-    ).decode("utf-8")
-
-    from auth import derive_node_id
-
-    node_id = derive_node_id(pub_pem)
-
-    return private_key, pub_pem, node_id
-
-
-
-
-
-def _auth_headers(private_key, node_id: str, payload_str: str) -> dict:
-
-    """Build the X-MEP-* auth headers required by verify_request."""
-
-    ts = str(int(time.time()))
-
-    message = f"{payload_str}{ts}".encode("utf-8")
-
-    signature = base64.b64encode(private_key.sign(message)).decode("utf-8")
-
-    return {
-
-        "X-MEP-NodeID": node_id,
-
-        "X-MEP-Timestamp": ts,
-
-        "X-MEP-Signature": signature,
-
-        "Content-Type": "application/json",
-
-    }
-
-
-
-
-
-def _diagnostic_headers(private_key, node_id: str) -> dict:
-
-    """Build auth headers for GET /diagnostic Tier-2 auth."""
-
-    ts = str(int(time.time()))
-
-    message = f"{node_id}{ts}".encode("utf-8")
-
-    signature = base64.b64encode(private_key.sign(message)).decode("utf-8")
-
-    return {
-
-        "X-MEP-NodeID": node_id,
-
-        "X-MEP-Timestamp": ts,
-
-        "X-MEP-Signature": signature,
-
-    }
-
-
-
-
-
-def _register(pub_pem: str, auto_approve: bool = True) -> dict:
-
-    resp = client.post("/register", json={"pubkey": pub_pem})
-
-    assert resp.status_code == 200, f"Register failed: {resp.text}"
-
-    data = resp.json()
-
-    if auto_approve and data["status"] == "pending":
-
-        node_id = data["node_id"]
-
-        approve_resp = client.post("/admin/approve-registration", json={"node_id": node_id}, headers={"x-mep-admin-key": "test-admin-key"})
-
-        assert approve_resp.status_code == 200, f"Approve failed: {approve_resp.text}"
-
-        data = approve_resp.json()
-
-    return data
-
-
-
-
-
-@contextmanager
-
-def _interbot_validation(enabled: bool, legacy_policy: str = "dm_only"):
-
-    old_enabled = main.INTERBOT_SPEC_VALIDATE_ENABLED
-
-    old_policy = main.INTERBOT_LEGACY_POLICY
-
-    main.INTERBOT_SPEC_VALIDATE_ENABLED = enabled
-
-    main.INTERBOT_LEGACY_POLICY = legacy_policy
-
-    try:
-
-        yield
-
-    finally:
-
-        main.INTERBOT_SPEC_VALIDATE_ENABLED = old_enabled
-
-        main.INTERBOT_LEGACY_POLICY = old_policy
-
-
-
-
-
-# ---------------------------------------------------------------------------
-
-# Tests
-
-# ---------------------------------------------------------------------------
-
-class TestHealthEndpoint(unittest.TestCase):
-
-
-
-    def test_health_returns_ok(self):
-
-        resp = client.get("/health")
-
-        self.assertEqual(resp.status_code, 200)
-
-        data = resp.json()
-
-        self.assertEqual(data["status"], "ok")
-
-        self.assertIn("metrics", data)
-
-
-
-
-
-class TestRegistration(unittest.TestCase):
-
-
-
-    def test_register_new_node_pending_approval(self):
-
-        _, pub_pem, _ = _make_identity()
-
-        data = _register(pub_pem, auto_approve=False)
-
-        self.assertEqual(data["status"], "pending")
-
-        self.assertTrue(data["node_id"].startswith("node_"))
-
-        self.assertEqual(data["balance"], 0.0)
-
-
-
-    def test_duplicate_registration_preserves_pending_status(self):
-
-        _, pub_pem, _ = _make_identity()
-
-        data1 = _register(pub_pem, auto_approve=False)
-
-        data2 = _register(pub_pem, auto_approve=False)
-
-        self.assertEqual(data1["node_id"], data2["node_id"])
-
-        self.assertEqual(data1["status"], "pending")
-
-        self.assertEqual(data2["status"], "pending")
-
-
-
-    def test_register_persists_x25519_public_key_in_registry(self):
-
-        _, pub_pem, node_id = _make_identity()
-
-        resp = client.post("/register", json={"pubkey": pub_pem, "alias": "enc-node", "x25519_public_key": "encpub"})
-
-        self.assertEqual(resp.status_code, 200, f"Register failed: {resp.text}")
-
-
-
-        registry = db.get_registry(node_id)
-
-        self.assertIsNotNone(registry)
-
-        self.assertEqual(registry["alias"], "enc-node")
-
-        self.assertEqual(registry["x25519_public_key"], "encpub")
-
-
-
-
-
-class TestBalance(unittest.TestCase):
-
-
-
-    def test_get_balance(self):
-
-        _, pub_pem, node_id = _make_identity()
-
-        _register(pub_pem)
-
-        resp = client.get(f"/balance/{node_id}")
-
-        self.assertEqual(resp.status_code, 200)
-
-        self.assertGreater(resp.json()["balance_seconds"], 0)
-
-
-
-    def test_unknown_node_404(self):
-
-        resp = client.get("/balance/node_doesnotexist")
-
-        self.assertEqual(resp.status_code, 404)
-
-
-
-
-
+
+# Point hub DB at a temp file so tests don't pollute anything
+_test_db = os.path.join(tempfile.gettempdir(), "mep_test_hub.db")
+os.environ["MEP_SQLITE_PATH"] = _test_db
+os.environ.setdefault("MEP_DATABASE_URL", "")  # force SQLite
+os.environ.setdefault("MEP_ADMIN_KEY", "test-admin-key")  # for admin endpoint tests
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "hub"))
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: E402
+from cryptography.hazmat.primitives import serialization  # noqa: E402
+
+# Import hub app AFTER env vars are set — db import triggers init_db()
+import db  # noqa: E402, F401
+import main  # noqa: E402
+from main import app  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+client = TestClient(app)
+
+
+class _FakeWebSocket:
+    def __init__(self):
+        self.sent = []
+
+    async def send_json(self, payload):
+        self.sent.append(payload)
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers (mirrors node/identity.py crypto)
+# ---------------------------------------------------------------------------
+def _make_identity():
+    """Generate a keypair and return (private_key, pub_pem, node_id)."""
+    private_key = Ed25519PrivateKey.generate()
+    pub_pem = private_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    from auth import derive_node_id
+    node_id = derive_node_id(pub_pem)
+    return private_key, pub_pem, node_id
+
+
+def _auth_headers(private_key, node_id: str, payload_str: str) -> dict:
+    """Build the X-MEP-* auth headers required by verify_request."""
+    ts = str(int(time.time()))
+    message = f"{payload_str}{ts}".encode("utf-8")
+    signature = base64.b64encode(private_key.sign(message)).decode("utf-8")
+    return {
+        "X-MEP-NodeID": node_id,
+        "X-MEP-Timestamp": ts,
+        "X-MEP-Signature": signature,
+        "Content-Type": "application/json",
+    }
+
+
+def _diagnostic_headers(private_key, node_id: str) -> dict:
+    """Build auth headers for GET /diagnostic Tier-2 auth."""
+    ts = str(int(time.time()))
+    message = f"{node_id}{ts}".encode("utf-8")
+    signature = base64.b64encode(private_key.sign(message)).decode("utf-8")
+    return {
+        "X-MEP-NodeID": node_id,
+        "X-MEP-Timestamp": ts,
+        "X-MEP-Signature": signature,
+    }
+
+
+def _register(pub_pem: str, auto_approve: bool = True) -> dict:
+    resp = client.post("/register", json={"pubkey": pub_pem})
+    assert resp.status_code == 200, f"Register failed: {resp.text}"
+    data = resp.json()
+    if auto_approve and data["status"] == "pending":
+        node_id = data["node_id"]
+        approve_resp = client.post("/admin/approve-registration", json={"node_id": node_id}, headers={"x-mep-admin-key": "test-admin-key"})
+        assert approve_resp.status_code == 200, f"Approve failed: {approve_resp.text}"
+        data = approve_resp.json()
+    return data
+
+
+@contextmanager
+def _interbot_validation(enabled: bool, legacy_policy: str = "dm_only"):
+    old_enabled = main.INTERBOT_SPEC_VALIDATE_ENABLED
+    old_policy = main.INTERBOT_LEGACY_POLICY
+    main.INTERBOT_SPEC_VALIDATE_ENABLED = enabled
+    main.INTERBOT_LEGACY_POLICY = legacy_policy
+    try:
+        yield
+    finally:
+        main.INTERBOT_SPEC_VALIDATE_ENABLED = old_enabled
+        main.INTERBOT_LEGACY_POLICY = old_policy
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestHealthEndpoint(unittest.TestCase):
+
+    def test_health_returns_ok(self):
+        resp = client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "ok")
+        self.assertIn("metrics", data)
+
+
+class TestRegistration(unittest.TestCase):
+
+    def test_register_new_node_pending_approval(self):
+        _, pub_pem, _ = _make_identity()
+        data = _register(pub_pem, auto_approve=False)
+        self.assertEqual(data["status"], "pending")
+        self.assertTrue(data["node_id"].startswith("node_"))
+        self.assertEqual(data["balance"], 0.0)
+
+    def test_duplicate_registration_preserves_pending_status(self):
+        _, pub_pem, _ = _make_identity()
+        data1 = _register(pub_pem, auto_approve=False)
+        data2 = _register(pub_pem, auto_approve=False)
+        self.assertEqual(data1["node_id"], data2["node_id"])
+        self.assertEqual(data1["status"], "pending")
+        self.assertEqual(data2["status"], "pending")
+
+    def test_register_persists_x25519_public_key_in_registry(self):
+        _, pub_pem, node_id = _make_identity()
+        resp = client.post("/register", json={"pubkey": pub_pem, "alias": "enc-node", "x25519_public_key": "encpub"})
+        self.assertEqual(resp.status_code, 200, f"Register failed: {resp.text}")
+
+        registry = db.get_registry(node_id)
+        self.assertIsNotNone(registry)
+        self.assertEqual(registry["alias"], "enc-node")
+        self.assertEqual(registry["x25519_public_key"], "encpub")
+
+
+class TestBalance(unittest.TestCase):
+
+    def test_get_balance(self):
+        _, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+        resp = client.get(f"/balance/{node_id}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertGreater(resp.json()["balance_seconds"], 0)
+
+    def test_unknown_node_404(self):
+        resp = client.get("/balance/node_doesnotexist")
+        self.assertEqual(resp.status_code, 404)
+
+
 class TestV2Endpoints(unittest.TestCase):
 
     def setUp(self):
@@ -409,884 +246,450 @@ class TestV2Endpoints(unittest.TestCase):
         self.assertIn("amount_ns", data["entries"][0])
 
 
-class TestTaskLifecycle(unittest.TestCase):
-
-    """Full happy-path: register consumer + provider, submit, bid, complete."""
-
-
-
-    def setUp(self):
-
-        main.rate_limits.clear()
-
-
-
-    def test_submit_bid_complete(self):
-
-        # Setup: two identities
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        # Submit task
-
-        bounty = 1.0
-
-        task_payload = json.dumps({
-
-            "consumer_id": consumer_id,
-
-            "payload": "What is 2+2?",
-
-            "bounty": bounty,
-
-        })
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-
-        task_id = resp.json()["task_id"]
-
-
-
-        # Bid on task
-
-        bid_payload = json.dumps({
-
-            "task_id": task_id,
-
-            "provider_id": provider_id,
-
-        })
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200)
-
-        self.assertEqual(resp.json()["status"], "accepted")
-
-
-
-        # Complete task
-
-        result_payload = json.dumps({
-
-            "task_id": task_id,
-
-            "provider_id": provider_id,
-
-            "result_payload": "4",
-
-        })
-
-        headers = _auth_headers(provider_priv, provider_id, result_payload)
-
-        resp = client.post("/tasks/complete", content=result_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Complete failed: {resp.text}")
-
-        self.assertEqual(resp.json()["status"], "success")
-
-        self.assertEqual(resp.json()["earned"], bounty)
-
-
-
-        # Verify provider balance increased
-
-        resp = client.get(f"/balance/{provider_id}")
-
-        self.assertGreater(resp.json()["balance_seconds"], 10.0)  # 10 starting + 1 earned
-
-
-
-    def test_submitted_result_timeout_refunds_manual_verification_escrow(self):
-
-        main.rate_limits.clear()
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-        task_payload = json.dumps({
-
-            "consumer_id": consumer_id,
-
-            "payload": "Requires review but never accepted",
-
-            "bounty": 1.0,
-
-            "verifier_type": "manual_acceptance",
-
-        })
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(submit.status_code, 200, submit.text)
-
-        task_id = submit.json()["task_id"]
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-
-
-        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "stale"})
-
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-
-        complete = client.post("/tasks/complete", content=complete_payload, headers=headers)
-
-        self.assertEqual(complete.status_code, 200, complete.text)
-
-        self.assertEqual(complete.json()["status"], "pending_verification")
-
-        self.assertEqual(db.get_escrow(task_id)["status"], "held")
-
-
-
-        old_time = time.time() - main.SUBMITTED_RESULT_TIMEOUT_SECONDS - 1
-
-        conn = db._get_conn()
-
-        conn.execute(
-
-            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
-
-            (old_time, task_id)
-
-        )
-
-        conn.commit()
-
-        db._release_conn(conn)
-
-
-
-        import asyncio
-
-        from main import _sweep_submitted_result_timeouts
-
-        loop = asyncio.new_event_loop()
-
-        try:
-
-            loop.run_until_complete(_sweep_submitted_result_timeouts())
-
-        finally:
-
-            loop.close()
-
-
-
-        self.assertEqual(db.get_task(task_id)["status"], "expired")
-
-        self.assertEqual(db.get_escrow(task_id)["status"], "refunded")
-
-        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
-
-        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
-
-
-
-    def test_manual_verification_gates_settlement_until_consumer_accepts(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-        task_payload = json.dumps({
-
-            "consumer_id": consumer_id,
-
-            "payload": "Requires review",
-
-            "bounty": 1.0,
-
-            "verifier_type": "manual_acceptance",
-
-        })
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(submit.status_code, 200, submit.text)
-
-        task_id = submit.json()["task_id"]
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-        bid = client.post("/tasks/bid", content=bid_payload, headers=headers)
-
-        self.assertEqual(bid.status_code, 200, bid.text)
-
-        self.assertEqual(bid.json()["status"], "accepted")
-
-
-
-        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "review me"})
-
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-
-        complete = client.post("/tasks/complete", content=complete_payload, headers=headers)
-
-        self.assertEqual(complete.status_code, 200, complete.text)
-
-        self.assertEqual(complete.json()["status"], "pending_verification")
-
-        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
-
-        task = db.get_task(task_id)
-
-        self.assertEqual(task["status"], "submitted_result")
-
-        self.assertEqual(db.get_escrow(task_id)["status"], "held")
-
-
-
-        accept_payload = json.dumps({"task_id": task_id})
-
-        headers = _auth_headers(provider_priv, provider_id, accept_payload)
-
-        forbidden = client.post("/tasks/verify/accept", content=accept_payload, headers=headers)
-
-        self.assertEqual(forbidden.status_code, 403, forbidden.text)
-
-
-
-        headers = _auth_headers(consumer_priv, consumer_id, accept_payload)
-
-        accepted = client.post("/tasks/verify/accept", content=accept_payload, headers=headers)
-
-        self.assertEqual(accepted.status_code, 200, accepted.text)
-
-        self.assertEqual(accepted.json()["status"], "success")
-
-        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before + 1.0)
-
-        self.assertEqual(db.get_task(task_id)["status"], "completed")
-
-        self.assertEqual(db.get_escrow(task_id)["status"], "released")
-
-
-
-    def test_provider_reject_refunds_escrow_without_payment(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-
-
-        task_payload = json.dumps({
-
-            "consumer_id": consumer_id,
-
-            "payload": "Run unsafe code",
-
-            "bounty": 1.0,
-
-            "target_node": provider_id,
-
-        })
-
-        fake_ws = _FakeWebSocket()
-
-        main.connected_nodes[provider_id] = fake_ws
-
-        try:
-
-            headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-            submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-            self.assertEqual(submit.status_code, 200, submit.text)
-
-            self.assertEqual(submit.json()["status"], "success")
-
-            task_id = submit.json()["task_id"]
-
-        finally:
-
-            main.connected_nodes.pop(provider_id, None)
-
-
-
-        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
-
-        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
-
-        self.assertEqual(db.get_task(task_id)["status"], "assigned")
-
-        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
-
-
-
-        reject_payload = json.dumps({
-
-            "task_id": task_id,
-
-            "provider_id": provider_id,
-
-            "reason": "execution_disabled",
-
-        })
-
-        headers = _auth_headers(provider_priv, provider_id, reject_payload)
-
-        rejected = client.post("/tasks/reject", content=reject_payload, headers=headers)
-
-        self.assertEqual(rejected.status_code, 200, rejected.text)
-
-        self.assertEqual(rejected.json()["status"], "success")
-
-
-
-        self.assertEqual(db.get_task(task_id)["status"], "rejected")
-
-        self.assertEqual(db.get_escrow(task_id)["status"], "refunded")
-
-        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
-
-        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
-
-
-
-    def test_duplicate_completion_does_not_double_settle(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "once", "bounty": 1.0})
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(submit.status_code, 200, submit.text)
-
-        task_id = submit.json()["task_id"]
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-
-
-        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "done"})
-
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-
-        first = client.post("/tasks/complete", content=complete_payload, headers=headers)
-
-        self.assertEqual(first.status_code, 200, first.text)
-
-
-
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-
-        second = client.post("/tasks/complete", content=complete_payload, headers=headers)
-
-        self.assertEqual(second.status_code, 404, second.text)
-
-
-
-        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-        self.assertEqual(provider_after, provider_before + 1.0)
-
-        escrow = db.get_escrow(task_id)
-
-        self.assertEqual(escrow["status"], "released")
-
-
-
-    def test_completion_idempotency_replays_response_without_double_settlement(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "idem", "bounty": 1.0})
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        task_id = submit.json()["task_id"]
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-
-
-        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "done"})
-
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-
-        headers["X-MEP-Idempotency-Key"] = "complete-once"
-
-        first = client.post("/tasks/complete", content=complete_payload, headers=headers)
-
-        self.assertEqual(first.status_code, 200, first.text)
-
-
-
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-
-        headers["X-MEP-Idempotency-Key"] = "complete-once"
-
-        second = client.post("/tasks/complete", content=complete_payload, headers=headers)
-
-        self.assertEqual(second.status_code, 200, second.text)
-
-        self.assertEqual(second.json(), first.json())
-
-
-
-        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-        self.assertEqual(provider_after, provider_before + 1.0)
-
-
-
-    def test_atomic_completion_allows_only_one_concurrent_settlement(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        _, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "race", "bounty": 1.0})
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        task_id = submit.json()["task_id"]
-
-        self.assertTrue(db.assign_task_if_open(task_id, provider_id, time.time()))
-
-
-
-        def settle_once():
-
-            return db.complete_task_atomic(task_id, provider_id, "done", time.time())
-
-
-
-        with ThreadPoolExecutor(max_workers=2) as pool:
-
-            results = list(pool.map(lambda _: settle_once(), range(2)))
-
-
-
-        statuses = [item["status"] for item in results]
-
-        self.assertEqual(statuses.count("success"), 1, statuses)
-
-        self.assertEqual(statuses.count("not_active"), 1, statuses)
-
-        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-        self.assertEqual(provider_after, provider_before + 1.0)
-
-
-
-    def test_insufficient_balance_rejected(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        _register(consumer_pub)
-
-
-
-        task_payload = json.dumps({
-
-            "consumer_id": consumer_id,
-
-            "payload": "Expensive task",
-
-            "bounty": 99999.0,
-
-        })
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 400)
-
-        self.assertIn("Insufficient", resp.json()["detail"])
-
-
-
-
-
-class TestThreeMarketSpecConformance(unittest.TestCase):
-
-    """Spec-shaped task envelopes should support compute, chat/DM, and data markets."""
-
-
-
-    def setUp(self):
-
-        # The /register rate-limit bucket is keyed only by client IP, so it is
-
-        # shared across the whole suite. Reset it for deterministic isolation.
-
-        main.rate_limits.clear()
-
-
-
-    def _submit_spec_task(
-
-        self,
-
-        private_key,
-
-        node_id: str,
-
-        *,
-
-        instructions: str,
-
-        bounty_ns: int,
-
-        market: str,
-
-        payment_direction: str,
-
-        target_node: str | None = None,
-
-        target_capability: str | None = None,
-
-        secret_data: str | None = None,
-
+class TestTaskLifecycle(unittest.TestCase):
+    """Full happy-path: register consumer + provider, submit, bid, complete."""
+
+    def setUp(self):
+        main.rate_limits.clear()
+
+    def test_submit_bid_complete(self):
+        # Setup: two identities
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        # Submit task
+        bounty = 1.0
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "What is 2+2?",
+            "bounty": bounty,
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+        task_id = resp.json()["task_id"]
+
+        # Bid on task
+        bid_payload = json.dumps({
+            "task_id": task_id,
+            "provider_id": provider_id,
+        })
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "accepted")
+
+        # Complete task
+        result_payload = json.dumps({
+            "task_id": task_id,
+            "provider_id": provider_id,
+            "result_payload": "4",
+        })
+        headers = _auth_headers(provider_priv, provider_id, result_payload)
+        resp = client.post("/tasks/complete", content=result_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Complete failed: {resp.text}")
+        self.assertEqual(resp.json()["status"], "success")
+        self.assertEqual(resp.json()["earned"], bounty)
+
+        # Verify provider balance increased
+        resp = client.get(f"/balance/{provider_id}")
+        self.assertGreater(resp.json()["balance_seconds"], 10.0)  # 10 starting + 1 earned
+
+    def test_submitted_result_timeout_refunds_manual_verification_escrow(self):
+        main.rate_limits.clear()
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "Requires review but never accepted",
+            "bounty": 1.0,
+            "verifier_type": "manual_acceptance",
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(submit.status_code, 200, submit.text)
+        task_id = submit.json()["task_id"]
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "stale"})
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        complete = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(complete.status_code, 200, complete.text)
+        self.assertEqual(complete.json()["status"], "pending_verification")
+        self.assertEqual(db.get_escrow(task_id)["status"], "held")
+
+        old_time = time.time() - main.SUBMITTED_RESULT_TIMEOUT_SECONDS - 1
+        conn = db._get_conn()
+        conn.execute(
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+            (old_time, task_id)
+        )
+        conn.commit()
+        db._release_conn(conn)
+
+        import asyncio
+        from main import _sweep_submitted_result_timeouts
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(_sweep_submitted_result_timeouts())
+        finally:
+            loop.close()
+
+        self.assertEqual(db.get_task(task_id)["status"], "expired")
+        self.assertEqual(db.get_escrow(task_id)["status"], "refunded")
+        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
+
+    def test_manual_verification_gates_settlement_until_consumer_accepts(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "Requires review",
+            "bounty": 1.0,
+            "verifier_type": "manual_acceptance",
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(submit.status_code, 200, submit.text)
+        task_id = submit.json()["task_id"]
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+        bid = client.post("/tasks/bid", content=bid_payload, headers=headers)
+        self.assertEqual(bid.status_code, 200, bid.text)
+        self.assertEqual(bid.json()["status"], "accepted")
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "review me"})
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        complete = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(complete.status_code, 200, complete.text)
+        self.assertEqual(complete.json()["status"], "pending_verification")
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
+        task = db.get_task(task_id)
+        self.assertEqual(task["status"], "submitted_result")
+        self.assertEqual(db.get_escrow(task_id)["status"], "held")
+
+        accept_payload = json.dumps({"task_id": task_id})
+        headers = _auth_headers(provider_priv, provider_id, accept_payload)
+        forbidden = client.post("/tasks/verify/accept", content=accept_payload, headers=headers)
+        self.assertEqual(forbidden.status_code, 403, forbidden.text)
+
+        headers = _auth_headers(consumer_priv, consumer_id, accept_payload)
+        accepted = client.post("/tasks/verify/accept", content=accept_payload, headers=headers)
+        self.assertEqual(accepted.status_code, 200, accepted.text)
+        self.assertEqual(accepted.json()["status"], "success")
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before + 1.0)
+        self.assertEqual(db.get_task(task_id)["status"], "completed")
+        self.assertEqual(db.get_escrow(task_id)["status"], "released")
+
+    def test_provider_reject_refunds_escrow_without_payment(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "Run unsafe code",
+            "bounty": 1.0,
+            "target_node": provider_id,
+        })
+        fake_ws = _FakeWebSocket()
+        main.connected_nodes[provider_id] = fake_ws
+        try:
+            headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+            submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+            self.assertEqual(submit.status_code, 200, submit.text)
+            self.assertEqual(submit.json()["status"], "success")
+            task_id = submit.json()["task_id"]
+        finally:
+            main.connected_nodes.pop(provider_id, None)
+
+        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
+        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
+        self.assertEqual(db.get_task(task_id)["status"], "assigned")
+        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
+
+        reject_payload = json.dumps({
+            "task_id": task_id,
+            "provider_id": provider_id,
+            "reason": "execution_disabled",
+        })
+        headers = _auth_headers(provider_priv, provider_id, reject_payload)
+        rejected = client.post("/tasks/reject", content=reject_payload, headers=headers)
+        self.assertEqual(rejected.status_code, 200, rejected.text)
+        self.assertEqual(rejected.json()["status"], "success")
+
+        self.assertEqual(db.get_task(task_id)["status"], "rejected")
+        self.assertEqual(db.get_escrow(task_id)["status"], "refunded")
+        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
+
+    def test_duplicate_completion_does_not_double_settle(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "once", "bounty": 1.0})
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(submit.status_code, 200, submit.text)
+        task_id = submit.json()["task_id"]
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "done"})
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        first = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(first.status_code, 200, first.text)
+
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        second = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(second.status_code, 404, second.text)
+
+        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        self.assertEqual(provider_after, provider_before + 1.0)
+        escrow = db.get_escrow(task_id)
+        self.assertEqual(escrow["status"], "released")
+
+    def test_completion_idempotency_replays_response_without_double_settlement(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "idem", "bounty": 1.0})
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+        task_id = submit.json()["task_id"]
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "done"})
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        headers["X-MEP-Idempotency-Key"] = "complete-once"
+        first = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(first.status_code, 200, first.text)
+
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+        headers["X-MEP-Idempotency-Key"] = "complete-once"
+        second = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(second.status_code, 200, second.text)
+        self.assertEqual(second.json(), first.json())
+
+        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        self.assertEqual(provider_after, provider_before + 1.0)
+
+    def test_atomic_completion_allows_only_one_concurrent_settlement(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "race", "bounty": 1.0})
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+        task_id = submit.json()["task_id"]
+        self.assertTrue(db.assign_task_if_open(task_id, provider_id, time.time()))
+
+        def settle_once():
+            return db.complete_task_atomic(task_id, provider_id, "done", time.time())
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(lambda _: settle_once(), range(2)))
+
+        statuses = [item["status"] for item in results]
+        self.assertEqual(statuses.count("success"), 1, statuses)
+        self.assertEqual(statuses.count("not_active"), 1, statuses)
+        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+        self.assertEqual(provider_after, provider_before + 1.0)
+
+    def test_insufficient_balance_rejected(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "Expensive task",
+            "bounty": 99999.0,
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Insufficient", resp.json()["detail"])
+
+
+class TestThreeMarketSpecConformance(unittest.TestCase):
+    """Spec-shaped task envelopes should support compute, chat/DM, and data markets."""
+
+    def setUp(self):
+        # The /register rate-limit bucket is keyed only by client IP, so it is
+        # shared across the whole suite. Reset it for deterministic isolation.
+        main.rate_limits.clear()
+
+    def _submit_spec_task(
+        self,
+        private_key,
+        node_id: str,
+        *,
+        instructions: str,
+        bounty_ns: int,
+        market: str,
+        payment_direction: str,
+        target_node: str | None = None,
+        target_capability: str | None = None,
+        secret_data: str | None = None,
         intent_type: str = "conformance.request",
         expected_output: dict | None = None,
         task_title: str | None = None,
         task_inputs: dict | None = None,
-    ) -> str:
-
-        payload = {
-
-            "source": {"node_id": node_id},
-
+    ) -> str:
+        payload = {
+            "source": {"node_id": node_id},
             "intent": {"type": intent_type},
-            "task": {
-
-                "instructions": instructions,
-
+            "task": {
+                "instructions": instructions,
                 "expected_output": expected_output or {"result_type": "text"},
-            },
-
-            "economics": {
-
-                "bounty_ns": bounty_ns,
-
-                "currency": "MEP_NS",
-
-                "market": market,
-
-                "payment_direction": payment_direction,
-
-            },
-
-        }
-
+            },
+            "economics": {
+                "bounty_ns": bounty_ns,
+                "currency": "MEP_NS",
+                "market": market,
+                "payment_direction": payment_direction,
+            },
+        }
         if task_title:
             payload["task"]["title"] = task_title
         if task_inputs:
             payload["task"]["inputs"] = task_inputs
-        routing = {}
-
-        if target_node:
-
-            routing["target_node_id"] = target_node
-
-        if target_capability:
-
-            routing["target_capability"] = target_capability
-
-        if routing:
-
-            payload["routing"] = routing
-
-        if secret_data is not None:
-
-            payload["secret_data"] = secret_data
-
-
-
-        task_payload = json.dumps(payload)
-
-        headers = _auth_headers(private_key, node_id, task_payload)
-
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["status"], "success")
-
-        return data["task_id"]
-
-
-
-    def _bid(self, private_key, provider_id: str, task_id: str) -> dict:
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-        headers = _auth_headers(private_key, provider_id, bid_payload)
-
-        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Bid failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["status"], "accepted")
-
-        return data
-
-
-
-    def _complete(self, private_key, provider_id: str, task_id: str, result_payload: str) -> dict:
-
-        complete_payload = json.dumps(
-
-            {
-
-                "task_id": task_id,
-
-                "provider_id": provider_id,
-
-                "result_payload": result_payload,
-
-            }
-
-        )
-
-        headers = _auth_headers(private_key, provider_id, complete_payload)
-
-        resp = client.post("/tasks/complete", content=complete_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Complete failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["status"], "success")
-
-        return data
-
-
-
-    def test_spec_compute_market_sender_pays_receiver(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-
-
-        task_id = self._submit_spec_task(
-
-            consumer_priv,
-
-            consumer_id,
-
-            instructions="compute this",
-
-            bounty_ns=1_000_000_000,
-
-            market="compute",
-
-            payment_direction="sender_to_receiver",
-
-            target_capability="text",
-
-        )
-
-        stored = db.get_task(task_id)
-
-        self.assertEqual(stored["payload"], "compute this")
-
-        self.assertEqual(stored["bounty"], 1.0)
-
-        self.assertEqual(stored["model_requirement"], "text")
-
-
-
-        self._bid(provider_priv, provider_id, task_id)
-
-        result = self._complete(provider_priv, provider_id, task_id, "computed")
-
-        self.assertEqual(result["earned"], 1.0)
-
-        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
-
-        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before + 1.0)
-
-
-
-    def test_spec_chat_market_targeted_zero_bounty(self):
-
-        sender_priv, sender_pub, sender_id = _make_identity()
-
-        _, target_pub, target_id = _make_identity()
-
-        _register(sender_pub)
-
-        _register(target_pub)
-
-
-
-        sender_before = client.get(f"/balance/{sender_id}").json()["balance_seconds"]
-
-        fake_ws = _FakeWebSocket()
-
-        main.connected_nodes[target_id] = fake_ws
-
-        try:
-
-            task_id = self._submit_spec_task(
-
-                sender_priv,
-
-                sender_id,
-
-                instructions="hello target",
-
-                bounty_ns=0,
-
-                market="chat",
-
-                payment_direction="none",
-
-                target_node=target_id,
-
-            )
-
-        finally:
-
-            main.connected_nodes.pop(target_id, None)
-
-        stored = db.get_task(task_id)
-
-        self.assertEqual(stored["payload"], "hello target")
-
-        self.assertEqual(stored["bounty"], 0.0)
-
-        self.assertEqual(stored["target_node"], target_id)
-
-        self.assertEqual(stored["status"], "assigned")
-
-        self.assertEqual(stored["provider_id"], target_id)
-
-        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
-
-        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
-
-        self.assertEqual(client.get(f"/balance/{sender_id}").json()["balance_seconds"], sender_before)
-
-
-
+        routing = {}
+        if target_node:
+            routing["target_node_id"] = target_node
+        if target_capability:
+            routing["target_capability"] = target_capability
+        if routing:
+            payload["routing"] = routing
+        if secret_data is not None:
+            payload["secret_data"] = secret_data
+
+        task_payload = json.dumps(payload)
+        headers = _auth_headers(private_key, node_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["status"], "success")
+        return data["task_id"]
+
+    def _bid(self, private_key, provider_id: str, task_id: str) -> dict:
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+        headers = _auth_headers(private_key, provider_id, bid_payload)
+        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Bid failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["status"], "accepted")
+        return data
+
+    def _complete(self, private_key, provider_id: str, task_id: str, result_payload: str) -> dict:
+        complete_payload = json.dumps(
+            {
+                "task_id": task_id,
+                "provider_id": provider_id,
+                "result_payload": result_payload,
+            }
+        )
+        headers = _auth_headers(private_key, provider_id, complete_payload)
+        resp = client.post("/tasks/complete", content=complete_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Complete failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["status"], "success")
+        return data
+
+    def test_spec_compute_market_sender_pays_receiver(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+        task_id = self._submit_spec_task(
+            consumer_priv,
+            consumer_id,
+            instructions="compute this",
+            bounty_ns=1_000_000_000,
+            market="compute",
+            payment_direction="sender_to_receiver",
+            target_capability="text",
+        )
+        stored = db.get_task(task_id)
+        self.assertEqual(stored["payload"], "compute this")
+        self.assertEqual(stored["bounty"], 1.0)
+        self.assertEqual(stored["model_requirement"], "text")
+
+        self._bid(provider_priv, provider_id, task_id)
+        result = self._complete(provider_priv, provider_id, task_id, "computed")
+        self.assertEqual(result["earned"], 1.0)
+        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before + 1.0)
+
+    def test_spec_chat_market_targeted_zero_bounty(self):
+        sender_priv, sender_pub, sender_id = _make_identity()
+        _, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+
+        sender_before = client.get(f"/balance/{sender_id}").json()["balance_seconds"]
+        fake_ws = _FakeWebSocket()
+        main.connected_nodes[target_id] = fake_ws
+        try:
+            task_id = self._submit_spec_task(
+                sender_priv,
+                sender_id,
+                instructions="hello target",
+                bounty_ns=0,
+                market="chat",
+                payment_direction="none",
+                target_node=target_id,
+            )
+        finally:
+            main.connected_nodes.pop(target_id, None)
+        stored = db.get_task(task_id)
+        self.assertEqual(stored["payload"], "hello target")
+        self.assertEqual(stored["bounty"], 0.0)
+        self.assertEqual(stored["target_node"], target_id)
+        self.assertEqual(stored["status"], "assigned")
+        self.assertEqual(stored["provider_id"], target_id)
+        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
+        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
+        self.assertEqual(client.get(f"/balance/{sender_id}").json()["balance_seconds"], sender_before)
+
     def test_targeted_task_delivery_preserves_structured_task_metadata(self):
         sender_priv, sender_pub, sender_id = _make_identity()
         _, target_pub, target_id = _make_identity()
@@ -1385,202 +788,104 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
         self.assertEqual(len(db.get_active_tasks()), active_before)
 
-    def test_spec_data_market_receiver_pays_sender_for_secret_data(self):
-
-        seller_priv, seller_pub, seller_id = _make_identity()
-
-        buyer_priv, buyer_pub, buyer_id = _make_identity()
-
-        _register(seller_pub)
-
-        _register(buyer_pub)
-
-
-
-        seller_before = client.get(f"/balance/{seller_id}").json()["balance_seconds"]
-
-        buyer_before = client.get(f"/balance/{buyer_id}").json()["balance_seconds"]
-
-        task_id = self._submit_spec_task(
-
-            seller_priv,
-
-            seller_id,
-
-            instructions="premium dataset",
-
-            bounty_ns=500_000_000,
-
-            market="data",
-
-            payment_direction="receiver_to_sender",
-
-            secret_data="encrypted-premium-data",
-
-        )
-
-        stored = db.get_task(task_id)
-
-        self.assertEqual(stored["bounty"], -0.5)
-
-        self.assertEqual(stored["result_payload"], "encrypted-premium-data")
-
-
-
-        bid_data = self._bid(buyer_priv, buyer_id, task_id)
-
-        self.assertEqual(bid_data["secret_data"], "encrypted-premium-data")
-
-        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
-
-        escrow = db.get_escrow(task_id)
-
-        self.assertEqual(escrow["status"], "held")
-
-        self.assertEqual(escrow["consumer_id"], buyer_id)
-
-
-
-        result = self._complete(buyer_priv, buyer_id, task_id, "data received")
-
-        self.assertEqual(result["earned"], -0.5)
-
-        self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before + 0.5)
-
-        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
-
-
-
-    def _submit_offline_dm(self, sender_priv, sender_id, target_id, instructions="offline hello"):
-
-        task_payload = json.dumps(
-
-            {
-
-                "source": {"node_id": sender_id},
-
-                "intent": {"type": "conformance.request"},
-
-                "task": {
-
-                    "instructions": instructions,
-
-                    "expected_output": {"result_type": "text"},
-
-                },
-
-                "economics": {
-
-                    "bounty_ns": 0,
-
-                    "currency": "MEP_NS",
-
-                    "market": "chat",
-
-                    "payment_direction": "none",
-
-                },
-
-                "routing": {"target_node_id": target_id},
-
-            }
-
-        )
-
-        headers = _auth_headers(sender_priv, sender_id, task_payload)
-
-        return client.post("/tasks/submit", content=task_payload, headers=headers)
-
-
-
-    def test_zero_bounty_dm_to_offline_node_is_queued(self):
-
-        sender_priv, sender_pub, sender_id = _make_identity()
-
-        _, target_pub, target_id = _make_identity()
-
-        _register(sender_pub)
-
-        _register(target_pub)
-
-        main.connected_nodes.pop(target_id, None)
-
-
-
-        resp = self._submit_offline_dm(sender_priv, sender_id, target_id)
-
-
-
-        self.assertEqual(resp.status_code, 200)
-
-        body = resp.json()
-
-        self.assertEqual(body["status"], "queued")
-
-        self.assertEqual(body["queued_for"], target_id)
-
-        stored = db.get_task(body["task_id"])
-
-        self.assertEqual(stored["status"], "queued_dm")
-
-        self.assertEqual(stored["target_node"], target_id)
-
-        self.assertEqual(db.count_queued_dms_for_node(target_id), 1)
-
-
-
-    def test_queued_dm_flushed_on_reconnect(self):
-
-        import asyncio
-
-
-
-        sender_priv, sender_pub, sender_id = _make_identity()
-
-        _, target_pub, target_id = _make_identity()
-
-        _register(sender_pub)
-
-        _register(target_pub)
-
-        main.connected_nodes.pop(target_id, None)
-
-
-
-        resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="ping while away")
-
-        task_id = resp.json()["task_id"]
-
-        self.assertEqual(resp.json()["status"], "queued")
-
-
-
-        # Target reconnects -> flush should deliver the queued DM and mark it assigned.
-
-        fake_ws = _FakeWebSocket()
-
-        asyncio.run(main._flush_queued_dms(target_id, fake_ws))
-
-
-
-        self.assertEqual(len(fake_ws.sent), 1)
-
-        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
-
-        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
-
-        self.assertEqual(fake_ws.sent[0]["data"]["payload"], "ping while away")
-
-        stored = db.get_task(task_id)
-
-        self.assertEqual(stored["status"], "assigned")
-
-        self.assertEqual(stored["provider_id"], target_id)
-
-        self.assertEqual(db.count_queued_dms_for_node(target_id), 0)
-
-
-
+    def test_spec_data_market_receiver_pays_sender_for_secret_data(self):
+        seller_priv, seller_pub, seller_id = _make_identity()
+        buyer_priv, buyer_pub, buyer_id = _make_identity()
+        _register(seller_pub)
+        _register(buyer_pub)
+
+        seller_before = client.get(f"/balance/{seller_id}").json()["balance_seconds"]
+        buyer_before = client.get(f"/balance/{buyer_id}").json()["balance_seconds"]
+        task_id = self._submit_spec_task(
+            seller_priv,
+            seller_id,
+            instructions="premium dataset",
+            bounty_ns=500_000_000,
+            market="data",
+            payment_direction="receiver_to_sender",
+            secret_data="encrypted-premium-data",
+        )
+        stored = db.get_task(task_id)
+        self.assertEqual(stored["bounty"], -0.5)
+        self.assertEqual(stored["result_payload"], "encrypted-premium-data")
+
+        bid_data = self._bid(buyer_priv, buyer_id, task_id)
+        self.assertEqual(bid_data["secret_data"], "encrypted-premium-data")
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
+        escrow = db.get_escrow(task_id)
+        self.assertEqual(escrow["status"], "held")
+        self.assertEqual(escrow["consumer_id"], buyer_id)
+
+        result = self._complete(buyer_priv, buyer_id, task_id, "data received")
+        self.assertEqual(result["earned"], -0.5)
+        self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before + 0.5)
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
+
+    def _submit_offline_dm(self, sender_priv, sender_id, target_id, instructions="offline hello"):
+        task_payload = json.dumps(
+            {
+                "source": {"node_id": sender_id},
+                "intent": {"type": "conformance.request"},
+                "task": {
+                    "instructions": instructions,
+                    "expected_output": {"result_type": "text"},
+                },
+                "economics": {
+                    "bounty_ns": 0,
+                    "currency": "MEP_NS",
+                    "market": "chat",
+                    "payment_direction": "none",
+                },
+                "routing": {"target_node_id": target_id},
+            }
+        )
+        headers = _auth_headers(sender_priv, sender_id, task_payload)
+        return client.post("/tasks/submit", content=task_payload, headers=headers)
+
+    def test_zero_bounty_dm_to_offline_node_is_queued(self):
+        sender_priv, sender_pub, sender_id = _make_identity()
+        _, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+        main.connected_nodes.pop(target_id, None)
+
+        resp = self._submit_offline_dm(sender_priv, sender_id, target_id)
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["status"], "queued")
+        self.assertEqual(body["queued_for"], target_id)
+        stored = db.get_task(body["task_id"])
+        self.assertEqual(stored["status"], "queued_dm")
+        self.assertEqual(stored["target_node"], target_id)
+        self.assertEqual(db.count_queued_dms_for_node(target_id), 1)
+
+    def test_queued_dm_flushed_on_reconnect(self):
+        import asyncio
+
+        sender_priv, sender_pub, sender_id = _make_identity()
+        _, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+        main.connected_nodes.pop(target_id, None)
+
+        resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="ping while away")
+        task_id = resp.json()["task_id"]
+        self.assertEqual(resp.json()["status"], "queued")
+
+        # Target reconnects -> flush should deliver the queued DM and mark it assigned.
+        fake_ws = _FakeWebSocket()
+        asyncio.run(main._flush_queued_dms(target_id, fake_ws))
+
+        self.assertEqual(len(fake_ws.sent), 1)
+        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
+        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
+        self.assertEqual(fake_ws.sent[0]["data"]["payload"], "ping while away")
+        stored = db.get_task(task_id)
+        self.assertEqual(stored["status"], "assigned")
+        self.assertEqual(stored["provider_id"], target_id)
+        self.assertEqual(db.count_queued_dms_for_node(target_id), 0)
+
     def test_pending_tasks_endpoint_lists_assigned_tasks_for_provider(self):
         sender_priv, sender_pub, sender_id = _make_identity()
         target_priv, target_pub, target_id = _make_identity()
@@ -1672,92 +977,49 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(bid_data["source"], {"node_id": consumer_id})
         self.assertEqual(bid_data["economics"]["market"], "compute")
 
-    def test_queued_dm_flush_matches_live_targeted_shape(self):
-
-        """A queued DM must be flushed with the same new_task event contract as a
-
-        live targeted delivery, so offline recipients are not handed a thinner
-
-        payload (regression guard for the store-and-forward shape mismatch)."""
-
-        import asyncio
-
-
-
-        sender_priv, sender_pub, sender_id = _make_identity()
-
-        _, target_pub, target_id = _make_identity()
-
-        _register(sender_pub)
-
-        _register(target_pub)
-
-
-
-        # 1) Live targeted delivery: target online, capture the new_task data.
-
-        live_ws = _FakeWebSocket()
-
-        main.connected_nodes[target_id] = live_ws
-
-        try:
-
-            live_resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="same body")
-
-        finally:
-
-            main.connected_nodes.pop(target_id, None)
-
-        self.assertEqual(live_resp.json()["status"], "success")
-
-        live_data = live_ws.sent[0]["data"]
-
-
-
-        # 2) Queued delivery: target offline -> queue -> reconnect -> flush.
-
-        main.connected_nodes.pop(target_id, None)
-
-        queued_resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="same body")
-
-        self.assertEqual(queued_resp.json()["status"], "queued")
-
-        flush_ws = _FakeWebSocket()
-
-        asyncio.run(main._flush_queued_dms(target_id, flush_ws))
-
-        self.assertEqual(len(flush_ws.sent), 1)
-
-        flushed_data = flush_ws.sent[0]["data"]
-
-
-
-        # Core contract fields must be identical (task_id differs per submit).
-
-        for field in (
-
-            "consumer_id", "payload", "bounty", "status", "provider_id",
-
-            "source", "intent", "task", "economics", "target_node",
-
-            "model_requirement", "payload_uri",
-
-        ):
-
-            self.assertEqual(
-
-                flushed_data.get(field), live_data.get(field),
-
-                f"queued-flush field '{field}' diverged from live targeted delivery",
-
-            )
-
-        # source.node_id (used for reply routing) must survive store-and-forward.
-
-        self.assertEqual(flushed_data["source"]["node_id"], sender_id)
-
-        self.assertEqual(flushed_data["task"]["expected_output"], live_data["task"]["expected_output"])
-
+    def test_queued_dm_flush_matches_live_targeted_shape(self):
+        """A queued DM must be flushed with the same new_task event contract as a
+        live targeted delivery, so offline recipients are not handed a thinner
+        payload (regression guard for the store-and-forward shape mismatch)."""
+        import asyncio
+
+        sender_priv, sender_pub, sender_id = _make_identity()
+        _, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+
+        # 1) Live targeted delivery: target online, capture the new_task data.
+        live_ws = _FakeWebSocket()
+        main.connected_nodes[target_id] = live_ws
+        try:
+            live_resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="same body")
+        finally:
+            main.connected_nodes.pop(target_id, None)
+        self.assertEqual(live_resp.json()["status"], "success")
+        live_data = live_ws.sent[0]["data"]
+
+        # 2) Queued delivery: target offline -> queue -> reconnect -> flush.
+        main.connected_nodes.pop(target_id, None)
+        queued_resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="same body")
+        self.assertEqual(queued_resp.json()["status"], "queued")
+        flush_ws = _FakeWebSocket()
+        asyncio.run(main._flush_queued_dms(target_id, flush_ws))
+        self.assertEqual(len(flush_ws.sent), 1)
+        flushed_data = flush_ws.sent[0]["data"]
+
+        # Core contract fields must be identical (task_id differs per submit).
+        for field in (
+            "consumer_id", "payload", "bounty", "status", "provider_id",
+            "source", "intent", "task", "economics", "target_node",
+            "model_requirement", "payload_uri",
+        ):
+            self.assertEqual(
+                flushed_data.get(field), live_data.get(field),
+                f"queued-flush field '{field}' diverged from live targeted delivery",
+            )
+        # source.node_id (used for reply routing) must survive store-and-forward.
+        self.assertEqual(flushed_data["source"]["node_id"], sender_id)
+        self.assertEqual(flushed_data["task"]["expected_output"], live_data["task"]["expected_output"])
 
     def test_queued_dm_flush_preserves_structured_task_metadata(self):
         import asyncio
@@ -1810,2056 +1072,1030 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(flushed_data["task"]["inputs"]["repo_audit"]["audit_type"], "architecture_audit")
         self.assertEqual(flushed_data["task"]["expected_output"]["result_type"], "repo_audit_result")
         self.assertEqual(flushed_data["model_requirement"], "repo_audit")
-
-
-    def test_dm_queue_full_rejected(self):
-
-        sender_priv, sender_pub, sender_id = _make_identity()
-
-        _, target_pub, target_id = _make_identity()
-
-        _register(sender_pub)
-
-        _register(target_pub)
-
-        main.connected_nodes.pop(target_id, None)
-
-
-
-        original_cap = main.MAX_QUEUED_DMS_PER_NODE
-
-        main.MAX_QUEUED_DMS_PER_NODE = 1
-
-        try:
-
-            first = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="dm one")
-
-            self.assertEqual(first.json()["status"], "queued")
-
-            second = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="dm two")
-
-            self.assertEqual(second.json()["status"], "error")
-
-            self.assertIn("queue is full", second.json()["detail"])
-
-        finally:
-
-            main.MAX_QUEUED_DMS_PER_NODE = original_cap
-
-
-
-    def test_targeted_dm_to_offline_node_errors_when_queue_disabled(self):
-
-        sender_priv, sender_pub, sender_id = _make_identity()
-
-        _, target_pub, target_id = _make_identity()
-
-        _register(sender_pub)
-
-        _register(target_pub)
-
-        main.connected_nodes.pop(target_id, None)
-
-
-
-        original = main.DM_QUEUE_ENABLED
-
-        main.DM_QUEUE_ENABLED = False
-
-        try:
-
-            resp = self._submit_offline_dm(sender_priv, sender_id, target_id)
-
-            self.assertEqual(resp.status_code, 200)
-
-            self.assertEqual(resp.json()["status"], "error")
-
-            self.assertIn("not currently connected", resp.json()["detail"])
-
-        finally:
-
-            main.DM_QUEUE_ENABLED = original
-
-
-
-    def test_data_market_requires_secret_data(self):
-
-        seller_priv, seller_pub, seller_id = _make_identity()
-
-        _register(seller_pub)
-
-
-
-        task_payload = json.dumps(
-
-            {
-
-                "source": {"node_id": seller_id},
-
-                "intent": {"type": "conformance.request"},
-
-                "task": {
-
-                    "instructions": "premium dataset",
-
-                    "expected_output": {"result_type": "text"},
-
-                },
-
-                "economics": {
-
-                    "bounty_ns": 500_000_000,
-
-                    "currency": "MEP_NS",
-
-                    "market": "data",
-
-                    "payment_direction": "receiver_to_sender",
-
-                },
-
-            }
-
-        )
-
-        headers = _auth_headers(seller_priv, seller_id, task_payload)
-
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-
-
-        self.assertEqual(resp.status_code, 400)
-
-        self.assertIn("require secret_data", resp.json()["detail"])
-
-
-
-
-
-class TestInterBotSpecValidation(unittest.TestCase):
-
-    def test_rejects_invalid_structured_payload_when_enabled(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        _register(consumer_pub)
-
-        invalid_payload = json.dumps(
-
-            {
-
-                "consumer_id": consumer_id,
-
-                "payload": json.dumps({"spec_version": "mep.interbot.v1"}),
-
-                "bounty": 0.0,
-
-            }
-
-        )
-
-        headers = _auth_headers(consumer_priv, consumer_id, invalid_payload)
-
-        with _interbot_validation(True):
-
-            resp = client.post("/tasks/submit", content=invalid_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 400)
-
-        self.assertIn("Inter-bot payload", resp.json()["detail"])
-
-
-
-    def test_accepts_valid_structured_dm_payload_when_enabled(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        _, target_pub, target_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(target_pub)
-
-        message = {
-
-            "spec_version": "mep.interbot.v1",
-
-            "message_id": "msg-123",
-
-            "timestamp_ms": int(time.time() * 1000),
-
-            "source": {"node_id": consumer_id, "alias": "consumer"},
-
-            "target": {"node_id": target_id, "alias": "target"},
-
-            "intent": {"type": "chat.request"},
-
-            "task": {"instructions": "hello", "expected_output": {"result_type": "text"}},
-
-            "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
-
-        }
-
-        task_payload = json.dumps(
-
-            {
-
-                "consumer_id": consumer_id,
-
-                "payload": json.dumps(message),
-
-                "bounty": 0.0,
-
-                "target_node": target_id,
-
-            }
-
-        )
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        with _interbot_validation(True):
-
-            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200)
-
-        self.assertIn(resp.json()["status"], ("success", "error", "queued"))
-
-
-
-    def test_rejects_legacy_plaintext_non_dm_when_enabled(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        _register(consumer_pub)
-
-        task_payload = json.dumps(
-
-            {
-
-                "consumer_id": consumer_id,
-
-                "payload": "legacy plaintext non-dm",
-
-                "bounty": 1.0,
-
-            }
-
-        )
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        with _interbot_validation(True):
-
-            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 400)
-
-        self.assertIn("Legacy plaintext payload", resp.json()["detail"])
-
-
-
-    def test_spec_shaped_task_bounty_ns_is_converted_to_seconds(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        _register(consumer_pub)
-
-
-
-        resp = client.get(f"/balance/{consumer_id}")
-
-        initial_balance = resp.json()["balance_seconds"]
-
-
-
-        task_payload = json.dumps(
-
-            {
-
-                "source": {"node_id": consumer_id},
-
-                "intent": {"type": "analysis.request"},
-
-                "task": {
-
-                    "instructions": "spec-shaped compute task",
-
-                    "expected_output": {"result_type": "text"},
-
-                },
-
-                "economics": {
-
-                    "bounty_ns": 1_000_000_000,
-
-                    "currency": "MEP_NS",
-
-                    "market": "compute",
-
-                    "payment_direction": "sender_to_receiver",
-
-                },
-
-                "routing": {"target_capability": "text"},
-
-            }
-
-        )
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        with _interbot_validation(True):
-
-            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-
-
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-
-        task_id = resp.json()["task_id"]
-
-        stored_task = db.get_task(task_id)
-
-        self.assertEqual(stored_task["bounty"], 1.0)
-
-
-
-        resp = client.get(f"/balance/{consumer_id}")
-
-        self.assertEqual(resp.json()["balance_seconds"], initial_balance - 1.0)
-
-
-
-    def test_rejects_obsolete_bounty_quanta_name(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        _register(consumer_pub)
-
-
-
-        task_payload = json.dumps(
-
-            {
-
-                "source": {"node_id": consumer_id},
-
-                "task": {
-
-                    "instructions": "obsolete unit name",
-
-                    "expected_output": {"result_type": "text"},
-
-                },
-
-                "economics": {
-
-                    "bounty_quanta": 1_000_000_000,
-
-                    "currency": "MEP_QUANTA",
-
-                    "market": "compute",
-
-                    "payment_direction": "sender_to_receiver",
-
-                },
-
-            }
-
-        )
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        with _interbot_validation(True):
-
-            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-
-
-        self.assertEqual(resp.status_code, 400)
-
-        self.assertIn("MEP_NS", resp.json()["detail"])
-
-
-
-
-
-class TestAuthRejection(unittest.TestCase):
-
-
-
-    def test_invalid_signature_rejected(self):
-
-        priv, pub_pem, node_id = _make_identity()
-
-        _register(pub_pem)
-
-
-
-        payload = json.dumps({"consumer_id": node_id, "payload": "x", "bounty": 0.1})
-
-        headers = {
-
-            "X-MEP-NodeID": node_id,
-
-            "X-MEP-Timestamp": str(int(time.time())),
-
-            "X-MEP-Signature": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-
-            "Content-Type": "application/json",
-
-        }
-
-        resp = client.post("/tasks/submit", content=payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 401)
-
-
-
-    def test_unregistered_node_rejected(self):
-
-        priv, _, node_id = _make_identity()
-
-        # Don't register
-
-        payload = json.dumps({"consumer_id": node_id, "payload": "x", "bounty": 0.1})
-
-        headers = _auth_headers(priv, node_id, payload)
-
-        resp = client.post("/tasks/submit", content=payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 401)
-
-
-
-
-
-class TestDiagnosticEndpoint(unittest.TestCase):
-
-
-
-    def test_public_diagnostic_for_registered_node(self):
-
-        priv, pub_pem, node_id = _make_identity()
-
-        _register(pub_pem)
-
-        # Ensure node exists in registry table so public diagnostic can resolve it.
-
-        update_payload = json.dumps({"alias": "diag-node"})
-
-        headers = _auth_headers(priv, node_id, update_payload)
-
-        update_resp = client.post("/registry/update", content=update_payload, headers=headers)
-
-        self.assertEqual(update_resp.status_code, 200, f"Registry update failed: {update_resp.text}")
-
-
-
-        resp = client.get(f"/diagnostic?node_id={node_id}")
-
-        self.assertEqual(resp.status_code, 200)
-
-        data = resp.json()
-
-        self.assertEqual(data["node_id"], node_id)
-
-        self.assertTrue(data["registered"])
-
-        self.assertIn("availability", data)
-
-        self.assertIn("last_heartbeat", data)
-
-
-
-    def test_authenticated_diagnostic_rejects_invalid_signature(self):
-
-        _, pub_pem, node_id = _make_identity()
-
-        _register(pub_pem)
-
-        bad_headers = {
-
-            "X-MEP-NodeID": node_id,
-
-            "X-MEP-Timestamp": str(int(time.time())),
-
-            "X-MEP-Signature": "invalid-signature",
-
-        }
-
-        resp = client.get("/diagnostic", headers=bad_headers)
-
-        self.assertEqual(resp.status_code, 401)
-
-
-
-    def test_authenticated_diagnostic_succeeds_with_valid_signature(self):
-
-        priv, pub_pem, node_id = _make_identity()
-
-        _register(pub_pem)
-
-        headers = _diagnostic_headers(priv, node_id)
-
-        resp = client.get("/diagnostic", headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Diagnostic failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["node_id"], node_id)
-
-        self.assertIn("ws_connected", data)
-
-        self.assertIn("last_ws_activity", data)
-
-        self.assertTrue(data["auth_ok"])
-
-
-
-    def test_registry_update_can_persist_x25519_public_key(self):
-
-        priv, pub_pem, node_id = _make_identity()
-
-        _register(pub_pem)
-
-        update_payload = json.dumps({"alias": "diag-node", "x25519_public_key": "updated-encpub"})
-
-        headers = _auth_headers(priv, node_id, update_payload)
-
-
-
-        update_resp = client.post("/registry/update", content=update_payload, headers=headers)
-
-        self.assertEqual(update_resp.status_code, 200, f"Registry update failed: {update_resp.text}")
-
-
-
-        registry = db.get_registry(node_id)
-
-        self.assertIsNotNone(registry)
-
-        self.assertEqual(registry["x25519_public_key"], "updated-encpub")
-
-
-
-
-
-class TestOnboardDiagnose(unittest.TestCase):
-
-    def setUp(self):
-
-        main.onboard_diagnosis_counts.clear()
-
-        main.onboard_diagnosis_total = 0
-
-
-
-    def test_detects_auth_401_signature_or_timestamp(self):
-
-        payload = {
-
-            "node_id": "node_test",
-
-            "auth_status": "401",
-
-            "registered": True,
-
-        }
-
-        resp = client.post("/onboard/diagnose", json=payload)
-
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["root_cause"], "auth_401_signature_or_timestamp")
-
-        self.assertEqual(data["severity"], "high")
-
-        self.assertGreaterEqual(data["telemetry"]["total_requests"], 1)
-
-
-
-    def test_detects_ghost_online_without_ws(self):
-
-        payload = {
-
-            "node_id": "node_test",
-
-            "registered": True,
-
-            "ws_connected": False,
-
-            "heartbeat_seconds_ago": 15,
-
-            "auth_status": "ok",
-
-        }
-
-        resp = client.post("/onboard/diagnose", json=payload)
-
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["root_cause"], "ghost_online_no_ws_presence")
-
-        self.assertEqual(data["severity"], "high")
-
-
-
-    def test_returns_healthy_or_insufficient_signal_when_no_fault(self):
-
-        payload = {
-
-            "node_id": "node_test",
-
-            "registered": True,
-
-            "ws_connected": True,
-
-            "auth_status": "ok",
-
-            "dm_status": "ok",
-
-            "listener_contract_ok": True,
-
-            "ai_configured": True,
-
-        }
-
-        resp = client.post("/onboard/diagnose", json=payload)
-
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["root_cause"], "healthy_or_insufficient_signal")
-
-        self.assertEqual(data["severity"], "info")
-
-
-
-    def test_detects_auth_403_unregistered_or_policy(self):
-
-        payload = {
-
-            "node_id": "node_test",
-
-            "auth_status": "403",
-
-            "registered": False,
-
-        }
-
-        resp = client.post("/onboard/diagnose", json=payload)
-
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["root_cause"], "auth_403_unregistered_or_policy")
-
-        self.assertEqual(data["severity"], "high")
-
-
-
-    def test_detects_dm_pending_target_offline_or_route_issue(self):
-
-        payload = {
-
-            "node_id": "node_test",
-
-            "registered": True,
-
-            "ws_connected": True,
-
-            "auth_status": "ok",
-
-            "dm_status": "pending",
-
-        }
-
-        resp = client.post("/onboard/diagnose", json=payload)
-
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["root_cause"], "dm_pending_target_offline_or_route_issue")
-
-        self.assertEqual(data["severity"], "medium")
-
-
-
-    def test_detects_listener_payload_contract_mismatch(self):
-
-        payload = {
-
-            "node_id": "node_test",
-
-            "registered": True,
-
-            "ws_connected": True,
-
-            "auth_status": "ok",
-
-            "dm_status": "ok",
-
-            "listener_contract_ok": False,
-
-        }
-
-        resp = client.post("/onboard/diagnose", json=payload)
-
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["root_cause"], "listener_payload_contract_mismatch")
-
-        self.assertEqual(data["severity"], "medium")
-
-
-
-    def test_detects_heartbeat_interval_or_clock_drift(self):
-
-        payload = {
-
-            "node_id": "node_test",
-
-            "registered": True,
-
-            "ws_connected": True,
-
-            "auth_status": "ok",
-
-            "dm_status": "ok",
-
-            "listener_contract_ok": True,
-
-            "ai_configured": True,
-
-            "clock_skew_seconds": 400,
-
-        }
-
-        resp = client.post("/onboard/diagnose", json=payload)
-
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["root_cause"], "heartbeat_interval_or_clock_drift")
-
-        self.assertEqual(data["severity"], "medium")
-
-
-
-    def test_detects_ai_provider_config_invalid(self):
-
-        payload = {
-
-            "node_id": "node_test",
-
-            "registered": True,
-
-            "ws_connected": True,
-
-            "auth_status": "ok",
-
-            "dm_status": "ok",
-
-            "listener_contract_ok": True,
-
-            "ai_configured": False,
-
-        }
-
-        resp = client.post("/onboard/diagnose", json=payload)
-
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertEqual(data["root_cause"], "ai_provider_config_invalid")
-
-        self.assertEqual(data["severity"], "low")
-
-
-
-
-
-class TestRegistryHeartbeatPresence(unittest.TestCase):
-
-    def test_heartbeat_online_without_websocket_forces_offline(self):
-
-        node_priv, node_pub, node_id = _make_identity()
-
-        _register(node_pub)
-
-        heartbeat_payload = json.dumps({"availability": "online"})
-
-        headers = _auth_headers(node_priv, node_id, heartbeat_payload)
-
-        heartbeat_response = client.post("/registry/heartbeat", content=heartbeat_payload, headers=headers)
-
-        self.assertEqual(heartbeat_response.status_code, 200, f"Heartbeat failed: {heartbeat_response.text}")
-
-        self.assertEqual(heartbeat_response.json()["availability"], "offline")
-
-
-
-        registry_response = client.get(f"/registry/{node_id}")
-
-        self.assertEqual(registry_response.status_code, 200, f"Registry read failed: {registry_response.text}")
-
-        self.assertEqual(registry_response.json()["availability"], "offline")
-
-
-
-
-
-class TestMeshAssembly(unittest.TestCase):
-
-    def setUp(self):
-
-        conn = db._get_conn()
-
-        conn.execute("UPDATE agent_registry SET availability = 'offline'")
-
-        conn.commit()
-
-        db._release_conn(conn)
-
-        main.mesh_assemblies.clear()
-
-        main.connected_nodes.clear()
-
-
-
-    def _register_with_mesh_metadata(
-
-        self,
-
-        role: str,
-
-        *,
-
-        provider: str,
-
-        thinking_mode: str,
-
-        alias: str,
-
-        availability: str = "online",
-
-    ):
-
-        priv, pub, node_id = _make_identity()
-
-        _register(pub)
-
-        # Mesh role selection treats websocket presence as source of truth.
-
-        main.connected_nodes[node_id] = object()
-
-        update_payload = json.dumps(
-
-            {
-
-                "alias": alias,
-
-                "availability": availability,
-
-                "metadata": {
-
-                    "ai_provider": provider,
-
-                    "ai_status": "online",
-
-                    "thinking_mode": thinking_mode,
-
-                    "mesh_role_preference": role,
-
-                },
-
-            }
-
-        )
-
-        headers = _auth_headers(priv, node_id, update_payload)
-
-        resp = client.post("/registry/update", content=update_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Registry update failed: {resp.text}")
-
-        return priv, node_id
-
-
-
-    def test_mesh_assemble_complete_with_four_roles(self):
-
-        requester_priv, requester_id = self._register_with_mesh_metadata(
-
-            "strategist",
-
-            provider="deepseek",
-
-            thinking_mode="reasoning",
-
-            alias="Hermes",
-
-        )
-
-        self._register_with_mesh_metadata(
-
-            "implementer",
-
-            provider="yunwu",
-
-            thinking_mode="code_reading",
-
-            alias="Alisa",
-
-        )
-
-        self._register_with_mesh_metadata(
-
-            "facilitator",
-
-            provider="template",
-
-            thinking_mode="aggregation",
-
-            alias="Hub-Sentinel",
-
-        )
-
-        self._register_with_mesh_metadata(
-
-            "scout",
-
-            provider="echo",
-
-            thinking_mode="ack_only",
-
-            alias="Moltbot",
-
-        )
-
-
-
-        payload = json.dumps({"trigger": "brainstorm", "timeout_seconds": 180})
-
-        headers = _auth_headers(requester_priv, requester_id, payload)
-
-        resp = client.post("/mesh/assemble", content=payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Assemble failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertTrue(data["complete"])
-
-        self.assertEqual(
-
-            set(data["roles"].keys()),
-
-            {"strategist", "implementer", "facilitator", "scout"},
-
-        )
-
-
-
-    def test_mesh_assemble_degraded_when_insufficient_nodes(self):
-
-        requester_priv, requester_id = self._register_with_mesh_metadata(
-
-            "strategist",
-
-            provider="deepseek",
-
-            thinking_mode="reasoning",
-
-            alias="Solo",
-
-        )
-
-        payload = json.dumps({"trigger": "incident"})
-
-        headers = _auth_headers(requester_priv, requester_id, payload)
-
-        resp = client.post("/mesh/assemble", content=payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Assemble failed: {resp.text}")
-
-        data = resp.json()
-
-        self.assertFalse(data["complete"])
-
-        self.assertIn("degraded_warning", data)
-
-        self.assertIn("strategist", data["roles"])
-
-
-
-    def test_mesh_status_reports_drop_and_reassignment(self):
-
-        requester_priv, requester_id = self._register_with_mesh_metadata(
-
-            "strategist",
-
-            provider="deepseek",
-
-            thinking_mode="reasoning",
-
-            alias="Hermes",
-
-        )
-
-        self._register_with_mesh_metadata(
-
-            "implementer",
-
-            provider="yunwu",
-
-            thinking_mode="code_reading",
-
-            alias="Alisa",
-
-        )
-
-        self._register_with_mesh_metadata(
-
-            "facilitator",
-
-            provider="template",
-
-            thinking_mode="aggregation",
-
-            alias="Hub-Sentinel",
-
-        )
-
-        self._register_with_mesh_metadata(
-
-            "scout",
-
-            provider="echo",
-
-            thinking_mode="ack_only",
-
-            alias="Moltbot",
-
-        )
-
-        self._register_with_mesh_metadata(
-
-            "scout",
-
-            provider="echo",
-
-            thinking_mode="ack_only",
-
-            alias="Backup-Scout",
-
-        )
-
-
-
-        assemble_payload = json.dumps({"trigger": "planning"})
-
-        assemble_headers = _auth_headers(requester_priv, requester_id, assemble_payload)
-
-        assemble_resp = client.post("/mesh/assemble", content=assemble_payload, headers=assemble_headers)
-
-        self.assertEqual(assemble_resp.status_code, 200, f"Assemble failed: {assemble_resp.text}")
-
-        assembly = assemble_resp.json()
-
-        scout_node_id = assembly["roles"]["scout"]["node_id"]
-
-        db.update_registry_availability(scout_node_id, "offline", time.time())
-
-
-
-        status_headers = _auth_headers(requester_priv, requester_id, "")
-
-        status_resp = client.get(
-
-            f"/mesh/status?assembly_id={assembly['assembly_id']}",
-
-            headers=status_headers,
-
-        )
-
-        self.assertEqual(status_resp.status_code, 200, f"Status failed: {status_resp.text}")
-
-        status_data = status_resp.json()
-
-        self.assertFalse(status_data["complete"])
-
-        self.assertIn("scout", status_data["dropped_roles"])
-
-        self.assertIn("scout", status_data["reassignment_suggestions"])
-
-        self.assertNotEqual(
-
-            status_data["reassignment_suggestions"]["scout"]["node_id"],
-
-            scout_node_id,
-
-        )
-
-
-
-
-
-class TestBrainstormSessions(unittest.TestCase):
-
-    def setUp(self):
-
-        main.brainstorm_sessions.clear()
-
-
-
-    def test_create_post_and_read_session(self):
-
-        owner_priv, owner_pub, owner_id = _make_identity()
-
-        p1_priv, p1_pub, p1_id = _make_identity()
-
-        p2_priv, p2_pub, p2_id = _make_identity()
-
-        _register(owner_pub)
-
-        _register(p1_pub)
-
-        _register(p2_pub)
-
-
-
-        create_payload = json.dumps(
-
-            {
-
-                "owner_id": owner_id,
-
-                "participants": [p1_id, p2_id],
-
-                "topic": "Loop-free architecture",
-
-            }
-
-        )
-
-        create_headers = _auth_headers(owner_priv, owner_id, create_payload)
-
-        create_resp = client.post("/brainstorm/sessions/create", content=create_payload, headers=create_headers)
-
-        self.assertEqual(create_resp.status_code, 200, f"Create failed: {create_resp.text}")
-
-        session_id = create_resp.json()["session_id"]
-
-
-
-        post_payload = json.dumps(
-
-            {
-
-                "session_id": session_id,
-
-                "message": "I suggest we add a shared session timeline.",
-
-            }
-
-        )
-
-        post_headers = _auth_headers(p1_priv, p1_id, post_payload)
-
-        post_resp = client.post("/brainstorm/sessions/post", content=post_payload, headers=post_headers)
-
-        self.assertEqual(post_resp.status_code, 200, f"Post failed: {post_resp.text}")
-
-
-
-        get_headers = _auth_headers(p2_priv, p2_id, "")
-
-        get_resp = client.get(f"/brainstorm/sessions/{session_id}", headers=get_headers)
-
-        self.assertEqual(get_resp.status_code, 200, f"Get failed: {get_resp.text}")
-
-        data = get_resp.json()
-
-        self.assertEqual(data["topic"], "Loop-free architecture")
-
-        self.assertEqual(data["message_count"], 1)
-
-        self.assertEqual(data["messages"][0]["sender_id"], p1_id)
-
-
-
-    def test_non_participant_cannot_post(self):
-
-        owner_priv, owner_pub, owner_id = _make_identity()
-
-        p1_priv, p1_pub, p1_id = _make_identity()
-
-        outsider_priv, outsider_pub, outsider_id = _make_identity()
-
-        _register(owner_pub)
-
-        _register(p1_pub)
-
-        _register(outsider_pub)
-
-
-
-        create_payload = json.dumps({"owner_id": owner_id, "participants": [p1_id]})
-
-        create_headers = _auth_headers(owner_priv, owner_id, create_payload)
-
-        create_resp = client.post("/brainstorm/sessions/create", content=create_payload, headers=create_headers)
-
-        self.assertEqual(create_resp.status_code, 200)
-
-        session_id = create_resp.json()["session_id"]
-
-
-
-        post_payload = json.dumps({"session_id": session_id, "message": "Intruding message"})
-
-        post_headers = _auth_headers(outsider_priv, outsider_id, post_payload)
-
-        post_resp = client.post("/brainstorm/sessions/post", content=post_payload, headers=post_headers)
-
-        self.assertEqual(post_resp.status_code, 403)
-
-
-
-
-
-def tearDownModule():
-
-    """Clean up test database."""
-
-    try:
-
-        os.remove(_test_db)
-
-    except OSError:
-
-        pass
-
-
-
-class TestBiddingTimeout(unittest.TestCase):
-
-    """Test bidding task timeout + refund flow"""
-
-
-
-    def test_stale_bidding_task_expired_and_refunded(self):
-
-        """Verify stale bidding tasks are expired and bounty refunded to consumer"""
-
-        # Setup: consumer and provider
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        # Get initial balance
-
-        resp = client.get(f"/balance/{consumer_id}")
-
-        initial_balance = resp.json()["balance_seconds"]
-
-
-
-        # Submit task with bounty (escrow created)
-
-        bounty = 1.0
-
-        task_payload = json.dumps({
-
-            "consumer_id": consumer_id,
-
-            "payload": "Stale task that will timeout",
-
-            "bounty": bounty,
-
-        })
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-
-        task_id = resp.json()["task_id"]
-
-
-
-        # Verify balance is escrowed (reduced by bounty)
-
-        resp = client.get(f"/balance/{consumer_id}")
-
-        self.assertLess(resp.json()["balance_seconds"], initial_balance,
-
-                       "Consumer balance should decrease by bounty")
-
-
-
-        # Simulate task aging: directly update task's updated_at in DB to be old
-
-        # (In real system, timeout worker does this after ASSIGNMENT_TIMEOUT_SECONDS)
-
-        import time as t
-
-        old_time = t.time() - 7200  # 2 hours ago (well beyond 1 hour timeout)
-
-        conn = db._get_conn()
-
-        conn.execute(
-
-            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
-
-            (old_time, task_id)
-
-        )
-
-        conn.commit()
-
-        db._release_conn(conn)
-
-
-
-        # Run the bidding timeout sweep
-
-        import asyncio
-
-        from main import _sweep_bidding_timeouts
-
-        loop = asyncio.new_event_loop()
-
-        try:
-
-            loop.run_until_complete(_sweep_bidding_timeouts())
-
-        finally:
-
-            loop.close()
-
-
-
-        # Verify task status from DB helper (not /tasks/{task_id}, which does not exist)
-
-        task = db.get_task(task_id)
-
-        self.assertIsNotNone(task)
-
-        self.assertEqual(task["status"], "expired", "Task should be expired after timeout")
-
-
-
-        # Verify consumer balance is restored (refunded)
-
-        resp = client.get(f"/balance/{consumer_id}")
-
-        self.assertEqual(resp.json()["balance_seconds"], initial_balance,
-
-                        "Consumer balance should be restored after refund")
-
-
-
-    def test_assigned_data_market_timeout_refunds_buyer_escrow(self):
-
-        seller_priv, seller_pub, seller_id = _make_identity()
-
-        buyer_priv, buyer_pub, buyer_id = _make_identity()
-
-        _register(seller_pub)
-
-        _register(buyer_pub)
-
-
-
-        seller_before = client.get(f"/balance/{seller_id}").json()["balance_seconds"]
-
-        buyer_before = client.get(f"/balance/{buyer_id}").json()["balance_seconds"]
-
-        task_payload = json.dumps(
-
-            {
-
-                "consumer_id": seller_id,
-
-                "payload": "Premium dataset",
-
-                "bounty": -0.5,
-
-                "secret_data": "encrypted-premium-data",
-
-            }
-
-        )
-
-        headers = _auth_headers(seller_priv, seller_id, task_payload)
-
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-
-        task_id = resp.json()["task_id"]
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": buyer_id})
-
-        headers = _auth_headers(buyer_priv, buyer_id, bid_payload)
-
-        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Bid failed: {resp.text}")
-
-        self.assertEqual(resp.json()["status"], "accepted")
-
-        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
-
-
-
-        old_time = time.time() - 7200
-
-        conn = db._get_conn()
-
-        conn.execute(
-
-            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
-
-            (old_time, task_id)
-
-        )
-
-        conn.commit()
-
-        db._release_conn(conn)
-
-
-
-        import asyncio
-
-        from main import _sweep_assigned_timeouts
-
-        loop = asyncio.new_event_loop()
-
-        try:
-
-            loop.run_until_complete(_sweep_assigned_timeouts())
-
-        finally:
-
-            loop.close()
-
-
-
-        task = db.get_task(task_id)
-
-        self.assertEqual(task["status"], "expired")
-
-        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before)
-
-        self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before)
-
-
-
-    def test_rebroadcast_limit_expires_after_max_rebroadcasts(self):
-
-        """When TIMEOUT_POLICY=rebroadcast, task should requeue up to MAX_REBROADCAST_COUNT then expire and refund."""
-
-        old_policy = main.TIMEOUT_POLICY
-
-        old_max = main.MAX_REBROADCAST_COUNT
-
-        main.TIMEOUT_POLICY = "rebroadcast"
-
-        main.MAX_REBROADCAST_COUNT = 2
-
-        try:
-
-            consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-            provider_priv, provider_pub, provider_id = _make_identity()
-
-            _register(consumer_pub)
-
-            _register(provider_pub)
-
-
-
-            consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
-
-
-
-            task_payload = json.dumps({"consumer_id": consumer_id, "payload": "rebroadcast me", "bounty": 1.0})
-
-            headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-            submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-            self.assertEqual(submit.status_code, 200, submit.text)
-
-            task_id = submit.json()["task_id"]
-
-
-
-            bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-            headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-            self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-            self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
-
-
-
-            import asyncio
-
-            from main import _sweep_assigned_timeouts
-
-
-
-            for i in range(3):
-
-                old_time = time.time() - 7200
-
-                conn = db._get_conn()
-
-                conn.execute("UPDATE tasks SET updated_at = ? WHERE task_id = ?", (old_time, task_id))
-
-                conn.commit()
-
-                db._release_conn(conn)
-
-
-
-                loop = asyncio.new_event_loop()
-
-                try:
-
-                    loop.run_until_complete(_sweep_assigned_timeouts())
-
-                finally:
-
-                    loop.close()
-
-
-
-                task = db.get_task(task_id)
-
-                if i < 2:
-
-                    self.assertEqual(task["status"], "bidding", f"Expected bidding after requeue {i+1}, got {task['status']}")
-
-                    self.assertEqual(task.get("rebroadcast_count", 0), i + 1)
-
-                    # Re-bid so next sweep can requeue again
-
-                    bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-                    headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-                    self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-                else:
-
-                    self.assertEqual(task["status"], "expired", f"Expected expired after hitting limit on iteration {i+1}, got {task['status']}")
-
-                    self.assertEqual(task.get("rebroadcast_count", 0), 2)
-
-
-
-            self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
-
-        finally:
-
-            main.TIMEOUT_POLICY = old_policy
-
-            main.MAX_REBROADCAST_COUNT = old_max
-
-
-
-class TestConsumerDefinedTimeout(unittest.TestCase):
-
-    """Per-task consumer timeout should override global default within bounds."""
-
-
-
-    def test_consumer_timeout_expires_task_earlier(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        _register(consumer_pub)
-
-
-
-        resp = client.get(f"/balance/{consumer_id}")
-
-        initial_balance = resp.json()["balance_seconds"]
-
-
-
-        bounty = 1.0
-
-        task_payload = json.dumps({
-
-            "consumer_id": consumer_id,
-
-            "payload": "Expire me quickly",
-
-            "bounty": bounty,
-
-            "expires_in_seconds": 60,
-
-        })
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-
-        task_id = resp.json()["task_id"]
-
-
-
-        # This is older than the consumer timeout (60s) but younger than global default (3600s).
-
-        old_time = time.time() - 120
-
-        conn = db._get_conn()
-
-        conn.execute(
-
-            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
-
-            (old_time, task_id)
-
-        )
-
-        conn.commit()
-
-        db._release_conn(conn)
-
-
-
-        import asyncio
-
-        from main import _sweep_bidding_timeouts
-
-        loop = asyncio.new_event_loop()
-
-        try:
-
-            loop.run_until_complete(_sweep_bidding_timeouts())
-
-        finally:
-
-            loop.close()
-
-
-
-        task = db.get_task(task_id)
-
-        self.assertIsNotNone(task)
-
-        self.assertEqual(task["status"], "expired")
-
-
-
-        resp = client.get(f"/balance/{consumer_id}")
-
-        self.assertEqual(resp.json()["balance_seconds"], initial_balance)
-
-
-
-
-
-if __name__ == "__main__":
-
-    unittest.main()
-
-
-
-
-
-
-
-class TestAutomatedVerifier(unittest.TestCase):
-
-
-
-    """Test lean automated verifier prototype."""
-
-
-
-
-
-
-
-    def test_automated_verifier_accepts_valid_json_result(self):
-
-
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-
-
-        _register(consumer_pub)
-
-
-
-        _register(provider_pub)
-
-
-
-
-
-
-
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
-
-
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-
-
-        self.assertEqual(submit.status_code, 200, submit.text)
-
-
-
-        task_id = submit.json()["task_id"]
-
-
-
-
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-
-
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-
-
-
-
-
-
-        result_payload = json.dumps({"result": "success"})
-
-
-
-        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
-
-
-
-        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
-
-
-
-        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
-
-
-
-        self.assertEqual(complete.status_code, 200, complete.text)
-
-
-
-
-
-
-
-        # Admin triggers automated verification
-
-
-
-        verify_payload = json.dumps({"task_id": task_id})
-
-
-
-        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
-
-
-
-        self.assertEqual(verify_resp.status_code, 200, f"Verify failed: {verify_resp.text}")
-
-
-
-        result = verify_resp.json()
-
-
-
-        self.assertEqual(result["status"], "verified")
-
-
-
-        self.assertEqual(result["task_id"], task_id)
-
-
-
-
-
-
-
-        # Task should be completed
-
-
-
-        task = db.get_task(task_id)
-
-
-
-        self.assertEqual(task["status"], "completed")
-
-
-
-
-
-
-
-    def test_automated_verifier_rejects_invalid_json(self):
-
-
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-
-
-        _register(consumer_pub)
-
-
-
-        _register(provider_pub)
-
-
-
-
-
-
-
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
-
-
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-
-
-        self.assertEqual(submit.status_code, 200, submit.text)
-
-
-
-        task_id = submit.json()["task_id"]
-
-
-
-
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-
-
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-
-
-
-
-
-
-        result_payload = "not valid json"
-
-
-
-        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
-
-
-
-        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
-
-
-
-        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
-
-
-
-        self.assertEqual(complete.status_code, 200, complete.text)
-
-
-
-
-
-
-
-        # Admin triggers automated verification
-
-
-
-        verify_payload = json.dumps({"task_id": task_id})
-
-
-
-        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
-
-
-
-        self.assertEqual(verify_resp.status_code, 400, f"Expected rejection: {verify_resp.text}")
-
-
-
-
-
-
-
-    def test_automated_verifier_rejects_empty_result(self):
-
-
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-
-
-        _register(consumer_pub)
-
-
-
-        _register(provider_pub)
-
-
-
-
-
-
-
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
-
-
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-
-
-        self.assertEqual(submit.status_code, 200, submit.text)
-
-
-
-        task_id = submit.json()["task_id"]
-
-
-
-
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-
-
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-
-
-
-
-
-
-        result_payload = "   "  # whitespace-only should be rejected
-
-
-
-        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
-
-
-
-        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
-
-
-
-        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
-
-
-
-        self.assertEqual(complete.status_code, 200, complete.text)
-
-
-
-
-
-
-
-        # Admin triggers automated verification
-
-
-
-        verify_payload = json.dumps({"task_id": task_id})
-
-
-
-        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
-
-
-
+
+    def test_dm_queue_full_rejected(self):
+        sender_priv, sender_pub, sender_id = _make_identity()
+        _, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+        main.connected_nodes.pop(target_id, None)
+
+        original_cap = main.MAX_QUEUED_DMS_PER_NODE
+        main.MAX_QUEUED_DMS_PER_NODE = 1
+        try:
+            first = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="dm one")
+            self.assertEqual(first.json()["status"], "queued")
+            second = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="dm two")
+            self.assertEqual(second.json()["status"], "error")
+            self.assertIn("queue is full", second.json()["detail"])
+        finally:
+            main.MAX_QUEUED_DMS_PER_NODE = original_cap
+
+    def test_targeted_dm_to_offline_node_errors_when_queue_disabled(self):
+        sender_priv, sender_pub, sender_id = _make_identity()
+        _, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+        main.connected_nodes.pop(target_id, None)
+
+        original = main.DM_QUEUE_ENABLED
+        main.DM_QUEUE_ENABLED = False
+        try:
+            resp = self._submit_offline_dm(sender_priv, sender_id, target_id)
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json()["status"], "error")
+            self.assertIn("not currently connected", resp.json()["detail"])
+        finally:
+            main.DM_QUEUE_ENABLED = original
+
+    def test_data_market_requires_secret_data(self):
+        seller_priv, seller_pub, seller_id = _make_identity()
+        _register(seller_pub)
+
+        task_payload = json.dumps(
+            {
+                "source": {"node_id": seller_id},
+                "intent": {"type": "conformance.request"},
+                "task": {
+                    "instructions": "premium dataset",
+                    "expected_output": {"result_type": "text"},
+                },
+                "economics": {
+                    "bounty_ns": 500_000_000,
+                    "currency": "MEP_NS",
+                    "market": "data",
+                    "payment_direction": "receiver_to_sender",
+                },
+            }
+        )
+        headers = _auth_headers(seller_priv, seller_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("require secret_data", resp.json()["detail"])
+
+
+class TestInterBotSpecValidation(unittest.TestCase):
+    def test_rejects_invalid_structured_payload_when_enabled(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+        invalid_payload = json.dumps(
+            {
+                "consumer_id": consumer_id,
+                "payload": json.dumps({"spec_version": "mep.interbot.v1"}),
+                "bounty": 0.0,
+            }
+        )
+        headers = _auth_headers(consumer_priv, consumer_id, invalid_payload)
+        with _interbot_validation(True):
+            resp = client.post("/tasks/submit", content=invalid_payload, headers=headers)
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Inter-bot payload", resp.json()["detail"])
+
+    def test_accepts_valid_structured_dm_payload_when_enabled(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _, target_pub, target_id = _make_identity()
+        _register(consumer_pub)
+        _register(target_pub)
+        message = {
+            "spec_version": "mep.interbot.v1",
+            "message_id": "msg-123",
+            "timestamp_ms": int(time.time() * 1000),
+            "source": {"node_id": consumer_id, "alias": "consumer"},
+            "target": {"node_id": target_id, "alias": "target"},
+            "intent": {"type": "chat.request"},
+            "task": {"instructions": "hello", "expected_output": {"result_type": "text"}},
+            "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+        }
+        task_payload = json.dumps(
+            {
+                "consumer_id": consumer_id,
+                "payload": json.dumps(message),
+                "bounty": 0.0,
+                "target_node": target_id,
+            }
+        )
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        with _interbot_validation(True):
+            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.json()["status"], ("success", "error", "queued"))
+
+    def test_rejects_legacy_plaintext_non_dm_when_enabled(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+        task_payload = json.dumps(
+            {
+                "consumer_id": consumer_id,
+                "payload": "legacy plaintext non-dm",
+                "bounty": 1.0,
+            }
+        )
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        with _interbot_validation(True):
+            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Legacy plaintext payload", resp.json()["detail"])
+
+    def test_spec_shaped_task_bounty_ns_is_converted_to_seconds(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+
+        resp = client.get(f"/balance/{consumer_id}")
+        initial_balance = resp.json()["balance_seconds"]
+
+        task_payload = json.dumps(
+            {
+                "source": {"node_id": consumer_id},
+                "intent": {"type": "analysis.request"},
+                "task": {
+                    "instructions": "spec-shaped compute task",
+                    "expected_output": {"result_type": "text"},
+                },
+                "economics": {
+                    "bounty_ns": 1_000_000_000,
+                    "currency": "MEP_NS",
+                    "market": "compute",
+                    "payment_direction": "sender_to_receiver",
+                },
+                "routing": {"target_capability": "text"},
+            }
+        )
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        with _interbot_validation(True):
+            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+        task_id = resp.json()["task_id"]
+        stored_task = db.get_task(task_id)
+        self.assertEqual(stored_task["bounty"], 1.0)
+
+        resp = client.get(f"/balance/{consumer_id}")
+        self.assertEqual(resp.json()["balance_seconds"], initial_balance - 1.0)
+
+    def test_rejects_obsolete_bounty_quanta_name(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+
+        task_payload = json.dumps(
+            {
+                "source": {"node_id": consumer_id},
+                "task": {
+                    "instructions": "obsolete unit name",
+                    "expected_output": {"result_type": "text"},
+                },
+                "economics": {
+                    "bounty_quanta": 1_000_000_000,
+                    "currency": "MEP_QUANTA",
+                    "market": "compute",
+                    "payment_direction": "sender_to_receiver",
+                },
+            }
+        )
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        with _interbot_validation(True):
+            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("MEP_NS", resp.json()["detail"])
+
+
+class TestAuthRejection(unittest.TestCase):
+
+    def test_invalid_signature_rejected(self):
+        priv, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+
+        payload = json.dumps({"consumer_id": node_id, "payload": "x", "bounty": 0.1})
+        headers = {
+            "X-MEP-NodeID": node_id,
+            "X-MEP-Timestamp": str(int(time.time())),
+            "X-MEP-Signature": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+            "Content-Type": "application/json",
+        }
+        resp = client.post("/tasks/submit", content=payload, headers=headers)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_unregistered_node_rejected(self):
+        priv, _, node_id = _make_identity()
+        # Don't register
+        payload = json.dumps({"consumer_id": node_id, "payload": "x", "bounty": 0.1})
+        headers = _auth_headers(priv, node_id, payload)
+        resp = client.post("/tasks/submit", content=payload, headers=headers)
+        self.assertEqual(resp.status_code, 401)
+
+
+class TestDiagnosticEndpoint(unittest.TestCase):
+
+    def test_public_diagnostic_for_registered_node(self):
+        priv, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+        # Ensure node exists in registry table so public diagnostic can resolve it.
+        update_payload = json.dumps({"alias": "diag-node"})
+        headers = _auth_headers(priv, node_id, update_payload)
+        update_resp = client.post("/registry/update", content=update_payload, headers=headers)
+        self.assertEqual(update_resp.status_code, 200, f"Registry update failed: {update_resp.text}")
+
+        resp = client.get(f"/diagnostic?node_id={node_id}")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["node_id"], node_id)
+        self.assertTrue(data["registered"])
+        self.assertIn("availability", data)
+        self.assertIn("last_heartbeat", data)
+
+    def test_authenticated_diagnostic_rejects_invalid_signature(self):
+        _, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+        bad_headers = {
+            "X-MEP-NodeID": node_id,
+            "X-MEP-Timestamp": str(int(time.time())),
+            "X-MEP-Signature": "invalid-signature",
+        }
+        resp = client.get("/diagnostic", headers=bad_headers)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_authenticated_diagnostic_succeeds_with_valid_signature(self):
+        priv, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+        headers = _diagnostic_headers(priv, node_id)
+        resp = client.get("/diagnostic", headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Diagnostic failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["node_id"], node_id)
+        self.assertIn("ws_connected", data)
+        self.assertIn("last_ws_activity", data)
+        self.assertTrue(data["auth_ok"])
+
+    def test_registry_update_can_persist_x25519_public_key(self):
+        priv, pub_pem, node_id = _make_identity()
+        _register(pub_pem)
+        update_payload = json.dumps({"alias": "diag-node", "x25519_public_key": "updated-encpub"})
+        headers = _auth_headers(priv, node_id, update_payload)
+
+        update_resp = client.post("/registry/update", content=update_payload, headers=headers)
+        self.assertEqual(update_resp.status_code, 200, f"Registry update failed: {update_resp.text}")
+
+        registry = db.get_registry(node_id)
+        self.assertIsNotNone(registry)
+        self.assertEqual(registry["x25519_public_key"], "updated-encpub")
+
+
+class TestOnboardDiagnose(unittest.TestCase):
+    def setUp(self):
+        main.onboard_diagnosis_counts.clear()
+        main.onboard_diagnosis_total = 0
+
+    def test_detects_auth_401_signature_or_timestamp(self):
+        payload = {
+            "node_id": "node_test",
+            "auth_status": "401",
+            "registered": True,
+        }
+        resp = client.post("/onboard/diagnose", json=payload)
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["root_cause"], "auth_401_signature_or_timestamp")
+        self.assertEqual(data["severity"], "high")
+        self.assertGreaterEqual(data["telemetry"]["total_requests"], 1)
+
+    def test_detects_ghost_online_without_ws(self):
+        payload = {
+            "node_id": "node_test",
+            "registered": True,
+            "ws_connected": False,
+            "heartbeat_seconds_ago": 15,
+            "auth_status": "ok",
+        }
+        resp = client.post("/onboard/diagnose", json=payload)
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["root_cause"], "ghost_online_no_ws_presence")
+        self.assertEqual(data["severity"], "high")
+
+    def test_returns_healthy_or_insufficient_signal_when_no_fault(self):
+        payload = {
+            "node_id": "node_test",
+            "registered": True,
+            "ws_connected": True,
+            "auth_status": "ok",
+            "dm_status": "ok",
+            "listener_contract_ok": True,
+            "ai_configured": True,
+        }
+        resp = client.post("/onboard/diagnose", json=payload)
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["root_cause"], "healthy_or_insufficient_signal")
+        self.assertEqual(data["severity"], "info")
+
+    def test_detects_auth_403_unregistered_or_policy(self):
+        payload = {
+            "node_id": "node_test",
+            "auth_status": "403",
+            "registered": False,
+        }
+        resp = client.post("/onboard/diagnose", json=payload)
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["root_cause"], "auth_403_unregistered_or_policy")
+        self.assertEqual(data["severity"], "high")
+
+    def test_detects_dm_pending_target_offline_or_route_issue(self):
+        payload = {
+            "node_id": "node_test",
+            "registered": True,
+            "ws_connected": True,
+            "auth_status": "ok",
+            "dm_status": "pending",
+        }
+        resp = client.post("/onboard/diagnose", json=payload)
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["root_cause"], "dm_pending_target_offline_or_route_issue")
+        self.assertEqual(data["severity"], "medium")
+
+    def test_detects_listener_payload_contract_mismatch(self):
+        payload = {
+            "node_id": "node_test",
+            "registered": True,
+            "ws_connected": True,
+            "auth_status": "ok",
+            "dm_status": "ok",
+            "listener_contract_ok": False,
+        }
+        resp = client.post("/onboard/diagnose", json=payload)
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["root_cause"], "listener_payload_contract_mismatch")
+        self.assertEqual(data["severity"], "medium")
+
+    def test_detects_heartbeat_interval_or_clock_drift(self):
+        payload = {
+            "node_id": "node_test",
+            "registered": True,
+            "ws_connected": True,
+            "auth_status": "ok",
+            "dm_status": "ok",
+            "listener_contract_ok": True,
+            "ai_configured": True,
+            "clock_skew_seconds": 400,
+        }
+        resp = client.post("/onboard/diagnose", json=payload)
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["root_cause"], "heartbeat_interval_or_clock_drift")
+        self.assertEqual(data["severity"], "medium")
+
+    def test_detects_ai_provider_config_invalid(self):
+        payload = {
+            "node_id": "node_test",
+            "registered": True,
+            "ws_connected": True,
+            "auth_status": "ok",
+            "dm_status": "ok",
+            "listener_contract_ok": True,
+            "ai_configured": False,
+        }
+        resp = client.post("/onboard/diagnose", json=payload)
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+        data = resp.json()
+        self.assertEqual(data["root_cause"], "ai_provider_config_invalid")
+        self.assertEqual(data["severity"], "low")
+
+
+class TestRegistryHeartbeatPresence(unittest.TestCase):
+    def test_heartbeat_online_without_websocket_forces_offline(self):
+        node_priv, node_pub, node_id = _make_identity()
+        _register(node_pub)
+        heartbeat_payload = json.dumps({"availability": "online"})
+        headers = _auth_headers(node_priv, node_id, heartbeat_payload)
+        heartbeat_response = client.post("/registry/heartbeat", content=heartbeat_payload, headers=headers)
+        self.assertEqual(heartbeat_response.status_code, 200, f"Heartbeat failed: {heartbeat_response.text}")
+        self.assertEqual(heartbeat_response.json()["availability"], "offline")
+
+        registry_response = client.get(f"/registry/{node_id}")
+        self.assertEqual(registry_response.status_code, 200, f"Registry read failed: {registry_response.text}")
+        self.assertEqual(registry_response.json()["availability"], "offline")
+
+
+class TestMeshAssembly(unittest.TestCase):
+    def setUp(self):
+        conn = db._get_conn()
+        conn.execute("UPDATE agent_registry SET availability = 'offline'")
+        conn.commit()
+        db._release_conn(conn)
+        main.mesh_assemblies.clear()
+        main.connected_nodes.clear()
+
+    def _register_with_mesh_metadata(
+        self,
+        role: str,
+        *,
+        provider: str,
+        thinking_mode: str,
+        alias: str,
+        availability: str = "online",
+    ):
+        priv, pub, node_id = _make_identity()
+        _register(pub)
+        # Mesh role selection treats websocket presence as source of truth.
+        main.connected_nodes[node_id] = object()
+        update_payload = json.dumps(
+            {
+                "alias": alias,
+                "availability": availability,
+                "metadata": {
+                    "ai_provider": provider,
+                    "ai_status": "online",
+                    "thinking_mode": thinking_mode,
+                    "mesh_role_preference": role,
+                },
+            }
+        )
+        headers = _auth_headers(priv, node_id, update_payload)
+        resp = client.post("/registry/update", content=update_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Registry update failed: {resp.text}")
+        return priv, node_id
+
+    def test_mesh_assemble_complete_with_four_roles(self):
+        requester_priv, requester_id = self._register_with_mesh_metadata(
+            "strategist",
+            provider="deepseek",
+            thinking_mode="reasoning",
+            alias="Hermes",
+        )
+        self._register_with_mesh_metadata(
+            "implementer",
+            provider="yunwu",
+            thinking_mode="code_reading",
+            alias="Alisa",
+        )
+        self._register_with_mesh_metadata(
+            "facilitator",
+            provider="template",
+            thinking_mode="aggregation",
+            alias="Hub-Sentinel",
+        )
+        self._register_with_mesh_metadata(
+            "scout",
+            provider="echo",
+            thinking_mode="ack_only",
+            alias="Moltbot",
+        )
+
+        payload = json.dumps({"trigger": "brainstorm", "timeout_seconds": 180})
+        headers = _auth_headers(requester_priv, requester_id, payload)
+        resp = client.post("/mesh/assemble", content=payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Assemble failed: {resp.text}")
+        data = resp.json()
+        self.assertTrue(data["complete"])
+        self.assertEqual(
+            set(data["roles"].keys()),
+            {"strategist", "implementer", "facilitator", "scout"},
+        )
+
+    def test_mesh_assemble_degraded_when_insufficient_nodes(self):
+        requester_priv, requester_id = self._register_with_mesh_metadata(
+            "strategist",
+            provider="deepseek",
+            thinking_mode="reasoning",
+            alias="Solo",
+        )
+        payload = json.dumps({"trigger": "incident"})
+        headers = _auth_headers(requester_priv, requester_id, payload)
+        resp = client.post("/mesh/assemble", content=payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Assemble failed: {resp.text}")
+        data = resp.json()
+        self.assertFalse(data["complete"])
+        self.assertIn("degraded_warning", data)
+        self.assertIn("strategist", data["roles"])
+
+    def test_mesh_status_reports_drop_and_reassignment(self):
+        requester_priv, requester_id = self._register_with_mesh_metadata(
+            "strategist",
+            provider="deepseek",
+            thinking_mode="reasoning",
+            alias="Hermes",
+        )
+        self._register_with_mesh_metadata(
+            "implementer",
+            provider="yunwu",
+            thinking_mode="code_reading",
+            alias="Alisa",
+        )
+        self._register_with_mesh_metadata(
+            "facilitator",
+            provider="template",
+            thinking_mode="aggregation",
+            alias="Hub-Sentinel",
+        )
+        self._register_with_mesh_metadata(
+            "scout",
+            provider="echo",
+            thinking_mode="ack_only",
+            alias="Moltbot",
+        )
+        self._register_with_mesh_metadata(
+            "scout",
+            provider="echo",
+            thinking_mode="ack_only",
+            alias="Backup-Scout",
+        )
+
+        assemble_payload = json.dumps({"trigger": "planning"})
+        assemble_headers = _auth_headers(requester_priv, requester_id, assemble_payload)
+        assemble_resp = client.post("/mesh/assemble", content=assemble_payload, headers=assemble_headers)
+        self.assertEqual(assemble_resp.status_code, 200, f"Assemble failed: {assemble_resp.text}")
+        assembly = assemble_resp.json()
+        scout_node_id = assembly["roles"]["scout"]["node_id"]
+        db.update_registry_availability(scout_node_id, "offline", time.time())
+
+        status_headers = _auth_headers(requester_priv, requester_id, "")
+        status_resp = client.get(
+            f"/mesh/status?assembly_id={assembly['assembly_id']}",
+            headers=status_headers,
+        )
+        self.assertEqual(status_resp.status_code, 200, f"Status failed: {status_resp.text}")
+        status_data = status_resp.json()
+        self.assertFalse(status_data["complete"])
+        self.assertIn("scout", status_data["dropped_roles"])
+        self.assertIn("scout", status_data["reassignment_suggestions"])
+        self.assertNotEqual(
+            status_data["reassignment_suggestions"]["scout"]["node_id"],
+            scout_node_id,
+        )
+
+
+class TestBrainstormSessions(unittest.TestCase):
+    def setUp(self):
+        main.brainstorm_sessions.clear()
+
+    def test_create_post_and_read_session(self):
+        owner_priv, owner_pub, owner_id = _make_identity()
+        p1_priv, p1_pub, p1_id = _make_identity()
+        p2_priv, p2_pub, p2_id = _make_identity()
+        _register(owner_pub)
+        _register(p1_pub)
+        _register(p2_pub)
+
+        create_payload = json.dumps(
+            {
+                "owner_id": owner_id,
+                "participants": [p1_id, p2_id],
+                "topic": "Loop-free architecture",
+            }
+        )
+        create_headers = _auth_headers(owner_priv, owner_id, create_payload)
+        create_resp = client.post("/brainstorm/sessions/create", content=create_payload, headers=create_headers)
+        self.assertEqual(create_resp.status_code, 200, f"Create failed: {create_resp.text}")
+        session_id = create_resp.json()["session_id"]
+
+        post_payload = json.dumps(
+            {
+                "session_id": session_id,
+                "message": "I suggest we add a shared session timeline.",
+            }
+        )
+        post_headers = _auth_headers(p1_priv, p1_id, post_payload)
+        post_resp = client.post("/brainstorm/sessions/post", content=post_payload, headers=post_headers)
+        self.assertEqual(post_resp.status_code, 200, f"Post failed: {post_resp.text}")
+
+        get_headers = _auth_headers(p2_priv, p2_id, "")
+        get_resp = client.get(f"/brainstorm/sessions/{session_id}", headers=get_headers)
+        self.assertEqual(get_resp.status_code, 200, f"Get failed: {get_resp.text}")
+        data = get_resp.json()
+        self.assertEqual(data["topic"], "Loop-free architecture")
+        self.assertEqual(data["message_count"], 1)
+        self.assertEqual(data["messages"][0]["sender_id"], p1_id)
+
+    def test_non_participant_cannot_post(self):
+        owner_priv, owner_pub, owner_id = _make_identity()
+        p1_priv, p1_pub, p1_id = _make_identity()
+        outsider_priv, outsider_pub, outsider_id = _make_identity()
+        _register(owner_pub)
+        _register(p1_pub)
+        _register(outsider_pub)
+
+        create_payload = json.dumps({"owner_id": owner_id, "participants": [p1_id]})
+        create_headers = _auth_headers(owner_priv, owner_id, create_payload)
+        create_resp = client.post("/brainstorm/sessions/create", content=create_payload, headers=create_headers)
+        self.assertEqual(create_resp.status_code, 200)
+        session_id = create_resp.json()["session_id"]
+
+        post_payload = json.dumps({"session_id": session_id, "message": "Intruding message"})
+        post_headers = _auth_headers(outsider_priv, outsider_id, post_payload)
+        post_resp = client.post("/brainstorm/sessions/post", content=post_payload, headers=post_headers)
+        self.assertEqual(post_resp.status_code, 403)
+
+
+def tearDownModule():
+    """Clean up test database."""
+    try:
+        os.remove(_test_db)
+    except OSError:
+        pass
+
+class TestBiddingTimeout(unittest.TestCase):
+    """Test bidding task timeout + refund flow"""
+
+    def test_stale_bidding_task_expired_and_refunded(self):
+        """Verify stale bidding tasks are expired and bounty refunded to consumer"""
+        # Setup: consumer and provider
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        provider_priv, provider_pub, provider_id = _make_identity()
+        _register(consumer_pub)
+        _register(provider_pub)
+
+        # Get initial balance
+        resp = client.get(f"/balance/{consumer_id}")
+        initial_balance = resp.json()["balance_seconds"]
+
+        # Submit task with bounty (escrow created)
+        bounty = 1.0
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "Stale task that will timeout",
+            "bounty": bounty,
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+        task_id = resp.json()["task_id"]
+
+        # Verify balance is escrowed (reduced by bounty)
+        resp = client.get(f"/balance/{consumer_id}")
+        self.assertLess(resp.json()["balance_seconds"], initial_balance,
+                       "Consumer balance should decrease by bounty")
+
+        # Simulate task aging: directly update task's updated_at in DB to be old
+        # (In real system, timeout worker does this after ASSIGNMENT_TIMEOUT_SECONDS)
+        import time as t
+        old_time = t.time() - 7200  # 2 hours ago (well beyond 1 hour timeout)
+        conn = db._get_conn()
+        conn.execute(
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+            (old_time, task_id)
+        )
+        conn.commit()
+        db._release_conn(conn)
+
+        # Run the bidding timeout sweep
+        import asyncio
+        from main import _sweep_bidding_timeouts
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(_sweep_bidding_timeouts())
+        finally:
+            loop.close()
+
+        # Verify task status from DB helper (not /tasks/{task_id}, which does not exist)
+        task = db.get_task(task_id)
+        self.assertIsNotNone(task)
+        self.assertEqual(task["status"], "expired", "Task should be expired after timeout")
+
+        # Verify consumer balance is restored (refunded)
+        resp = client.get(f"/balance/{consumer_id}")
+        self.assertEqual(resp.json()["balance_seconds"], initial_balance,
+                        "Consumer balance should be restored after refund")
+
+    def test_assigned_data_market_timeout_refunds_buyer_escrow(self):
+        seller_priv, seller_pub, seller_id = _make_identity()
+        buyer_priv, buyer_pub, buyer_id = _make_identity()
+        _register(seller_pub)
+        _register(buyer_pub)
+
+        seller_before = client.get(f"/balance/{seller_id}").json()["balance_seconds"]
+        buyer_before = client.get(f"/balance/{buyer_id}").json()["balance_seconds"]
+        task_payload = json.dumps(
+            {
+                "consumer_id": seller_id,
+                "payload": "Premium dataset",
+                "bounty": -0.5,
+                "secret_data": "encrypted-premium-data",
+            }
+        )
+        headers = _auth_headers(seller_priv, seller_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+        task_id = resp.json()["task_id"]
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": buyer_id})
+        headers = _auth_headers(buyer_priv, buyer_id, bid_payload)
+        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Bid failed: {resp.text}")
+        self.assertEqual(resp.json()["status"], "accepted")
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
+
+        old_time = time.time() - 7200
+        conn = db._get_conn()
+        conn.execute(
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+            (old_time, task_id)
+        )
+        conn.commit()
+        db._release_conn(conn)
+
+        import asyncio
+        from main import _sweep_assigned_timeouts
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(_sweep_assigned_timeouts())
+        finally:
+            loop.close()
+
+        task = db.get_task(task_id)
+        self.assertEqual(task["status"], "expired")
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before)
+        self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before)
+
+    def test_rebroadcast_limit_expires_after_max_rebroadcasts(self):
+        """When TIMEOUT_POLICY=rebroadcast, task should requeue up to MAX_REBROADCAST_COUNT then expire and refund."""
+        old_policy = main.TIMEOUT_POLICY
+        old_max = main.MAX_REBROADCAST_COUNT
+        main.TIMEOUT_POLICY = "rebroadcast"
+        main.MAX_REBROADCAST_COUNT = 2
+        try:
+            consumer_priv, consumer_pub, consumer_id = _make_identity()
+            provider_priv, provider_pub, provider_id = _make_identity()
+            _register(consumer_pub)
+            _register(provider_pub)
+
+            consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+
+            task_payload = json.dumps({"consumer_id": consumer_id, "payload": "rebroadcast me", "bounty": 1.0})
+            headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+            submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+            self.assertEqual(submit.status_code, 200, submit.text)
+            task_id = submit.json()["task_id"]
+
+            bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+            headers = _auth_headers(provider_priv, provider_id, bid_payload)
+            self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+            self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
+
+            import asyncio
+            from main import _sweep_assigned_timeouts
+
+            for i in range(3):
+                old_time = time.time() - 7200
+                conn = db._get_conn()
+                conn.execute("UPDATE tasks SET updated_at = ? WHERE task_id = ?", (old_time, task_id))
+                conn.commit()
+                db._release_conn(conn)
+
+                loop = asyncio.new_event_loop()
+                try:
+                    loop.run_until_complete(_sweep_assigned_timeouts())
+                finally:
+                    loop.close()
+
+                task = db.get_task(task_id)
+                if i < 2:
+                    self.assertEqual(task["status"], "bidding", f"Expected bidding after requeue {i+1}, got {task['status']}")
+                    self.assertEqual(task.get("rebroadcast_count", 0), i + 1)
+                    # Re-bid so next sweep can requeue again
+                    bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+                    headers = _auth_headers(provider_priv, provider_id, bid_payload)
+                    self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+                else:
+                    self.assertEqual(task["status"], "expired", f"Expected expired after hitting limit on iteration {i+1}, got {task['status']}")
+                    self.assertEqual(task.get("rebroadcast_count", 0), 2)
+
+            self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
+        finally:
+            main.TIMEOUT_POLICY = old_policy
+            main.MAX_REBROADCAST_COUNT = old_max
+
+class TestConsumerDefinedTimeout(unittest.TestCase):
+    """Per-task consumer timeout should override global default within bounds."""
+
+    def test_consumer_timeout_expires_task_earlier(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+
+        resp = client.get(f"/balance/{consumer_id}")
+        initial_balance = resp.json()["balance_seconds"]
+
+        bounty = 1.0
+        task_payload = json.dumps({
+            "consumer_id": consumer_id,
+            "payload": "Expire me quickly",
+            "bounty": bounty,
+            "expires_in_seconds": 60,
+        })
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+        task_id = resp.json()["task_id"]
+
+        # This is older than the consumer timeout (60s) but younger than global default (3600s).
+        old_time = time.time() - 120
+        conn = db._get_conn()
+        conn.execute(
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+            (old_time, task_id)
+        )
+        conn.commit()
+        db._release_conn(conn)
+
+        import asyncio
+        from main import _sweep_bidding_timeouts
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(_sweep_bidding_timeouts())
+        finally:
+            loop.close()
+
+        task = db.get_task(task_id)
+        self.assertIsNotNone(task)
+        self.assertEqual(task["status"], "expired")
+
+        resp = client.get(f"/balance/{consumer_id}")
+        self.assertEqual(resp.json()["balance_seconds"], initial_balance)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+
+class TestAutomatedVerifier(unittest.TestCase):
+
+    """Test lean automated verifier prototype."""
+
+
+
+    def test_automated_verifier_accepts_valid_json_result(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(submit.status_code, 200, submit.text)
+
+        task_id = submit.json()["task_id"]
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+
+
+        result_payload = json.dumps({"result": "success"})
+
+        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
+
+        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
+
+        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
+
+        self.assertEqual(complete.status_code, 200, complete.text)
+
+
+
+        # Admin triggers automated verification
+
+        verify_payload = json.dumps({"task_id": task_id})
+
+        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
+
+        self.assertEqual(verify_resp.status_code, 200, f"Verify failed: {verify_resp.text}")
+
+        result = verify_resp.json()
+
+        self.assertEqual(result["status"], "verified")
+
+        self.assertEqual(result["task_id"], task_id)
+
+
+
+        # Task should be completed
+
+        task = db.get_task(task_id)
+
+        self.assertEqual(task["status"], "completed")
+
+
+
+    def test_automated_verifier_rejects_invalid_json(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(submit.status_code, 200, submit.text)
+
+        task_id = submit.json()["task_id"]
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+
+
+        result_payload = "not valid json"
+
+        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
+
+        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
+
+        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
+
+        self.assertEqual(complete.status_code, 200, complete.text)
+
+
+
+        # Admin triggers automated verification
+
+        verify_payload = json.dumps({"task_id": task_id})
+
+        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
+
+        self.assertEqual(verify_resp.status_code, 400, f"Expected rejection: {verify_resp.text}")
+
+
+
+    def test_automated_verifier_rejects_empty_result(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(submit.status_code, 200, submit.text)
+
+        task_id = submit.json()["task_id"]
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+
+
+        result_payload = "   "  # whitespace-only should be rejected
+
+        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
+
+        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
+
+        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
+
+        self.assertEqual(complete.status_code, 200, complete.text)
+
+
+
+        # Admin triggers automated verification
+
+        verify_payload = json.dumps({"task_id": task_id})
+
+        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
+
         self.assertEqual(verify_resp.status_code, 400, f"Expected rejection: {verify_resp.text}")

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -1,166 +1,330 @@
-"""
-Hub API smoke tests — exercises the full task lifecycle using FastAPI TestClient.
-No running server or Postgres needed; uses SQLite backend automatically.
-"""
-import base64
-from contextlib import contextmanager
-from concurrent.futures import ThreadPoolExecutor
-import json
-import os
-import sys
-import time
-import tempfile
-import unittest
-
-# Point hub DB at a temp file so tests don't pollute anything
-_test_db = os.path.join(tempfile.gettempdir(), "mep_test_hub.db")
-os.environ["MEP_SQLITE_PATH"] = _test_db
-os.environ.setdefault("MEP_DATABASE_URL", "")  # force SQLite
-os.environ.setdefault("MEP_ADMIN_KEY", "test-admin-key")  # for admin endpoint tests
-
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "hub"))
-
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: E402
-from cryptography.hazmat.primitives import serialization  # noqa: E402
-
-# Import hub app AFTER env vars are set — db import triggers init_db()
-import db  # noqa: E402, F401
-import main  # noqa: E402
-from main import app  # noqa: E402
-
-from fastapi.testclient import TestClient  # noqa: E402
-
-client = TestClient(app)
-
-
-class _FakeWebSocket:
-    def __init__(self):
-        self.sent = []
-
-    async def send_json(self, payload):
-        self.sent.append(payload)
-
-
-# ---------------------------------------------------------------------------
-# Auth helpers (mirrors node/identity.py crypto)
-# ---------------------------------------------------------------------------
-def _make_identity():
-    """Generate a keypair and return (private_key, pub_pem, node_id)."""
-    private_key = Ed25519PrivateKey.generate()
-    pub_pem = private_key.public_key().public_bytes(
-        serialization.Encoding.PEM,
-        serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode("utf-8")
-    from auth import derive_node_id
-    node_id = derive_node_id(pub_pem)
-    return private_key, pub_pem, node_id
-
-
-def _auth_headers(private_key, node_id: str, payload_str: str) -> dict:
-    """Build the X-MEP-* auth headers required by verify_request."""
-    ts = str(int(time.time()))
-    message = f"{payload_str}{ts}".encode("utf-8")
-    signature = base64.b64encode(private_key.sign(message)).decode("utf-8")
-    return {
-        "X-MEP-NodeID": node_id,
-        "X-MEP-Timestamp": ts,
-        "X-MEP-Signature": signature,
-        "Content-Type": "application/json",
-    }
-
-
-def _diagnostic_headers(private_key, node_id: str) -> dict:
-    """Build auth headers for GET /diagnostic Tier-2 auth."""
-    ts = str(int(time.time()))
-    message = f"{node_id}{ts}".encode("utf-8")
-    signature = base64.b64encode(private_key.sign(message)).decode("utf-8")
-    return {
-        "X-MEP-NodeID": node_id,
-        "X-MEP-Timestamp": ts,
-        "X-MEP-Signature": signature,
-    }
-
-
-def _register(pub_pem: str, auto_approve: bool = True) -> dict:
-    resp = client.post("/register", json={"pubkey": pub_pem})
-    assert resp.status_code == 200, f"Register failed: {resp.text}"
-    data = resp.json()
-    if auto_approve and data["status"] == "pending":
-        node_id = data["node_id"]
-        approve_resp = client.post("/admin/approve-registration", json={"node_id": node_id}, headers={"x-mep-admin-key": "test-admin-key"})
-        assert approve_resp.status_code == 200, f"Approve failed: {approve_resp.text}"
-        data = approve_resp.json()
-    return data
-
-
-@contextmanager
-def _interbot_validation(enabled: bool, legacy_policy: str = "dm_only"):
-    old_enabled = main.INTERBOT_SPEC_VALIDATE_ENABLED
-    old_policy = main.INTERBOT_LEGACY_POLICY
-    main.INTERBOT_SPEC_VALIDATE_ENABLED = enabled
-    main.INTERBOT_LEGACY_POLICY = legacy_policy
-    try:
-        yield
-    finally:
-        main.INTERBOT_SPEC_VALIDATE_ENABLED = old_enabled
-        main.INTERBOT_LEGACY_POLICY = old_policy
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-class TestHealthEndpoint(unittest.TestCase):
-
-    def test_health_returns_ok(self):
-        resp = client.get("/health")
-        self.assertEqual(resp.status_code, 200)
-        data = resp.json()
-        self.assertEqual(data["status"], "ok")
-        self.assertIn("metrics", data)
-
-
-class TestRegistration(unittest.TestCase):
-
-    def test_register_new_node_pending_approval(self):
-        _, pub_pem, _ = _make_identity()
-        data = _register(pub_pem, auto_approve=False)
-        self.assertEqual(data["status"], "pending")
-        self.assertTrue(data["node_id"].startswith("node_"))
-        self.assertEqual(data["balance"], 0.0)
-
-    def test_duplicate_registration_preserves_pending_status(self):
-        _, pub_pem, _ = _make_identity()
-        data1 = _register(pub_pem, auto_approve=False)
-        data2 = _register(pub_pem, auto_approve=False)
-        self.assertEqual(data1["node_id"], data2["node_id"])
-        self.assertEqual(data1["status"], "pending")
-        self.assertEqual(data2["status"], "pending")
-
-    def test_register_persists_x25519_public_key_in_registry(self):
-        _, pub_pem, node_id = _make_identity()
-        resp = client.post("/register", json={"pubkey": pub_pem, "alias": "enc-node", "x25519_public_key": "encpub"})
-        self.assertEqual(resp.status_code, 200, f"Register failed: {resp.text}")
-
-        registry = db.get_registry(node_id)
-        self.assertIsNotNone(registry)
-        self.assertEqual(registry["alias"], "enc-node")
-        self.assertEqual(registry["x25519_public_key"], "encpub")
-
-
-class TestBalance(unittest.TestCase):
-
-    def test_get_balance(self):
-        _, pub_pem, node_id = _make_identity()
-        _register(pub_pem)
-        resp = client.get(f"/balance/{node_id}")
-        self.assertEqual(resp.status_code, 200)
-        self.assertGreater(resp.json()["balance_seconds"], 0)
-
-    def test_unknown_node_404(self):
-        resp = client.get("/balance/node_doesnotexist")
-        self.assertEqual(resp.status_code, 404)
-
-
+"""
+
+Hub API smoke tests — exercises the full task lifecycle using FastAPI TestClient.
+
+No running server or Postgres needed; uses SQLite backend automatically.
+
+"""
+
+import base64
+
+from contextlib import contextmanager
+
+from concurrent.futures import ThreadPoolExecutor
+
+import json
+
+import os
+
+import sys
+
+import time
+
+import tempfile
+
+import unittest
+
+from unittest import mock
+
+
+# Point hub DB at a temp file so tests don't pollute anything
+
+_test_db = os.path.join(tempfile.gettempdir(), "mep_test_hub.db")
+
+os.environ["MEP_SQLITE_PATH"] = _test_db
+
+os.environ.setdefault("MEP_DATABASE_URL", "")  # force SQLite
+
+os.environ.setdefault("MEP_ADMIN_KEY", "test-admin-key")  # for admin endpoint tests
+
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "hub"))
+
+
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: E402
+
+from cryptography.hazmat.primitives import serialization  # noqa: E402
+
+
+
+# Import hub app AFTER env vars are set — db import triggers init_db()
+
+import db  # noqa: E402, F401
+
+import main  # noqa: E402
+
+from main import app  # noqa: E402
+
+
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+
+client = TestClient(app)
+
+
+
+
+
+class _FakeWebSocket:
+
+    def __init__(self):
+
+        self.sent = []
+
+
+
+    async def send_json(self, payload):
+
+        self.sent.append(payload)
+
+
+
+
+
+# ---------------------------------------------------------------------------
+
+# Auth helpers (mirrors node/identity.py crypto)
+
+# ---------------------------------------------------------------------------
+
+def _make_identity():
+
+    """Generate a keypair and return (private_key, pub_pem, node_id)."""
+
+    private_key = Ed25519PrivateKey.generate()
+
+    pub_pem = private_key.public_key().public_bytes(
+
+        serialization.Encoding.PEM,
+
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+
+    ).decode("utf-8")
+
+    from auth import derive_node_id
+
+    node_id = derive_node_id(pub_pem)
+
+    return private_key, pub_pem, node_id
+
+
+
+
+
+def _auth_headers(private_key, node_id: str, payload_str: str) -> dict:
+
+    """Build the X-MEP-* auth headers required by verify_request."""
+
+    ts = str(int(time.time()))
+
+    message = f"{payload_str}{ts}".encode("utf-8")
+
+    signature = base64.b64encode(private_key.sign(message)).decode("utf-8")
+
+    return {
+
+        "X-MEP-NodeID": node_id,
+
+        "X-MEP-Timestamp": ts,
+
+        "X-MEP-Signature": signature,
+
+        "Content-Type": "application/json",
+
+    }
+
+
+
+
+
+def _diagnostic_headers(private_key, node_id: str) -> dict:
+
+    """Build auth headers for GET /diagnostic Tier-2 auth."""
+
+    ts = str(int(time.time()))
+
+    message = f"{node_id}{ts}".encode("utf-8")
+
+    signature = base64.b64encode(private_key.sign(message)).decode("utf-8")
+
+    return {
+
+        "X-MEP-NodeID": node_id,
+
+        "X-MEP-Timestamp": ts,
+
+        "X-MEP-Signature": signature,
+
+    }
+
+
+
+
+
+def _register(pub_pem: str, auto_approve: bool = True) -> dict:
+
+    resp = client.post("/register", json={"pubkey": pub_pem})
+
+    assert resp.status_code == 200, f"Register failed: {resp.text}"
+
+    data = resp.json()
+
+    if auto_approve and data["status"] == "pending":
+
+        node_id = data["node_id"]
+
+        approve_resp = client.post("/admin/approve-registration", json={"node_id": node_id}, headers={"x-mep-admin-key": "test-admin-key"})
+
+        assert approve_resp.status_code == 200, f"Approve failed: {approve_resp.text}"
+
+        data = approve_resp.json()
+
+    return data
+
+
+
+
+
+@contextmanager
+
+def _interbot_validation(enabled: bool, legacy_policy: str = "dm_only"):
+
+    old_enabled = main.INTERBOT_SPEC_VALIDATE_ENABLED
+
+    old_policy = main.INTERBOT_LEGACY_POLICY
+
+    main.INTERBOT_SPEC_VALIDATE_ENABLED = enabled
+
+    main.INTERBOT_LEGACY_POLICY = legacy_policy
+
+    try:
+
+        yield
+
+    finally:
+
+        main.INTERBOT_SPEC_VALIDATE_ENABLED = old_enabled
+
+        main.INTERBOT_LEGACY_POLICY = old_policy
+
+
+
+
+
+# ---------------------------------------------------------------------------
+
+# Tests
+
+# ---------------------------------------------------------------------------
+
+class TestHealthEndpoint(unittest.TestCase):
+
+
+
+    def test_health_returns_ok(self):
+
+        resp = client.get("/health")
+
+        self.assertEqual(resp.status_code, 200)
+
+        data = resp.json()
+
+        self.assertEqual(data["status"], "ok")
+
+        self.assertIn("metrics", data)
+
+
+
+
+
+class TestRegistration(unittest.TestCase):
+
+
+
+    def test_register_new_node_pending_approval(self):
+
+        _, pub_pem, _ = _make_identity()
+
+        data = _register(pub_pem, auto_approve=False)
+
+        self.assertEqual(data["status"], "pending")
+
+        self.assertTrue(data["node_id"].startswith("node_"))
+
+        self.assertEqual(data["balance"], 0.0)
+
+
+
+    def test_duplicate_registration_preserves_pending_status(self):
+
+        _, pub_pem, _ = _make_identity()
+
+        data1 = _register(pub_pem, auto_approve=False)
+
+        data2 = _register(pub_pem, auto_approve=False)
+
+        self.assertEqual(data1["node_id"], data2["node_id"])
+
+        self.assertEqual(data1["status"], "pending")
+
+        self.assertEqual(data2["status"], "pending")
+
+
+
+    def test_register_persists_x25519_public_key_in_registry(self):
+
+        _, pub_pem, node_id = _make_identity()
+
+        resp = client.post("/register", json={"pubkey": pub_pem, "alias": "enc-node", "x25519_public_key": "encpub"})
+
+        self.assertEqual(resp.status_code, 200, f"Register failed: {resp.text}")
+
+
+
+        registry = db.get_registry(node_id)
+
+        self.assertIsNotNone(registry)
+
+        self.assertEqual(registry["alias"], "enc-node")
+
+        self.assertEqual(registry["x25519_public_key"], "encpub")
+
+
+
+
+
+class TestBalance(unittest.TestCase):
+
+
+
+    def test_get_balance(self):
+
+        _, pub_pem, node_id = _make_identity()
+
+        _register(pub_pem)
+
+        resp = client.get(f"/balance/{node_id}")
+
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertGreater(resp.json()["balance_seconds"], 0)
+
+
+
+    def test_unknown_node_404(self):
+
+        resp = client.get("/balance/node_doesnotexist")
+
+        self.assertEqual(resp.status_code, 404)
+
+
+
+
+
 class TestV2Endpoints(unittest.TestCase):
 
     def setUp(self):
@@ -245,450 +409,884 @@ class TestV2Endpoints(unittest.TestCase):
         self.assertIn("amount_ns", data["entries"][0])
 
 
-class TestTaskLifecycle(unittest.TestCase):
-    """Full happy-path: register consumer + provider, submit, bid, complete."""
-
-    def setUp(self):
-        main.rate_limits.clear()
-
-    def test_submit_bid_complete(self):
-        # Setup: two identities
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        provider_priv, provider_pub, provider_id = _make_identity()
-        _register(consumer_pub)
-        _register(provider_pub)
-
-        # Submit task
-        bounty = 1.0
-        task_payload = json.dumps({
-            "consumer_id": consumer_id,
-            "payload": "What is 2+2?",
-            "bounty": bounty,
-        })
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-        task_id = resp.json()["task_id"]
-
-        # Bid on task
-        bid_payload = json.dumps({
-            "task_id": task_id,
-            "provider_id": provider_id,
-        })
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json()["status"], "accepted")
-
-        # Complete task
-        result_payload = json.dumps({
-            "task_id": task_id,
-            "provider_id": provider_id,
-            "result_payload": "4",
-        })
-        headers = _auth_headers(provider_priv, provider_id, result_payload)
-        resp = client.post("/tasks/complete", content=result_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Complete failed: {resp.text}")
-        self.assertEqual(resp.json()["status"], "success")
-        self.assertEqual(resp.json()["earned"], bounty)
-
-        # Verify provider balance increased
-        resp = client.get(f"/balance/{provider_id}")
-        self.assertGreater(resp.json()["balance_seconds"], 10.0)  # 10 starting + 1 earned
-
-    def test_submitted_result_timeout_refunds_manual_verification_escrow(self):
-        main.rate_limits.clear()
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        provider_priv, provider_pub, provider_id = _make_identity()
-        _register(consumer_pub)
-        _register(provider_pub)
-
-        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-        task_payload = json.dumps({
-            "consumer_id": consumer_id,
-            "payload": "Requires review but never accepted",
-            "bounty": 1.0,
-            "verifier_type": "manual_acceptance",
-        })
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(submit.status_code, 200, submit.text)
-        task_id = submit.json()["task_id"]
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "stale"})
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-        complete = client.post("/tasks/complete", content=complete_payload, headers=headers)
-        self.assertEqual(complete.status_code, 200, complete.text)
-        self.assertEqual(complete.json()["status"], "pending_verification")
-        self.assertEqual(db.get_escrow(task_id)["status"], "held")
-
-        old_time = time.time() - main.SUBMITTED_RESULT_TIMEOUT_SECONDS - 1
-        conn = db._get_conn()
-        conn.execute(
-            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
-            (old_time, task_id)
-        )
-        conn.commit()
-        db._release_conn(conn)
-
-        import asyncio
-        from main import _sweep_submitted_result_timeouts
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(_sweep_submitted_result_timeouts())
-        finally:
-            loop.close()
-
-        self.assertEqual(db.get_task(task_id)["status"], "expired")
-        self.assertEqual(db.get_escrow(task_id)["status"], "refunded")
-        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
-        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
-
-    def test_manual_verification_gates_settlement_until_consumer_accepts(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        provider_priv, provider_pub, provider_id = _make_identity()
-        _register(consumer_pub)
-        _register(provider_pub)
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-        task_payload = json.dumps({
-            "consumer_id": consumer_id,
-            "payload": "Requires review",
-            "bounty": 1.0,
-            "verifier_type": "manual_acceptance",
-        })
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(submit.status_code, 200, submit.text)
-        task_id = submit.json()["task_id"]
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-        bid = client.post("/tasks/bid", content=bid_payload, headers=headers)
-        self.assertEqual(bid.status_code, 200, bid.text)
-        self.assertEqual(bid.json()["status"], "accepted")
-
-        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "review me"})
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-        complete = client.post("/tasks/complete", content=complete_payload, headers=headers)
-        self.assertEqual(complete.status_code, 200, complete.text)
-        self.assertEqual(complete.json()["status"], "pending_verification")
-        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
-        task = db.get_task(task_id)
-        self.assertEqual(task["status"], "submitted_result")
-        self.assertEqual(db.get_escrow(task_id)["status"], "held")
-
-        accept_payload = json.dumps({"task_id": task_id})
-        headers = _auth_headers(provider_priv, provider_id, accept_payload)
-        forbidden = client.post("/tasks/verify/accept", content=accept_payload, headers=headers)
-        self.assertEqual(forbidden.status_code, 403, forbidden.text)
-
-        headers = _auth_headers(consumer_priv, consumer_id, accept_payload)
-        accepted = client.post("/tasks/verify/accept", content=accept_payload, headers=headers)
-        self.assertEqual(accepted.status_code, 200, accepted.text)
-        self.assertEqual(accepted.json()["status"], "success")
-        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before + 1.0)
-        self.assertEqual(db.get_task(task_id)["status"], "completed")
-        self.assertEqual(db.get_escrow(task_id)["status"], "released")
-
-    def test_provider_reject_refunds_escrow_without_payment(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        provider_priv, provider_pub, provider_id = _make_identity()
-        _register(consumer_pub)
-        _register(provider_pub)
-
-        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-        task_payload = json.dumps({
-            "consumer_id": consumer_id,
-            "payload": "Run unsafe code",
-            "bounty": 1.0,
-            "target_node": provider_id,
-        })
-        fake_ws = _FakeWebSocket()
-        main.connected_nodes[provider_id] = fake_ws
-        try:
-            headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-            submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-            self.assertEqual(submit.status_code, 200, submit.text)
-            self.assertEqual(submit.json()["status"], "success")
-            task_id = submit.json()["task_id"]
-        finally:
-            main.connected_nodes.pop(provider_id, None)
-
-        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
-        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
-        self.assertEqual(db.get_task(task_id)["status"], "assigned")
-        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
-
-        reject_payload = json.dumps({
-            "task_id": task_id,
-            "provider_id": provider_id,
-            "reason": "execution_disabled",
-        })
-        headers = _auth_headers(provider_priv, provider_id, reject_payload)
-        rejected = client.post("/tasks/reject", content=reject_payload, headers=headers)
-        self.assertEqual(rejected.status_code, 200, rejected.text)
-        self.assertEqual(rejected.json()["status"], "success")
-
-        self.assertEqual(db.get_task(task_id)["status"], "rejected")
-        self.assertEqual(db.get_escrow(task_id)["status"], "refunded")
-        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
-        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
-
-    def test_duplicate_completion_does_not_double_settle(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        provider_priv, provider_pub, provider_id = _make_identity()
-        _register(consumer_pub)
-        _register(provider_pub)
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "once", "bounty": 1.0})
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(submit.status_code, 200, submit.text)
-        task_id = submit.json()["task_id"]
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "done"})
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-        first = client.post("/tasks/complete", content=complete_payload, headers=headers)
-        self.assertEqual(first.status_code, 200, first.text)
-
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-        second = client.post("/tasks/complete", content=complete_payload, headers=headers)
-        self.assertEqual(second.status_code, 404, second.text)
-
-        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-        self.assertEqual(provider_after, provider_before + 1.0)
-        escrow = db.get_escrow(task_id)
-        self.assertEqual(escrow["status"], "released")
-
-    def test_completion_idempotency_replays_response_without_double_settlement(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        provider_priv, provider_pub, provider_id = _make_identity()
-        _register(consumer_pub)
-        _register(provider_pub)
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "idem", "bounty": 1.0})
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-        task_id = submit.json()["task_id"]
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "done"})
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-        headers["X-MEP-Idempotency-Key"] = "complete-once"
-        first = client.post("/tasks/complete", content=complete_payload, headers=headers)
-        self.assertEqual(first.status_code, 200, first.text)
-
-        headers = _auth_headers(provider_priv, provider_id, complete_payload)
-        headers["X-MEP-Idempotency-Key"] = "complete-once"
-        second = client.post("/tasks/complete", content=complete_payload, headers=headers)
-        self.assertEqual(second.status_code, 200, second.text)
-        self.assertEqual(second.json(), first.json())
-
-        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-        self.assertEqual(provider_after, provider_before + 1.0)
-
-    def test_atomic_completion_allows_only_one_concurrent_settlement(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        _, provider_pub, provider_id = _make_identity()
-        _register(consumer_pub)
-        _register(provider_pub)
-
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "race", "bounty": 1.0})
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-        task_id = submit.json()["task_id"]
-        self.assertTrue(db.assign_task_if_open(task_id, provider_id, time.time()))
-
-        def settle_once():
-            return db.complete_task_atomic(task_id, provider_id, "done", time.time())
-
-        with ThreadPoolExecutor(max_workers=2) as pool:
-            results = list(pool.map(lambda _: settle_once(), range(2)))
-
-        statuses = [item["status"] for item in results]
-        self.assertEqual(statuses.count("success"), 1, statuses)
-        self.assertEqual(statuses.count("not_active"), 1, statuses)
-        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-        self.assertEqual(provider_after, provider_before + 1.0)
-
-    def test_insufficient_balance_rejected(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        _register(consumer_pub)
-
-        task_payload = json.dumps({
-            "consumer_id": consumer_id,
-            "payload": "Expensive task",
-            "bounty": 99999.0,
-        })
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("Insufficient", resp.json()["detail"])
-
-
-class TestThreeMarketSpecConformance(unittest.TestCase):
-    """Spec-shaped task envelopes should support compute, chat/DM, and data markets."""
-
-    def setUp(self):
-        # The /register rate-limit bucket is keyed only by client IP, so it is
-        # shared across the whole suite. Reset it for deterministic isolation.
-        main.rate_limits.clear()
-
-    def _submit_spec_task(
-        self,
-        private_key,
-        node_id: str,
-        *,
-        instructions: str,
-        bounty_ns: int,
-        market: str,
-        payment_direction: str,
-        target_node: str | None = None,
-        target_capability: str | None = None,
-        secret_data: str | None = None,
+class TestTaskLifecycle(unittest.TestCase):
+
+    """Full happy-path: register consumer + provider, submit, bid, complete."""
+
+
+
+    def setUp(self):
+
+        main.rate_limits.clear()
+
+
+
+    def test_submit_bid_complete(self):
+
+        # Setup: two identities
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        # Submit task
+
+        bounty = 1.0
+
+        task_payload = json.dumps({
+
+            "consumer_id": consumer_id,
+
+            "payload": "What is 2+2?",
+
+            "bounty": bounty,
+
+        })
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+
+        task_id = resp.json()["task_id"]
+
+
+
+        # Bid on task
+
+        bid_payload = json.dumps({
+
+            "task_id": task_id,
+
+            "provider_id": provider_id,
+
+        })
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertEqual(resp.json()["status"], "accepted")
+
+
+
+        # Complete task
+
+        result_payload = json.dumps({
+
+            "task_id": task_id,
+
+            "provider_id": provider_id,
+
+            "result_payload": "4",
+
+        })
+
+        headers = _auth_headers(provider_priv, provider_id, result_payload)
+
+        resp = client.post("/tasks/complete", content=result_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Complete failed: {resp.text}")
+
+        self.assertEqual(resp.json()["status"], "success")
+
+        self.assertEqual(resp.json()["earned"], bounty)
+
+
+
+        # Verify provider balance increased
+
+        resp = client.get(f"/balance/{provider_id}")
+
+        self.assertGreater(resp.json()["balance_seconds"], 10.0)  # 10 starting + 1 earned
+
+
+
+    def test_submitted_result_timeout_refunds_manual_verification_escrow(self):
+
+        main.rate_limits.clear()
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+        task_payload = json.dumps({
+
+            "consumer_id": consumer_id,
+
+            "payload": "Requires review but never accepted",
+
+            "bounty": 1.0,
+
+            "verifier_type": "manual_acceptance",
+
+        })
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(submit.status_code, 200, submit.text)
+
+        task_id = submit.json()["task_id"]
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "stale"})
+
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+
+        complete = client.post("/tasks/complete", content=complete_payload, headers=headers)
+
+        self.assertEqual(complete.status_code, 200, complete.text)
+
+        self.assertEqual(complete.json()["status"], "pending_verification")
+
+        self.assertEqual(db.get_escrow(task_id)["status"], "held")
+
+
+
+        old_time = time.time() - main.SUBMITTED_RESULT_TIMEOUT_SECONDS - 1
+
+        conn = db._get_conn()
+
+        conn.execute(
+
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+
+            (old_time, task_id)
+
+        )
+
+        conn.commit()
+
+        db._release_conn(conn)
+
+
+
+        import asyncio
+
+        from main import _sweep_submitted_result_timeouts
+
+        loop = asyncio.new_event_loop()
+
+        try:
+
+            loop.run_until_complete(_sweep_submitted_result_timeouts())
+
+        finally:
+
+            loop.close()
+
+
+
+        self.assertEqual(db.get_task(task_id)["status"], "expired")
+
+        self.assertEqual(db.get_escrow(task_id)["status"], "refunded")
+
+        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
+
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
+
+
+
+    def test_manual_verification_gates_settlement_until_consumer_accepts(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+        task_payload = json.dumps({
+
+            "consumer_id": consumer_id,
+
+            "payload": "Requires review",
+
+            "bounty": 1.0,
+
+            "verifier_type": "manual_acceptance",
+
+        })
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(submit.status_code, 200, submit.text)
+
+        task_id = submit.json()["task_id"]
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+        bid = client.post("/tasks/bid", content=bid_payload, headers=headers)
+
+        self.assertEqual(bid.status_code, 200, bid.text)
+
+        self.assertEqual(bid.json()["status"], "accepted")
+
+
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "review me"})
+
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+
+        complete = client.post("/tasks/complete", content=complete_payload, headers=headers)
+
+        self.assertEqual(complete.status_code, 200, complete.text)
+
+        self.assertEqual(complete.json()["status"], "pending_verification")
+
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
+
+        task = db.get_task(task_id)
+
+        self.assertEqual(task["status"], "submitted_result")
+
+        self.assertEqual(db.get_escrow(task_id)["status"], "held")
+
+
+
+        accept_payload = json.dumps({"task_id": task_id})
+
+        headers = _auth_headers(provider_priv, provider_id, accept_payload)
+
+        forbidden = client.post("/tasks/verify/accept", content=accept_payload, headers=headers)
+
+        self.assertEqual(forbidden.status_code, 403, forbidden.text)
+
+
+
+        headers = _auth_headers(consumer_priv, consumer_id, accept_payload)
+
+        accepted = client.post("/tasks/verify/accept", content=accept_payload, headers=headers)
+
+        self.assertEqual(accepted.status_code, 200, accepted.text)
+
+        self.assertEqual(accepted.json()["status"], "success")
+
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before + 1.0)
+
+        self.assertEqual(db.get_task(task_id)["status"], "completed")
+
+        self.assertEqual(db.get_escrow(task_id)["status"], "released")
+
+
+
+    def test_provider_reject_refunds_escrow_without_payment(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+
+
+        task_payload = json.dumps({
+
+            "consumer_id": consumer_id,
+
+            "payload": "Run unsafe code",
+
+            "bounty": 1.0,
+
+            "target_node": provider_id,
+
+        })
+
+        fake_ws = _FakeWebSocket()
+
+        main.connected_nodes[provider_id] = fake_ws
+
+        try:
+
+            headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+            submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+            self.assertEqual(submit.status_code, 200, submit.text)
+
+            self.assertEqual(submit.json()["status"], "success")
+
+            task_id = submit.json()["task_id"]
+
+        finally:
+
+            main.connected_nodes.pop(provider_id, None)
+
+
+
+        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
+
+        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
+
+        self.assertEqual(db.get_task(task_id)["status"], "assigned")
+
+        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
+
+
+
+        reject_payload = json.dumps({
+
+            "task_id": task_id,
+
+            "provider_id": provider_id,
+
+            "reason": "execution_disabled",
+
+        })
+
+        headers = _auth_headers(provider_priv, provider_id, reject_payload)
+
+        rejected = client.post("/tasks/reject", content=reject_payload, headers=headers)
+
+        self.assertEqual(rejected.status_code, 200, rejected.text)
+
+        self.assertEqual(rejected.json()["status"], "success")
+
+
+
+        self.assertEqual(db.get_task(task_id)["status"], "rejected")
+
+        self.assertEqual(db.get_escrow(task_id)["status"], "refunded")
+
+        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
+
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before)
+
+
+
+    def test_duplicate_completion_does_not_double_settle(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "once", "bounty": 1.0})
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(submit.status_code, 200, submit.text)
+
+        task_id = submit.json()["task_id"]
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "done"})
+
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+
+        first = client.post("/tasks/complete", content=complete_payload, headers=headers)
+
+        self.assertEqual(first.status_code, 200, first.text)
+
+
+
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+
+        second = client.post("/tasks/complete", content=complete_payload, headers=headers)
+
+        self.assertEqual(second.status_code, 404, second.text)
+
+
+
+        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+        self.assertEqual(provider_after, provider_before + 1.0)
+
+        escrow = db.get_escrow(task_id)
+
+        self.assertEqual(escrow["status"], "released")
+
+
+
+    def test_completion_idempotency_replays_response_without_double_settlement(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "idem", "bounty": 1.0})
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        task_id = submit.json()["task_id"]
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+
+
+        complete_payload = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": "done"})
+
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+
+        headers["X-MEP-Idempotency-Key"] = "complete-once"
+
+        first = client.post("/tasks/complete", content=complete_payload, headers=headers)
+
+        self.assertEqual(first.status_code, 200, first.text)
+
+
+
+        headers = _auth_headers(provider_priv, provider_id, complete_payload)
+
+        headers["X-MEP-Idempotency-Key"] = "complete-once"
+
+        second = client.post("/tasks/complete", content=complete_payload, headers=headers)
+
+        self.assertEqual(second.status_code, 200, second.text)
+
+        self.assertEqual(second.json(), first.json())
+
+
+
+        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+        self.assertEqual(provider_after, provider_before + 1.0)
+
+
+
+    def test_atomic_completion_allows_only_one_concurrent_settlement(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        _, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "race", "bounty": 1.0})
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        task_id = submit.json()["task_id"]
+
+        self.assertTrue(db.assign_task_if_open(task_id, provider_id, time.time()))
+
+
+
+        def settle_once():
+
+            return db.complete_task_atomic(task_id, provider_id, "done", time.time())
+
+
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+
+            results = list(pool.map(lambda _: settle_once(), range(2)))
+
+
+
+        statuses = [item["status"] for item in results]
+
+        self.assertEqual(statuses.count("success"), 1, statuses)
+
+        self.assertEqual(statuses.count("not_active"), 1, statuses)
+
+        provider_after = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+        self.assertEqual(provider_after, provider_before + 1.0)
+
+
+
+    def test_insufficient_balance_rejected(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        _register(consumer_pub)
+
+
+
+        task_payload = json.dumps({
+
+            "consumer_id": consumer_id,
+
+            "payload": "Expensive task",
+
+            "bounty": 99999.0,
+
+        })
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 400)
+
+        self.assertIn("Insufficient", resp.json()["detail"])
+
+
+
+
+
+class TestThreeMarketSpecConformance(unittest.TestCase):
+
+    """Spec-shaped task envelopes should support compute, chat/DM, and data markets."""
+
+
+
+    def setUp(self):
+
+        # The /register rate-limit bucket is keyed only by client IP, so it is
+
+        # shared across the whole suite. Reset it for deterministic isolation.
+
+        main.rate_limits.clear()
+
+
+
+    def _submit_spec_task(
+
+        self,
+
+        private_key,
+
+        node_id: str,
+
+        *,
+
+        instructions: str,
+
+        bounty_ns: int,
+
+        market: str,
+
+        payment_direction: str,
+
+        target_node: str | None = None,
+
+        target_capability: str | None = None,
+
+        secret_data: str | None = None,
+
         intent_type: str = "conformance.request",
         expected_output: dict | None = None,
         task_title: str | None = None,
         task_inputs: dict | None = None,
-    ) -> str:
-        payload = {
-            "source": {"node_id": node_id},
+    ) -> str:
+
+        payload = {
+
+            "source": {"node_id": node_id},
+
             "intent": {"type": intent_type},
-            "task": {
-                "instructions": instructions,
+            "task": {
+
+                "instructions": instructions,
+
                 "expected_output": expected_output or {"result_type": "text"},
-            },
-            "economics": {
-                "bounty_ns": bounty_ns,
-                "currency": "MEP_NS",
-                "market": market,
-                "payment_direction": payment_direction,
-            },
-        }
+            },
+
+            "economics": {
+
+                "bounty_ns": bounty_ns,
+
+                "currency": "MEP_NS",
+
+                "market": market,
+
+                "payment_direction": payment_direction,
+
+            },
+
+        }
+
         if task_title:
             payload["task"]["title"] = task_title
         if task_inputs:
             payload["task"]["inputs"] = task_inputs
-        routing = {}
-        if target_node:
-            routing["target_node_id"] = target_node
-        if target_capability:
-            routing["target_capability"] = target_capability
-        if routing:
-            payload["routing"] = routing
-        if secret_data is not None:
-            payload["secret_data"] = secret_data
-
-        task_payload = json.dumps(payload)
-        headers = _auth_headers(private_key, node_id, task_payload)
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["status"], "success")
-        return data["task_id"]
-
-    def _bid(self, private_key, provider_id: str, task_id: str) -> dict:
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-        headers = _auth_headers(private_key, provider_id, bid_payload)
-        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Bid failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["status"], "accepted")
-        return data
-
-    def _complete(self, private_key, provider_id: str, task_id: str, result_payload: str) -> dict:
-        complete_payload = json.dumps(
-            {
-                "task_id": task_id,
-                "provider_id": provider_id,
-                "result_payload": result_payload,
-            }
-        )
-        headers = _auth_headers(private_key, provider_id, complete_payload)
-        resp = client.post("/tasks/complete", content=complete_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Complete failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["status"], "success")
-        return data
-
-    def test_spec_compute_market_sender_pays_receiver(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        provider_priv, provider_pub, provider_id = _make_identity()
-        _register(consumer_pub)
-        _register(provider_pub)
-
-        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
-        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
-
-        task_id = self._submit_spec_task(
-            consumer_priv,
-            consumer_id,
-            instructions="compute this",
-            bounty_ns=1_000_000_000,
-            market="compute",
-            payment_direction="sender_to_receiver",
-            target_capability="text",
-        )
-        stored = db.get_task(task_id)
-        self.assertEqual(stored["payload"], "compute this")
-        self.assertEqual(stored["bounty"], 1.0)
-        self.assertEqual(stored["model_requirement"], "text")
-
-        self._bid(provider_priv, provider_id, task_id)
-        result = self._complete(provider_priv, provider_id, task_id, "computed")
-        self.assertEqual(result["earned"], 1.0)
-        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
-        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before + 1.0)
-
-    def test_spec_chat_market_targeted_zero_bounty(self):
-        sender_priv, sender_pub, sender_id = _make_identity()
-        _, target_pub, target_id = _make_identity()
-        _register(sender_pub)
-        _register(target_pub)
-
-        sender_before = client.get(f"/balance/{sender_id}").json()["balance_seconds"]
-        fake_ws = _FakeWebSocket()
-        main.connected_nodes[target_id] = fake_ws
-        try:
-            task_id = self._submit_spec_task(
-                sender_priv,
-                sender_id,
-                instructions="hello target",
-                bounty_ns=0,
-                market="chat",
-                payment_direction="none",
-                target_node=target_id,
-            )
-        finally:
-            main.connected_nodes.pop(target_id, None)
-        stored = db.get_task(task_id)
-        self.assertEqual(stored["payload"], "hello target")
-        self.assertEqual(stored["bounty"], 0.0)
-        self.assertEqual(stored["target_node"], target_id)
-        self.assertEqual(stored["status"], "assigned")
-        self.assertEqual(stored["provider_id"], target_id)
-        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
-        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
-        self.assertEqual(client.get(f"/balance/{sender_id}").json()["balance_seconds"], sender_before)
-
+        routing = {}
+
+        if target_node:
+
+            routing["target_node_id"] = target_node
+
+        if target_capability:
+
+            routing["target_capability"] = target_capability
+
+        if routing:
+
+            payload["routing"] = routing
+
+        if secret_data is not None:
+
+            payload["secret_data"] = secret_data
+
+
+
+        task_payload = json.dumps(payload)
+
+        headers = _auth_headers(private_key, node_id, task_payload)
+
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["status"], "success")
+
+        return data["task_id"]
+
+
+
+    def _bid(self, private_key, provider_id: str, task_id: str) -> dict:
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+        headers = _auth_headers(private_key, provider_id, bid_payload)
+
+        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Bid failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["status"], "accepted")
+
+        return data
+
+
+
+    def _complete(self, private_key, provider_id: str, task_id: str, result_payload: str) -> dict:
+
+        complete_payload = json.dumps(
+
+            {
+
+                "task_id": task_id,
+
+                "provider_id": provider_id,
+
+                "result_payload": result_payload,
+
+            }
+
+        )
+
+        headers = _auth_headers(private_key, provider_id, complete_payload)
+
+        resp = client.post("/tasks/complete", content=complete_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Complete failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["status"], "success")
+
+        return data
+
+
+
+    def test_spec_compute_market_sender_pays_receiver(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+
+        provider_before = client.get(f"/balance/{provider_id}").json()["balance_seconds"]
+
+
+
+        task_id = self._submit_spec_task(
+
+            consumer_priv,
+
+            consumer_id,
+
+            instructions="compute this",
+
+            bounty_ns=1_000_000_000,
+
+            market="compute",
+
+            payment_direction="sender_to_receiver",
+
+            target_capability="text",
+
+        )
+
+        stored = db.get_task(task_id)
+
+        self.assertEqual(stored["payload"], "compute this")
+
+        self.assertEqual(stored["bounty"], 1.0)
+
+        self.assertEqual(stored["model_requirement"], "text")
+
+
+
+        self._bid(provider_priv, provider_id, task_id)
+
+        result = self._complete(provider_priv, provider_id, task_id, "computed")
+
+        self.assertEqual(result["earned"], 1.0)
+
+        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
+
+        self.assertEqual(client.get(f"/balance/{provider_id}").json()["balance_seconds"], provider_before + 1.0)
+
+
+
+    def test_spec_chat_market_targeted_zero_bounty(self):
+
+        sender_priv, sender_pub, sender_id = _make_identity()
+
+        _, target_pub, target_id = _make_identity()
+
+        _register(sender_pub)
+
+        _register(target_pub)
+
+
+
+        sender_before = client.get(f"/balance/{sender_id}").json()["balance_seconds"]
+
+        fake_ws = _FakeWebSocket()
+
+        main.connected_nodes[target_id] = fake_ws
+
+        try:
+
+            task_id = self._submit_spec_task(
+
+                sender_priv,
+
+                sender_id,
+
+                instructions="hello target",
+
+                bounty_ns=0,
+
+                market="chat",
+
+                payment_direction="none",
+
+                target_node=target_id,
+
+            )
+
+        finally:
+
+            main.connected_nodes.pop(target_id, None)
+
+        stored = db.get_task(task_id)
+
+        self.assertEqual(stored["payload"], "hello target")
+
+        self.assertEqual(stored["bounty"], 0.0)
+
+        self.assertEqual(stored["target_node"], target_id)
+
+        self.assertEqual(stored["status"], "assigned")
+
+        self.assertEqual(stored["provider_id"], target_id)
+
+        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
+
+        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
+
+        self.assertEqual(client.get(f"/balance/{sender_id}").json()["balance_seconds"], sender_before)
+
+
+
     def test_targeted_task_delivery_preserves_structured_task_metadata(self):
         sender_priv, sender_pub, sender_id = _make_identity()
         _, target_pub, target_id = _make_identity()
@@ -746,104 +1344,243 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(persisted_envelope["task"]["title"], "Repo audit: github.com/WUAIBING/MEP")
         self.assertEqual(persisted_envelope["model_requirement"], "repo_audit")
 
-    def test_spec_data_market_receiver_pays_sender_for_secret_data(self):
-        seller_priv, seller_pub, seller_id = _make_identity()
-        buyer_priv, buyer_pub, buyer_id = _make_identity()
-        _register(seller_pub)
-        _register(buyer_pub)
-
-        seller_before = client.get(f"/balance/{seller_id}").json()["balance_seconds"]
-        buyer_before = client.get(f"/balance/{buyer_id}").json()["balance_seconds"]
-        task_id = self._submit_spec_task(
-            seller_priv,
-            seller_id,
-            instructions="premium dataset",
-            bounty_ns=500_000_000,
-            market="data",
-            payment_direction="receiver_to_sender",
-            secret_data="encrypted-premium-data",
-        )
-        stored = db.get_task(task_id)
-        self.assertEqual(stored["bounty"], -0.5)
-        self.assertEqual(stored["result_payload"], "encrypted-premium-data")
-
-        bid_data = self._bid(buyer_priv, buyer_id, task_id)
-        self.assertEqual(bid_data["secret_data"], "encrypted-premium-data")
-        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
-        escrow = db.get_escrow(task_id)
-        self.assertEqual(escrow["status"], "held")
-        self.assertEqual(escrow["consumer_id"], buyer_id)
-
-        result = self._complete(buyer_priv, buyer_id, task_id, "data received")
-        self.assertEqual(result["earned"], -0.5)
-        self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before + 0.5)
-        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
-
-    def _submit_offline_dm(self, sender_priv, sender_id, target_id, instructions="offline hello"):
-        task_payload = json.dumps(
-            {
-                "source": {"node_id": sender_id},
-                "intent": {"type": "conformance.request"},
-                "task": {
-                    "instructions": instructions,
-                    "expected_output": {"result_type": "text"},
-                },
-                "economics": {
-                    "bounty_ns": 0,
-                    "currency": "MEP_NS",
-                    "market": "chat",
-                    "payment_direction": "none",
-                },
-                "routing": {"target_node_id": target_id},
-            }
-        )
-        headers = _auth_headers(sender_priv, sender_id, task_payload)
-        return client.post("/tasks/submit", content=task_payload, headers=headers)
-
-    def test_zero_bounty_dm_to_offline_node_is_queued(self):
-        sender_priv, sender_pub, sender_id = _make_identity()
-        _, target_pub, target_id = _make_identity()
-        _register(sender_pub)
-        _register(target_pub)
-        main.connected_nodes.pop(target_id, None)
-
-        resp = self._submit_offline_dm(sender_priv, sender_id, target_id)
-
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
-        self.assertEqual(body["status"], "queued")
-        self.assertEqual(body["queued_for"], target_id)
-        stored = db.get_task(body["task_id"])
-        self.assertEqual(stored["status"], "queued_dm")
-        self.assertEqual(stored["target_node"], target_id)
-        self.assertEqual(db.count_queued_dms_for_node(target_id), 1)
-
-    def test_queued_dm_flushed_on_reconnect(self):
-        import asyncio
-
-        sender_priv, sender_pub, sender_id = _make_identity()
-        _, target_pub, target_id = _make_identity()
-        _register(sender_pub)
-        _register(target_pub)
-        main.connected_nodes.pop(target_id, None)
-
-        resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="ping while away")
-        task_id = resp.json()["task_id"]
-        self.assertEqual(resp.json()["status"], "queued")
-
-        # Target reconnects -> flush should deliver the queued DM and mark it assigned.
-        fake_ws = _FakeWebSocket()
-        asyncio.run(main._flush_queued_dms(target_id, fake_ws))
-
-        self.assertEqual(len(fake_ws.sent), 1)
-        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
-        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
-        self.assertEqual(fake_ws.sent[0]["data"]["payload"], "ping while away")
-        stored = db.get_task(task_id)
-        self.assertEqual(stored["status"], "assigned")
-        self.assertEqual(stored["provider_id"], target_id)
-        self.assertEqual(db.count_queued_dms_for_node(target_id), 0)
-
+    def test_structured_task_submit_fails_closed_when_envelope_persistence_fails(self):
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+        _register(consumer_pub)
+
+        consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+        active_before = len(db.get_active_tasks())
+        payload = {
+            "source": {"node_id": consumer_id},
+            "intent": {"type": "repo_audit.request", "priority": "high"},
+            "task": {
+                "instructions": "Audit github.com/WUAIBING/MEP.",
+                "expected_output": {
+                    "result_type": "repo_audit_result",
+                    "format": "json",
+                },
+                "title": "Repo audit: github.com/WUAIBING/MEP",
+                "inputs": {
+                    "repo_audit": {
+                        "repo_url": "github.com/WUAIBING/MEP",
+                        "audit_type": "full_repo_audit",
+                    }
+                },
+            },
+            "economics": {
+                "bounty_ns": 1_000_000_000,
+                "currency": "MEP_NS",
+                "market": "compute",
+                "payment_direction": "sender_to_receiver",
+            },
+        }
+
+        task_payload = json.dumps(payload)
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+        with mock.patch.object(main.db, "set_task_envelope", side_effect=RuntimeError("boom")):
+            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 500, resp.text)
+        self.assertEqual(resp.json()["detail"], "Failed to persist structured task envelope")
+        self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
+        self.assertEqual(len(db.get_active_tasks()), active_before)
+
+    def test_spec_data_market_receiver_pays_sender_for_secret_data(self):
+
+        seller_priv, seller_pub, seller_id = _make_identity()
+
+        buyer_priv, buyer_pub, buyer_id = _make_identity()
+
+        _register(seller_pub)
+
+        _register(buyer_pub)
+
+
+
+        seller_before = client.get(f"/balance/{seller_id}").json()["balance_seconds"]
+
+        buyer_before = client.get(f"/balance/{buyer_id}").json()["balance_seconds"]
+
+        task_id = self._submit_spec_task(
+
+            seller_priv,
+
+            seller_id,
+
+            instructions="premium dataset",
+
+            bounty_ns=500_000_000,
+
+            market="data",
+
+            payment_direction="receiver_to_sender",
+
+            secret_data="encrypted-premium-data",
+
+        )
+
+        stored = db.get_task(task_id)
+
+        self.assertEqual(stored["bounty"], -0.5)
+
+        self.assertEqual(stored["result_payload"], "encrypted-premium-data")
+
+
+
+        bid_data = self._bid(buyer_priv, buyer_id, task_id)
+
+        self.assertEqual(bid_data["secret_data"], "encrypted-premium-data")
+
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
+
+        escrow = db.get_escrow(task_id)
+
+        self.assertEqual(escrow["status"], "held")
+
+        self.assertEqual(escrow["consumer_id"], buyer_id)
+
+
+
+        result = self._complete(buyer_priv, buyer_id, task_id, "data received")
+
+        self.assertEqual(result["earned"], -0.5)
+
+        self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before + 0.5)
+
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
+
+
+
+    def _submit_offline_dm(self, sender_priv, sender_id, target_id, instructions="offline hello"):
+
+        task_payload = json.dumps(
+
+            {
+
+                "source": {"node_id": sender_id},
+
+                "intent": {"type": "conformance.request"},
+
+                "task": {
+
+                    "instructions": instructions,
+
+                    "expected_output": {"result_type": "text"},
+
+                },
+
+                "economics": {
+
+                    "bounty_ns": 0,
+
+                    "currency": "MEP_NS",
+
+                    "market": "chat",
+
+                    "payment_direction": "none",
+
+                },
+
+                "routing": {"target_node_id": target_id},
+
+            }
+
+        )
+
+        headers = _auth_headers(sender_priv, sender_id, task_payload)
+
+        return client.post("/tasks/submit", content=task_payload, headers=headers)
+
+
+
+    def test_zero_bounty_dm_to_offline_node_is_queued(self):
+
+        sender_priv, sender_pub, sender_id = _make_identity()
+
+        _, target_pub, target_id = _make_identity()
+
+        _register(sender_pub)
+
+        _register(target_pub)
+
+        main.connected_nodes.pop(target_id, None)
+
+
+
+        resp = self._submit_offline_dm(sender_priv, sender_id, target_id)
+
+
+
+        self.assertEqual(resp.status_code, 200)
+
+        body = resp.json()
+
+        self.assertEqual(body["status"], "queued")
+
+        self.assertEqual(body["queued_for"], target_id)
+
+        stored = db.get_task(body["task_id"])
+
+        self.assertEqual(stored["status"], "queued_dm")
+
+        self.assertEqual(stored["target_node"], target_id)
+
+        self.assertEqual(db.count_queued_dms_for_node(target_id), 1)
+
+
+
+    def test_queued_dm_flushed_on_reconnect(self):
+
+        import asyncio
+
+
+
+        sender_priv, sender_pub, sender_id = _make_identity()
+
+        _, target_pub, target_id = _make_identity()
+
+        _register(sender_pub)
+
+        _register(target_pub)
+
+        main.connected_nodes.pop(target_id, None)
+
+
+
+        resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="ping while away")
+
+        task_id = resp.json()["task_id"]
+
+        self.assertEqual(resp.json()["status"], "queued")
+
+
+
+        # Target reconnects -> flush should deliver the queued DM and mark it assigned.
+
+        fake_ws = _FakeWebSocket()
+
+        asyncio.run(main._flush_queued_dms(target_id, fake_ws))
+
+
+
+        self.assertEqual(len(fake_ws.sent), 1)
+
+        self.assertEqual(fake_ws.sent[0]["event"], "new_task")
+
+        self.assertEqual(fake_ws.sent[0]["data"]["id"], task_id)
+
+        self.assertEqual(fake_ws.sent[0]["data"]["payload"], "ping while away")
+
+        stored = db.get_task(task_id)
+
+        self.assertEqual(stored["status"], "assigned")
+
+        self.assertEqual(stored["provider_id"], target_id)
+
+        self.assertEqual(db.count_queued_dms_for_node(target_id), 0)
+
+
+
     def test_pending_tasks_endpoint_lists_assigned_tasks_for_provider(self):
         sender_priv, sender_pub, sender_id = _make_identity()
         target_priv, target_pub, target_id = _make_identity()
@@ -935,49 +1672,92 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(bid_data["source"], {"node_id": consumer_id})
         self.assertEqual(bid_data["economics"]["market"], "compute")
 
-    def test_queued_dm_flush_matches_live_targeted_shape(self):
-        """A queued DM must be flushed with the same new_task event contract as a
-        live targeted delivery, so offline recipients are not handed a thinner
-        payload (regression guard for the store-and-forward shape mismatch)."""
-        import asyncio
-
-        sender_priv, sender_pub, sender_id = _make_identity()
-        _, target_pub, target_id = _make_identity()
-        _register(sender_pub)
-        _register(target_pub)
-
-        # 1) Live targeted delivery: target online, capture the new_task data.
-        live_ws = _FakeWebSocket()
-        main.connected_nodes[target_id] = live_ws
-        try:
-            live_resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="same body")
-        finally:
-            main.connected_nodes.pop(target_id, None)
-        self.assertEqual(live_resp.json()["status"], "success")
-        live_data = live_ws.sent[0]["data"]
-
-        # 2) Queued delivery: target offline -> queue -> reconnect -> flush.
-        main.connected_nodes.pop(target_id, None)
-        queued_resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="same body")
-        self.assertEqual(queued_resp.json()["status"], "queued")
-        flush_ws = _FakeWebSocket()
-        asyncio.run(main._flush_queued_dms(target_id, flush_ws))
-        self.assertEqual(len(flush_ws.sent), 1)
-        flushed_data = flush_ws.sent[0]["data"]
-
-        # Core contract fields must be identical (task_id differs per submit).
-        for field in (
-            "consumer_id", "payload", "bounty", "status", "provider_id",
-            "source", "intent", "task", "economics", "target_node",
-            "model_requirement", "payload_uri",
-        ):
-            self.assertEqual(
-                flushed_data.get(field), live_data.get(field),
-                f"queued-flush field '{field}' diverged from live targeted delivery",
-            )
-        # source.node_id (used for reply routing) must survive store-and-forward.
-        self.assertEqual(flushed_data["source"]["node_id"], sender_id)
-        self.assertEqual(flushed_data["task"]["expected_output"], live_data["task"]["expected_output"])
+    def test_queued_dm_flush_matches_live_targeted_shape(self):
+
+        """A queued DM must be flushed with the same new_task event contract as a
+
+        live targeted delivery, so offline recipients are not handed a thinner
+
+        payload (regression guard for the store-and-forward shape mismatch)."""
+
+        import asyncio
+
+
+
+        sender_priv, sender_pub, sender_id = _make_identity()
+
+        _, target_pub, target_id = _make_identity()
+
+        _register(sender_pub)
+
+        _register(target_pub)
+
+
+
+        # 1) Live targeted delivery: target online, capture the new_task data.
+
+        live_ws = _FakeWebSocket()
+
+        main.connected_nodes[target_id] = live_ws
+
+        try:
+
+            live_resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="same body")
+
+        finally:
+
+            main.connected_nodes.pop(target_id, None)
+
+        self.assertEqual(live_resp.json()["status"], "success")
+
+        live_data = live_ws.sent[0]["data"]
+
+
+
+        # 2) Queued delivery: target offline -> queue -> reconnect -> flush.
+
+        main.connected_nodes.pop(target_id, None)
+
+        queued_resp = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="same body")
+
+        self.assertEqual(queued_resp.json()["status"], "queued")
+
+        flush_ws = _FakeWebSocket()
+
+        asyncio.run(main._flush_queued_dms(target_id, flush_ws))
+
+        self.assertEqual(len(flush_ws.sent), 1)
+
+        flushed_data = flush_ws.sent[0]["data"]
+
+
+
+        # Core contract fields must be identical (task_id differs per submit).
+
+        for field in (
+
+            "consumer_id", "payload", "bounty", "status", "provider_id",
+
+            "source", "intent", "task", "economics", "target_node",
+
+            "model_requirement", "payload_uri",
+
+        ):
+
+            self.assertEqual(
+
+                flushed_data.get(field), live_data.get(field),
+
+                f"queued-flush field '{field}' diverged from live targeted delivery",
+
+            )
+
+        # source.node_id (used for reply routing) must survive store-and-forward.
+
+        self.assertEqual(flushed_data["source"]["node_id"], sender_id)
+
+        self.assertEqual(flushed_data["task"]["expected_output"], live_data["task"]["expected_output"])
+
 
     def test_queued_dm_flush_preserves_structured_task_metadata(self):
         import asyncio
@@ -1030,1030 +1810,2056 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(flushed_data["task"]["inputs"]["repo_audit"]["audit_type"], "architecture_audit")
         self.assertEqual(flushed_data["task"]["expected_output"]["result_type"], "repo_audit_result")
         self.assertEqual(flushed_data["model_requirement"], "repo_audit")
-
-    def test_dm_queue_full_rejected(self):
-        sender_priv, sender_pub, sender_id = _make_identity()
-        _, target_pub, target_id = _make_identity()
-        _register(sender_pub)
-        _register(target_pub)
-        main.connected_nodes.pop(target_id, None)
-
-        original_cap = main.MAX_QUEUED_DMS_PER_NODE
-        main.MAX_QUEUED_DMS_PER_NODE = 1
-        try:
-            first = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="dm one")
-            self.assertEqual(first.json()["status"], "queued")
-            second = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="dm two")
-            self.assertEqual(second.json()["status"], "error")
-            self.assertIn("queue is full", second.json()["detail"])
-        finally:
-            main.MAX_QUEUED_DMS_PER_NODE = original_cap
-
-    def test_targeted_dm_to_offline_node_errors_when_queue_disabled(self):
-        sender_priv, sender_pub, sender_id = _make_identity()
-        _, target_pub, target_id = _make_identity()
-        _register(sender_pub)
-        _register(target_pub)
-        main.connected_nodes.pop(target_id, None)
-
-        original = main.DM_QUEUE_ENABLED
-        main.DM_QUEUE_ENABLED = False
-        try:
-            resp = self._submit_offline_dm(sender_priv, sender_id, target_id)
-            self.assertEqual(resp.status_code, 200)
-            self.assertEqual(resp.json()["status"], "error")
-            self.assertIn("not currently connected", resp.json()["detail"])
-        finally:
-            main.DM_QUEUE_ENABLED = original
-
-    def test_data_market_requires_secret_data(self):
-        seller_priv, seller_pub, seller_id = _make_identity()
-        _register(seller_pub)
-
-        task_payload = json.dumps(
-            {
-                "source": {"node_id": seller_id},
-                "intent": {"type": "conformance.request"},
-                "task": {
-                    "instructions": "premium dataset",
-                    "expected_output": {"result_type": "text"},
-                },
-                "economics": {
-                    "bounty_ns": 500_000_000,
-                    "currency": "MEP_NS",
-                    "market": "data",
-                    "payment_direction": "receiver_to_sender",
-                },
-            }
-        )
-        headers = _auth_headers(seller_priv, seller_id, task_payload)
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("require secret_data", resp.json()["detail"])
-
-
-class TestInterBotSpecValidation(unittest.TestCase):
-    def test_rejects_invalid_structured_payload_when_enabled(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        _register(consumer_pub)
-        invalid_payload = json.dumps(
-            {
-                "consumer_id": consumer_id,
-                "payload": json.dumps({"spec_version": "mep.interbot.v1"}),
-                "bounty": 0.0,
-            }
-        )
-        headers = _auth_headers(consumer_priv, consumer_id, invalid_payload)
-        with _interbot_validation(True):
-            resp = client.post("/tasks/submit", content=invalid_payload, headers=headers)
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("Inter-bot payload", resp.json()["detail"])
-
-    def test_accepts_valid_structured_dm_payload_when_enabled(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        _, target_pub, target_id = _make_identity()
-        _register(consumer_pub)
-        _register(target_pub)
-        message = {
-            "spec_version": "mep.interbot.v1",
-            "message_id": "msg-123",
-            "timestamp_ms": int(time.time() * 1000),
-            "source": {"node_id": consumer_id, "alias": "consumer"},
-            "target": {"node_id": target_id, "alias": "target"},
-            "intent": {"type": "chat.request"},
-            "task": {"instructions": "hello", "expected_output": {"result_type": "text"}},
-            "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
-        }
-        task_payload = json.dumps(
-            {
-                "consumer_id": consumer_id,
-                "payload": json.dumps(message),
-                "bounty": 0.0,
-                "target_node": target_id,
-            }
-        )
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        with _interbot_validation(True):
-            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn(resp.json()["status"], ("success", "error", "queued"))
-
-    def test_rejects_legacy_plaintext_non_dm_when_enabled(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        _register(consumer_pub)
-        task_payload = json.dumps(
-            {
-                "consumer_id": consumer_id,
-                "payload": "legacy plaintext non-dm",
-                "bounty": 1.0,
-            }
-        )
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        with _interbot_validation(True):
-            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("Legacy plaintext payload", resp.json()["detail"])
-
-    def test_spec_shaped_task_bounty_ns_is_converted_to_seconds(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        _register(consumer_pub)
-
-        resp = client.get(f"/balance/{consumer_id}")
-        initial_balance = resp.json()["balance_seconds"]
-
-        task_payload = json.dumps(
-            {
-                "source": {"node_id": consumer_id},
-                "intent": {"type": "analysis.request"},
-                "task": {
-                    "instructions": "spec-shaped compute task",
-                    "expected_output": {"result_type": "text"},
-                },
-                "economics": {
-                    "bounty_ns": 1_000_000_000,
-                    "currency": "MEP_NS",
-                    "market": "compute",
-                    "payment_direction": "sender_to_receiver",
-                },
-                "routing": {"target_capability": "text"},
-            }
-        )
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        with _interbot_validation(True):
-            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-        task_id = resp.json()["task_id"]
-        stored_task = db.get_task(task_id)
-        self.assertEqual(stored_task["bounty"], 1.0)
-
-        resp = client.get(f"/balance/{consumer_id}")
-        self.assertEqual(resp.json()["balance_seconds"], initial_balance - 1.0)
-
-    def test_rejects_obsolete_bounty_quanta_name(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        _register(consumer_pub)
-
-        task_payload = json.dumps(
-            {
-                "source": {"node_id": consumer_id},
-                "task": {
-                    "instructions": "obsolete unit name",
-                    "expected_output": {"result_type": "text"},
-                },
-                "economics": {
-                    "bounty_quanta": 1_000_000_000,
-                    "currency": "MEP_QUANTA",
-                    "market": "compute",
-                    "payment_direction": "sender_to_receiver",
-                },
-            }
-        )
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        with _interbot_validation(True):
-            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("MEP_NS", resp.json()["detail"])
-
-
-class TestAuthRejection(unittest.TestCase):
-
-    def test_invalid_signature_rejected(self):
-        priv, pub_pem, node_id = _make_identity()
-        _register(pub_pem)
-
-        payload = json.dumps({"consumer_id": node_id, "payload": "x", "bounty": 0.1})
-        headers = {
-            "X-MEP-NodeID": node_id,
-            "X-MEP-Timestamp": str(int(time.time())),
-            "X-MEP-Signature": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-            "Content-Type": "application/json",
-        }
-        resp = client.post("/tasks/submit", content=payload, headers=headers)
-        self.assertEqual(resp.status_code, 401)
-
-    def test_unregistered_node_rejected(self):
-        priv, _, node_id = _make_identity()
-        # Don't register
-        payload = json.dumps({"consumer_id": node_id, "payload": "x", "bounty": 0.1})
-        headers = _auth_headers(priv, node_id, payload)
-        resp = client.post("/tasks/submit", content=payload, headers=headers)
-        self.assertEqual(resp.status_code, 401)
-
-
-class TestDiagnosticEndpoint(unittest.TestCase):
-
-    def test_public_diagnostic_for_registered_node(self):
-        priv, pub_pem, node_id = _make_identity()
-        _register(pub_pem)
-        # Ensure node exists in registry table so public diagnostic can resolve it.
-        update_payload = json.dumps({"alias": "diag-node"})
-        headers = _auth_headers(priv, node_id, update_payload)
-        update_resp = client.post("/registry/update", content=update_payload, headers=headers)
-        self.assertEqual(update_resp.status_code, 200, f"Registry update failed: {update_resp.text}")
-
-        resp = client.get(f"/diagnostic?node_id={node_id}")
-        self.assertEqual(resp.status_code, 200)
-        data = resp.json()
-        self.assertEqual(data["node_id"], node_id)
-        self.assertTrue(data["registered"])
-        self.assertIn("availability", data)
-        self.assertIn("last_heartbeat", data)
-
-    def test_authenticated_diagnostic_rejects_invalid_signature(self):
-        _, pub_pem, node_id = _make_identity()
-        _register(pub_pem)
-        bad_headers = {
-            "X-MEP-NodeID": node_id,
-            "X-MEP-Timestamp": str(int(time.time())),
-            "X-MEP-Signature": "invalid-signature",
-        }
-        resp = client.get("/diagnostic", headers=bad_headers)
-        self.assertEqual(resp.status_code, 401)
-
-    def test_authenticated_diagnostic_succeeds_with_valid_signature(self):
-        priv, pub_pem, node_id = _make_identity()
-        _register(pub_pem)
-        headers = _diagnostic_headers(priv, node_id)
-        resp = client.get("/diagnostic", headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Diagnostic failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["node_id"], node_id)
-        self.assertIn("ws_connected", data)
-        self.assertIn("last_ws_activity", data)
-        self.assertTrue(data["auth_ok"])
-
-    def test_registry_update_can_persist_x25519_public_key(self):
-        priv, pub_pem, node_id = _make_identity()
-        _register(pub_pem)
-        update_payload = json.dumps({"alias": "diag-node", "x25519_public_key": "updated-encpub"})
-        headers = _auth_headers(priv, node_id, update_payload)
-
-        update_resp = client.post("/registry/update", content=update_payload, headers=headers)
-        self.assertEqual(update_resp.status_code, 200, f"Registry update failed: {update_resp.text}")
-
-        registry = db.get_registry(node_id)
-        self.assertIsNotNone(registry)
-        self.assertEqual(registry["x25519_public_key"], "updated-encpub")
-
-
-class TestOnboardDiagnose(unittest.TestCase):
-    def setUp(self):
-        main.onboard_diagnosis_counts.clear()
-        main.onboard_diagnosis_total = 0
-
-    def test_detects_auth_401_signature_or_timestamp(self):
-        payload = {
-            "node_id": "node_test",
-            "auth_status": "401",
-            "registered": True,
-        }
-        resp = client.post("/onboard/diagnose", json=payload)
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["root_cause"], "auth_401_signature_or_timestamp")
-        self.assertEqual(data["severity"], "high")
-        self.assertGreaterEqual(data["telemetry"]["total_requests"], 1)
-
-    def test_detects_ghost_online_without_ws(self):
-        payload = {
-            "node_id": "node_test",
-            "registered": True,
-            "ws_connected": False,
-            "heartbeat_seconds_ago": 15,
-            "auth_status": "ok",
-        }
-        resp = client.post("/onboard/diagnose", json=payload)
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["root_cause"], "ghost_online_no_ws_presence")
-        self.assertEqual(data["severity"], "high")
-
-    def test_returns_healthy_or_insufficient_signal_when_no_fault(self):
-        payload = {
-            "node_id": "node_test",
-            "registered": True,
-            "ws_connected": True,
-            "auth_status": "ok",
-            "dm_status": "ok",
-            "listener_contract_ok": True,
-            "ai_configured": True,
-        }
-        resp = client.post("/onboard/diagnose", json=payload)
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["root_cause"], "healthy_or_insufficient_signal")
-        self.assertEqual(data["severity"], "info")
-
-    def test_detects_auth_403_unregistered_or_policy(self):
-        payload = {
-            "node_id": "node_test",
-            "auth_status": "403",
-            "registered": False,
-        }
-        resp = client.post("/onboard/diagnose", json=payload)
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["root_cause"], "auth_403_unregistered_or_policy")
-        self.assertEqual(data["severity"], "high")
-
-    def test_detects_dm_pending_target_offline_or_route_issue(self):
-        payload = {
-            "node_id": "node_test",
-            "registered": True,
-            "ws_connected": True,
-            "auth_status": "ok",
-            "dm_status": "pending",
-        }
-        resp = client.post("/onboard/diagnose", json=payload)
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["root_cause"], "dm_pending_target_offline_or_route_issue")
-        self.assertEqual(data["severity"], "medium")
-
-    def test_detects_listener_payload_contract_mismatch(self):
-        payload = {
-            "node_id": "node_test",
-            "registered": True,
-            "ws_connected": True,
-            "auth_status": "ok",
-            "dm_status": "ok",
-            "listener_contract_ok": False,
-        }
-        resp = client.post("/onboard/diagnose", json=payload)
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["root_cause"], "listener_payload_contract_mismatch")
-        self.assertEqual(data["severity"], "medium")
-
-    def test_detects_heartbeat_interval_or_clock_drift(self):
-        payload = {
-            "node_id": "node_test",
-            "registered": True,
-            "ws_connected": True,
-            "auth_status": "ok",
-            "dm_status": "ok",
-            "listener_contract_ok": True,
-            "ai_configured": True,
-            "clock_skew_seconds": 400,
-        }
-        resp = client.post("/onboard/diagnose", json=payload)
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["root_cause"], "heartbeat_interval_or_clock_drift")
-        self.assertEqual(data["severity"], "medium")
-
-    def test_detects_ai_provider_config_invalid(self):
-        payload = {
-            "node_id": "node_test",
-            "registered": True,
-            "ws_connected": True,
-            "auth_status": "ok",
-            "dm_status": "ok",
-            "listener_contract_ok": True,
-            "ai_configured": False,
-        }
-        resp = client.post("/onboard/diagnose", json=payload)
-        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
-        data = resp.json()
-        self.assertEqual(data["root_cause"], "ai_provider_config_invalid")
-        self.assertEqual(data["severity"], "low")
-
-
-class TestRegistryHeartbeatPresence(unittest.TestCase):
-    def test_heartbeat_online_without_websocket_forces_offline(self):
-        node_priv, node_pub, node_id = _make_identity()
-        _register(node_pub)
-        heartbeat_payload = json.dumps({"availability": "online"})
-        headers = _auth_headers(node_priv, node_id, heartbeat_payload)
-        heartbeat_response = client.post("/registry/heartbeat", content=heartbeat_payload, headers=headers)
-        self.assertEqual(heartbeat_response.status_code, 200, f"Heartbeat failed: {heartbeat_response.text}")
-        self.assertEqual(heartbeat_response.json()["availability"], "offline")
-
-        registry_response = client.get(f"/registry/{node_id}")
-        self.assertEqual(registry_response.status_code, 200, f"Registry read failed: {registry_response.text}")
-        self.assertEqual(registry_response.json()["availability"], "offline")
-
-
-class TestMeshAssembly(unittest.TestCase):
-    def setUp(self):
-        conn = db._get_conn()
-        conn.execute("UPDATE agent_registry SET availability = 'offline'")
-        conn.commit()
-        db._release_conn(conn)
-        main.mesh_assemblies.clear()
-        main.connected_nodes.clear()
-
-    def _register_with_mesh_metadata(
-        self,
-        role: str,
-        *,
-        provider: str,
-        thinking_mode: str,
-        alias: str,
-        availability: str = "online",
-    ):
-        priv, pub, node_id = _make_identity()
-        _register(pub)
-        # Mesh role selection treats websocket presence as source of truth.
-        main.connected_nodes[node_id] = object()
-        update_payload = json.dumps(
-            {
-                "alias": alias,
-                "availability": availability,
-                "metadata": {
-                    "ai_provider": provider,
-                    "ai_status": "online",
-                    "thinking_mode": thinking_mode,
-                    "mesh_role_preference": role,
-                },
-            }
-        )
-        headers = _auth_headers(priv, node_id, update_payload)
-        resp = client.post("/registry/update", content=update_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Registry update failed: {resp.text}")
-        return priv, node_id
-
-    def test_mesh_assemble_complete_with_four_roles(self):
-        requester_priv, requester_id = self._register_with_mesh_metadata(
-            "strategist",
-            provider="deepseek",
-            thinking_mode="reasoning",
-            alias="Hermes",
-        )
-        self._register_with_mesh_metadata(
-            "implementer",
-            provider="yunwu",
-            thinking_mode="code_reading",
-            alias="Alisa",
-        )
-        self._register_with_mesh_metadata(
-            "facilitator",
-            provider="template",
-            thinking_mode="aggregation",
-            alias="Hub-Sentinel",
-        )
-        self._register_with_mesh_metadata(
-            "scout",
-            provider="echo",
-            thinking_mode="ack_only",
-            alias="Moltbot",
-        )
-
-        payload = json.dumps({"trigger": "brainstorm", "timeout_seconds": 180})
-        headers = _auth_headers(requester_priv, requester_id, payload)
-        resp = client.post("/mesh/assemble", content=payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Assemble failed: {resp.text}")
-        data = resp.json()
-        self.assertTrue(data["complete"])
-        self.assertEqual(
-            set(data["roles"].keys()),
-            {"strategist", "implementer", "facilitator", "scout"},
-        )
-
-    def test_mesh_assemble_degraded_when_insufficient_nodes(self):
-        requester_priv, requester_id = self._register_with_mesh_metadata(
-            "strategist",
-            provider="deepseek",
-            thinking_mode="reasoning",
-            alias="Solo",
-        )
-        payload = json.dumps({"trigger": "incident"})
-        headers = _auth_headers(requester_priv, requester_id, payload)
-        resp = client.post("/mesh/assemble", content=payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Assemble failed: {resp.text}")
-        data = resp.json()
-        self.assertFalse(data["complete"])
-        self.assertIn("degraded_warning", data)
-        self.assertIn("strategist", data["roles"])
-
-    def test_mesh_status_reports_drop_and_reassignment(self):
-        requester_priv, requester_id = self._register_with_mesh_metadata(
-            "strategist",
-            provider="deepseek",
-            thinking_mode="reasoning",
-            alias="Hermes",
-        )
-        self._register_with_mesh_metadata(
-            "implementer",
-            provider="yunwu",
-            thinking_mode="code_reading",
-            alias="Alisa",
-        )
-        self._register_with_mesh_metadata(
-            "facilitator",
-            provider="template",
-            thinking_mode="aggregation",
-            alias="Hub-Sentinel",
-        )
-        self._register_with_mesh_metadata(
-            "scout",
-            provider="echo",
-            thinking_mode="ack_only",
-            alias="Moltbot",
-        )
-        self._register_with_mesh_metadata(
-            "scout",
-            provider="echo",
-            thinking_mode="ack_only",
-            alias="Backup-Scout",
-        )
-
-        assemble_payload = json.dumps({"trigger": "planning"})
-        assemble_headers = _auth_headers(requester_priv, requester_id, assemble_payload)
-        assemble_resp = client.post("/mesh/assemble", content=assemble_payload, headers=assemble_headers)
-        self.assertEqual(assemble_resp.status_code, 200, f"Assemble failed: {assemble_resp.text}")
-        assembly = assemble_resp.json()
-        scout_node_id = assembly["roles"]["scout"]["node_id"]
-        db.update_registry_availability(scout_node_id, "offline", time.time())
-
-        status_headers = _auth_headers(requester_priv, requester_id, "")
-        status_resp = client.get(
-            f"/mesh/status?assembly_id={assembly['assembly_id']}",
-            headers=status_headers,
-        )
-        self.assertEqual(status_resp.status_code, 200, f"Status failed: {status_resp.text}")
-        status_data = status_resp.json()
-        self.assertFalse(status_data["complete"])
-        self.assertIn("scout", status_data["dropped_roles"])
-        self.assertIn("scout", status_data["reassignment_suggestions"])
-        self.assertNotEqual(
-            status_data["reassignment_suggestions"]["scout"]["node_id"],
-            scout_node_id,
-        )
-
-
-class TestBrainstormSessions(unittest.TestCase):
-    def setUp(self):
-        main.brainstorm_sessions.clear()
-
-    def test_create_post_and_read_session(self):
-        owner_priv, owner_pub, owner_id = _make_identity()
-        p1_priv, p1_pub, p1_id = _make_identity()
-        p2_priv, p2_pub, p2_id = _make_identity()
-        _register(owner_pub)
-        _register(p1_pub)
-        _register(p2_pub)
-
-        create_payload = json.dumps(
-            {
-                "owner_id": owner_id,
-                "participants": [p1_id, p2_id],
-                "topic": "Loop-free architecture",
-            }
-        )
-        create_headers = _auth_headers(owner_priv, owner_id, create_payload)
-        create_resp = client.post("/brainstorm/sessions/create", content=create_payload, headers=create_headers)
-        self.assertEqual(create_resp.status_code, 200, f"Create failed: {create_resp.text}")
-        session_id = create_resp.json()["session_id"]
-
-        post_payload = json.dumps(
-            {
-                "session_id": session_id,
-                "message": "I suggest we add a shared session timeline.",
-            }
-        )
-        post_headers = _auth_headers(p1_priv, p1_id, post_payload)
-        post_resp = client.post("/brainstorm/sessions/post", content=post_payload, headers=post_headers)
-        self.assertEqual(post_resp.status_code, 200, f"Post failed: {post_resp.text}")
-
-        get_headers = _auth_headers(p2_priv, p2_id, "")
-        get_resp = client.get(f"/brainstorm/sessions/{session_id}", headers=get_headers)
-        self.assertEqual(get_resp.status_code, 200, f"Get failed: {get_resp.text}")
-        data = get_resp.json()
-        self.assertEqual(data["topic"], "Loop-free architecture")
-        self.assertEqual(data["message_count"], 1)
-        self.assertEqual(data["messages"][0]["sender_id"], p1_id)
-
-    def test_non_participant_cannot_post(self):
-        owner_priv, owner_pub, owner_id = _make_identity()
-        p1_priv, p1_pub, p1_id = _make_identity()
-        outsider_priv, outsider_pub, outsider_id = _make_identity()
-        _register(owner_pub)
-        _register(p1_pub)
-        _register(outsider_pub)
-
-        create_payload = json.dumps({"owner_id": owner_id, "participants": [p1_id]})
-        create_headers = _auth_headers(owner_priv, owner_id, create_payload)
-        create_resp = client.post("/brainstorm/sessions/create", content=create_payload, headers=create_headers)
-        self.assertEqual(create_resp.status_code, 200)
-        session_id = create_resp.json()["session_id"]
-
-        post_payload = json.dumps({"session_id": session_id, "message": "Intruding message"})
-        post_headers = _auth_headers(outsider_priv, outsider_id, post_payload)
-        post_resp = client.post("/brainstorm/sessions/post", content=post_payload, headers=post_headers)
-        self.assertEqual(post_resp.status_code, 403)
-
-
-def tearDownModule():
-    """Clean up test database."""
-    try:
-        os.remove(_test_db)
-    except OSError:
-        pass
-
-class TestBiddingTimeout(unittest.TestCase):
-    """Test bidding task timeout + refund flow"""
-
-    def test_stale_bidding_task_expired_and_refunded(self):
-        """Verify stale bidding tasks are expired and bounty refunded to consumer"""
-        # Setup: consumer and provider
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        provider_priv, provider_pub, provider_id = _make_identity()
-        _register(consumer_pub)
-        _register(provider_pub)
-
-        # Get initial balance
-        resp = client.get(f"/balance/{consumer_id}")
-        initial_balance = resp.json()["balance_seconds"]
-
-        # Submit task with bounty (escrow created)
-        bounty = 1.0
-        task_payload = json.dumps({
-            "consumer_id": consumer_id,
-            "payload": "Stale task that will timeout",
-            "bounty": bounty,
-        })
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-        task_id = resp.json()["task_id"]
-
-        # Verify balance is escrowed (reduced by bounty)
-        resp = client.get(f"/balance/{consumer_id}")
-        self.assertLess(resp.json()["balance_seconds"], initial_balance,
-                       "Consumer balance should decrease by bounty")
-
-        # Simulate task aging: directly update task's updated_at in DB to be old
-        # (In real system, timeout worker does this after ASSIGNMENT_TIMEOUT_SECONDS)
-        import time as t
-        old_time = t.time() - 7200  # 2 hours ago (well beyond 1 hour timeout)
-        conn = db._get_conn()
-        conn.execute(
-            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
-            (old_time, task_id)
-        )
-        conn.commit()
-        db._release_conn(conn)
-
-        # Run the bidding timeout sweep
-        import asyncio
-        from main import _sweep_bidding_timeouts
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(_sweep_bidding_timeouts())
-        finally:
-            loop.close()
-
-        # Verify task status from DB helper (not /tasks/{task_id}, which does not exist)
-        task = db.get_task(task_id)
-        self.assertIsNotNone(task)
-        self.assertEqual(task["status"], "expired", "Task should be expired after timeout")
-
-        # Verify consumer balance is restored (refunded)
-        resp = client.get(f"/balance/{consumer_id}")
-        self.assertEqual(resp.json()["balance_seconds"], initial_balance,
-                        "Consumer balance should be restored after refund")
-
-    def test_assigned_data_market_timeout_refunds_buyer_escrow(self):
-        seller_priv, seller_pub, seller_id = _make_identity()
-        buyer_priv, buyer_pub, buyer_id = _make_identity()
-        _register(seller_pub)
-        _register(buyer_pub)
-
-        seller_before = client.get(f"/balance/{seller_id}").json()["balance_seconds"]
-        buyer_before = client.get(f"/balance/{buyer_id}").json()["balance_seconds"]
-        task_payload = json.dumps(
-            {
-                "consumer_id": seller_id,
-                "payload": "Premium dataset",
-                "bounty": -0.5,
-                "secret_data": "encrypted-premium-data",
-            }
-        )
-        headers = _auth_headers(seller_priv, seller_id, task_payload)
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-        task_id = resp.json()["task_id"]
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": buyer_id})
-        headers = _auth_headers(buyer_priv, buyer_id, bid_payload)
-        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Bid failed: {resp.text}")
-        self.assertEqual(resp.json()["status"], "accepted")
-        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
-
-        old_time = time.time() - 7200
-        conn = db._get_conn()
-        conn.execute(
-            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
-            (old_time, task_id)
-        )
-        conn.commit()
-        db._release_conn(conn)
-
-        import asyncio
-        from main import _sweep_assigned_timeouts
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(_sweep_assigned_timeouts())
-        finally:
-            loop.close()
-
-        task = db.get_task(task_id)
-        self.assertEqual(task["status"], "expired")
-        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before)
-        self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before)
-
-    def test_rebroadcast_limit_expires_after_max_rebroadcasts(self):
-        """When TIMEOUT_POLICY=rebroadcast, task should requeue up to MAX_REBROADCAST_COUNT then expire and refund."""
-        old_policy = main.TIMEOUT_POLICY
-        old_max = main.MAX_REBROADCAST_COUNT
-        main.TIMEOUT_POLICY = "rebroadcast"
-        main.MAX_REBROADCAST_COUNT = 2
-        try:
-            consumer_priv, consumer_pub, consumer_id = _make_identity()
-            provider_priv, provider_pub, provider_id = _make_identity()
-            _register(consumer_pub)
-            _register(provider_pub)
-
-            consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
-
-            task_payload = json.dumps({"consumer_id": consumer_id, "payload": "rebroadcast me", "bounty": 1.0})
-            headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-            submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-            self.assertEqual(submit.status_code, 200, submit.text)
-            task_id = submit.json()["task_id"]
-
-            bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-            headers = _auth_headers(provider_priv, provider_id, bid_payload)
-            self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-            self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
-
-            import asyncio
-            from main import _sweep_assigned_timeouts
-
-            for i in range(3):
-                old_time = time.time() - 7200
-                conn = db._get_conn()
-                conn.execute("UPDATE tasks SET updated_at = ? WHERE task_id = ?", (old_time, task_id))
-                conn.commit()
-                db._release_conn(conn)
-
-                loop = asyncio.new_event_loop()
-                try:
-                    loop.run_until_complete(_sweep_assigned_timeouts())
-                finally:
-                    loop.close()
-
-                task = db.get_task(task_id)
-                if i < 2:
-                    self.assertEqual(task["status"], "bidding", f"Expected bidding after requeue {i+1}, got {task['status']}")
-                    self.assertEqual(task.get("rebroadcast_count", 0), i + 1)
-                    # Re-bid so next sweep can requeue again
-                    bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-                    headers = _auth_headers(provider_priv, provider_id, bid_payload)
-                    self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-                else:
-                    self.assertEqual(task["status"], "expired", f"Expected expired after hitting limit on iteration {i+1}, got {task['status']}")
-                    self.assertEqual(task.get("rebroadcast_count", 0), 2)
-
-            self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
-        finally:
-            main.TIMEOUT_POLICY = old_policy
-            main.MAX_REBROADCAST_COUNT = old_max
-
-class TestConsumerDefinedTimeout(unittest.TestCase):
-    """Per-task consumer timeout should override global default within bounds."""
-
-    def test_consumer_timeout_expires_task_earlier(self):
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-        _register(consumer_pub)
-
-        resp = client.get(f"/balance/{consumer_id}")
-        initial_balance = resp.json()["balance_seconds"]
-
-        bounty = 1.0
-        task_payload = json.dumps({
-            "consumer_id": consumer_id,
-            "payload": "Expire me quickly",
-            "bounty": bounty,
-            "expires_in_seconds": 60,
-        })
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
-        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
-        task_id = resp.json()["task_id"]
-
-        # This is older than the consumer timeout (60s) but younger than global default (3600s).
-        old_time = time.time() - 120
-        conn = db._get_conn()
-        conn.execute(
-            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
-            (old_time, task_id)
-        )
-        conn.commit()
-        db._release_conn(conn)
-
-        import asyncio
-        from main import _sweep_bidding_timeouts
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(_sweep_bidding_timeouts())
-        finally:
-            loop.close()
-
-        task = db.get_task(task_id)
-        self.assertIsNotNone(task)
-        self.assertEqual(task["status"], "expired")
-
-        resp = client.get(f"/balance/{consumer_id}")
-        self.assertEqual(resp.json()["balance_seconds"], initial_balance)
-
-
-if __name__ == "__main__":
-    unittest.main()
-
-
-
-class TestAutomatedVerifier(unittest.TestCase):
-
-    """Test lean automated verifier prototype."""
-
-
-
-    def test_automated_verifier_accepts_valid_json_result(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(submit.status_code, 200, submit.text)
-
-        task_id = submit.json()["task_id"]
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-
-
-        result_payload = json.dumps({"result": "success"})
-
-        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
-
-        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
-
-        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
-
-        self.assertEqual(complete.status_code, 200, complete.text)
-
-
-
-        # Admin triggers automated verification
-
-        verify_payload = json.dumps({"task_id": task_id})
-
-        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
-
-        self.assertEqual(verify_resp.status_code, 200, f"Verify failed: {verify_resp.text}")
-
-        result = verify_resp.json()
-
-        self.assertEqual(result["status"], "verified")
-
-        self.assertEqual(result["task_id"], task_id)
-
-
-
-        # Task should be completed
-
-        task = db.get_task(task_id)
-
-        self.assertEqual(task["status"], "completed")
-
-
-
-    def test_automated_verifier_rejects_invalid_json(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(submit.status_code, 200, submit.text)
-
-        task_id = submit.json()["task_id"]
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-
-
-        result_payload = "not valid json"
-
-        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
-
-        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
-
-        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
-
-        self.assertEqual(complete.status_code, 200, complete.text)
-
-
-
-        # Admin triggers automated verification
-
-        verify_payload = json.dumps({"task_id": task_id})
-
-        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
-
-        self.assertEqual(verify_resp.status_code, 400, f"Expected rejection: {verify_resp.text}")
-
-
-
-    def test_automated_verifier_rejects_empty_result(self):
-
-        consumer_priv, consumer_pub, consumer_id = _make_identity()
-
-        provider_priv, provider_pub, provider_id = _make_identity()
-
-        _register(consumer_pub)
-
-        _register(provider_pub)
-
-
-
-        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
-
-        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
-
-        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
-
-        self.assertEqual(submit.status_code, 200, submit.text)
-
-        task_id = submit.json()["task_id"]
-
-
-
-        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
-
-        headers = _auth_headers(provider_priv, provider_id, bid_payload)
-
-        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
-
-
-
-        result_payload = "   "  # whitespace-only should be rejected
-
-        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
-
-        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
-
-        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
-
-        self.assertEqual(complete.status_code, 200, complete.text)
-
-
-
-        # Admin triggers automated verification
-
-        verify_payload = json.dumps({"task_id": task_id})
-
-        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
-
+
+
+    def test_dm_queue_full_rejected(self):
+
+        sender_priv, sender_pub, sender_id = _make_identity()
+
+        _, target_pub, target_id = _make_identity()
+
+        _register(sender_pub)
+
+        _register(target_pub)
+
+        main.connected_nodes.pop(target_id, None)
+
+
+
+        original_cap = main.MAX_QUEUED_DMS_PER_NODE
+
+        main.MAX_QUEUED_DMS_PER_NODE = 1
+
+        try:
+
+            first = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="dm one")
+
+            self.assertEqual(first.json()["status"], "queued")
+
+            second = self._submit_offline_dm(sender_priv, sender_id, target_id, instructions="dm two")
+
+            self.assertEqual(second.json()["status"], "error")
+
+            self.assertIn("queue is full", second.json()["detail"])
+
+        finally:
+
+            main.MAX_QUEUED_DMS_PER_NODE = original_cap
+
+
+
+    def test_targeted_dm_to_offline_node_errors_when_queue_disabled(self):
+
+        sender_priv, sender_pub, sender_id = _make_identity()
+
+        _, target_pub, target_id = _make_identity()
+
+        _register(sender_pub)
+
+        _register(target_pub)
+
+        main.connected_nodes.pop(target_id, None)
+
+
+
+        original = main.DM_QUEUE_ENABLED
+
+        main.DM_QUEUE_ENABLED = False
+
+        try:
+
+            resp = self._submit_offline_dm(sender_priv, sender_id, target_id)
+
+            self.assertEqual(resp.status_code, 200)
+
+            self.assertEqual(resp.json()["status"], "error")
+
+            self.assertIn("not currently connected", resp.json()["detail"])
+
+        finally:
+
+            main.DM_QUEUE_ENABLED = original
+
+
+
+    def test_data_market_requires_secret_data(self):
+
+        seller_priv, seller_pub, seller_id = _make_identity()
+
+        _register(seller_pub)
+
+
+
+        task_payload = json.dumps(
+
+            {
+
+                "source": {"node_id": seller_id},
+
+                "intent": {"type": "conformance.request"},
+
+                "task": {
+
+                    "instructions": "premium dataset",
+
+                    "expected_output": {"result_type": "text"},
+
+                },
+
+                "economics": {
+
+                    "bounty_ns": 500_000_000,
+
+                    "currency": "MEP_NS",
+
+                    "market": "data",
+
+                    "payment_direction": "receiver_to_sender",
+
+                },
+
+            }
+
+        )
+
+        headers = _auth_headers(seller_priv, seller_id, task_payload)
+
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+
+
+        self.assertEqual(resp.status_code, 400)
+
+        self.assertIn("require secret_data", resp.json()["detail"])
+
+
+
+
+
+class TestInterBotSpecValidation(unittest.TestCase):
+
+    def test_rejects_invalid_structured_payload_when_enabled(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        _register(consumer_pub)
+
+        invalid_payload = json.dumps(
+
+            {
+
+                "consumer_id": consumer_id,
+
+                "payload": json.dumps({"spec_version": "mep.interbot.v1"}),
+
+                "bounty": 0.0,
+
+            }
+
+        )
+
+        headers = _auth_headers(consumer_priv, consumer_id, invalid_payload)
+
+        with _interbot_validation(True):
+
+            resp = client.post("/tasks/submit", content=invalid_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 400)
+
+        self.assertIn("Inter-bot payload", resp.json()["detail"])
+
+
+
+    def test_accepts_valid_structured_dm_payload_when_enabled(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        _, target_pub, target_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(target_pub)
+
+        message = {
+
+            "spec_version": "mep.interbot.v1",
+
+            "message_id": "msg-123",
+
+            "timestamp_ms": int(time.time() * 1000),
+
+            "source": {"node_id": consumer_id, "alias": "consumer"},
+
+            "target": {"node_id": target_id, "alias": "target"},
+
+            "intent": {"type": "chat.request"},
+
+            "task": {"instructions": "hello", "expected_output": {"result_type": "text"}},
+
+            "economics": {"bounty_seconds": 0.0, "currency": "SECONDS"},
+
+        }
+
+        task_payload = json.dumps(
+
+            {
+
+                "consumer_id": consumer_id,
+
+                "payload": json.dumps(message),
+
+                "bounty": 0.0,
+
+                "target_node": target_id,
+
+            }
+
+        )
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        with _interbot_validation(True):
+
+            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertIn(resp.json()["status"], ("success", "error", "queued"))
+
+
+
+    def test_rejects_legacy_plaintext_non_dm_when_enabled(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        _register(consumer_pub)
+
+        task_payload = json.dumps(
+
+            {
+
+                "consumer_id": consumer_id,
+
+                "payload": "legacy plaintext non-dm",
+
+                "bounty": 1.0,
+
+            }
+
+        )
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        with _interbot_validation(True):
+
+            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 400)
+
+        self.assertIn("Legacy plaintext payload", resp.json()["detail"])
+
+
+
+    def test_spec_shaped_task_bounty_ns_is_converted_to_seconds(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        _register(consumer_pub)
+
+
+
+        resp = client.get(f"/balance/{consumer_id}")
+
+        initial_balance = resp.json()["balance_seconds"]
+
+
+
+        task_payload = json.dumps(
+
+            {
+
+                "source": {"node_id": consumer_id},
+
+                "intent": {"type": "analysis.request"},
+
+                "task": {
+
+                    "instructions": "spec-shaped compute task",
+
+                    "expected_output": {"result_type": "text"},
+
+                },
+
+                "economics": {
+
+                    "bounty_ns": 1_000_000_000,
+
+                    "currency": "MEP_NS",
+
+                    "market": "compute",
+
+                    "payment_direction": "sender_to_receiver",
+
+                },
+
+                "routing": {"target_capability": "text"},
+
+            }
+
+        )
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        with _interbot_validation(True):
+
+            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+
+
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+
+        task_id = resp.json()["task_id"]
+
+        stored_task = db.get_task(task_id)
+
+        self.assertEqual(stored_task["bounty"], 1.0)
+
+
+
+        resp = client.get(f"/balance/{consumer_id}")
+
+        self.assertEqual(resp.json()["balance_seconds"], initial_balance - 1.0)
+
+
+
+    def test_rejects_obsolete_bounty_quanta_name(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        _register(consumer_pub)
+
+
+
+        task_payload = json.dumps(
+
+            {
+
+                "source": {"node_id": consumer_id},
+
+                "task": {
+
+                    "instructions": "obsolete unit name",
+
+                    "expected_output": {"result_type": "text"},
+
+                },
+
+                "economics": {
+
+                    "bounty_quanta": 1_000_000_000,
+
+                    "currency": "MEP_QUANTA",
+
+                    "market": "compute",
+
+                    "payment_direction": "sender_to_receiver",
+
+                },
+
+            }
+
+        )
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        with _interbot_validation(True):
+
+            resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+
+
+        self.assertEqual(resp.status_code, 400)
+
+        self.assertIn("MEP_NS", resp.json()["detail"])
+
+
+
+
+
+class TestAuthRejection(unittest.TestCase):
+
+
+
+    def test_invalid_signature_rejected(self):
+
+        priv, pub_pem, node_id = _make_identity()
+
+        _register(pub_pem)
+
+
+
+        payload = json.dumps({"consumer_id": node_id, "payload": "x", "bounty": 0.1})
+
+        headers = {
+
+            "X-MEP-NodeID": node_id,
+
+            "X-MEP-Timestamp": str(int(time.time())),
+
+            "X-MEP-Signature": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+
+            "Content-Type": "application/json",
+
+        }
+
+        resp = client.post("/tasks/submit", content=payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 401)
+
+
+
+    def test_unregistered_node_rejected(self):
+
+        priv, _, node_id = _make_identity()
+
+        # Don't register
+
+        payload = json.dumps({"consumer_id": node_id, "payload": "x", "bounty": 0.1})
+
+        headers = _auth_headers(priv, node_id, payload)
+
+        resp = client.post("/tasks/submit", content=payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 401)
+
+
+
+
+
+class TestDiagnosticEndpoint(unittest.TestCase):
+
+
+
+    def test_public_diagnostic_for_registered_node(self):
+
+        priv, pub_pem, node_id = _make_identity()
+
+        _register(pub_pem)
+
+        # Ensure node exists in registry table so public diagnostic can resolve it.
+
+        update_payload = json.dumps({"alias": "diag-node"})
+
+        headers = _auth_headers(priv, node_id, update_payload)
+
+        update_resp = client.post("/registry/update", content=update_payload, headers=headers)
+
+        self.assertEqual(update_resp.status_code, 200, f"Registry update failed: {update_resp.text}")
+
+
+
+        resp = client.get(f"/diagnostic?node_id={node_id}")
+
+        self.assertEqual(resp.status_code, 200)
+
+        data = resp.json()
+
+        self.assertEqual(data["node_id"], node_id)
+
+        self.assertTrue(data["registered"])
+
+        self.assertIn("availability", data)
+
+        self.assertIn("last_heartbeat", data)
+
+
+
+    def test_authenticated_diagnostic_rejects_invalid_signature(self):
+
+        _, pub_pem, node_id = _make_identity()
+
+        _register(pub_pem)
+
+        bad_headers = {
+
+            "X-MEP-NodeID": node_id,
+
+            "X-MEP-Timestamp": str(int(time.time())),
+
+            "X-MEP-Signature": "invalid-signature",
+
+        }
+
+        resp = client.get("/diagnostic", headers=bad_headers)
+
+        self.assertEqual(resp.status_code, 401)
+
+
+
+    def test_authenticated_diagnostic_succeeds_with_valid_signature(self):
+
+        priv, pub_pem, node_id = _make_identity()
+
+        _register(pub_pem)
+
+        headers = _diagnostic_headers(priv, node_id)
+
+        resp = client.get("/diagnostic", headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Diagnostic failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["node_id"], node_id)
+
+        self.assertIn("ws_connected", data)
+
+        self.assertIn("last_ws_activity", data)
+
+        self.assertTrue(data["auth_ok"])
+
+
+
+    def test_registry_update_can_persist_x25519_public_key(self):
+
+        priv, pub_pem, node_id = _make_identity()
+
+        _register(pub_pem)
+
+        update_payload = json.dumps({"alias": "diag-node", "x25519_public_key": "updated-encpub"})
+
+        headers = _auth_headers(priv, node_id, update_payload)
+
+
+
+        update_resp = client.post("/registry/update", content=update_payload, headers=headers)
+
+        self.assertEqual(update_resp.status_code, 200, f"Registry update failed: {update_resp.text}")
+
+
+
+        registry = db.get_registry(node_id)
+
+        self.assertIsNotNone(registry)
+
+        self.assertEqual(registry["x25519_public_key"], "updated-encpub")
+
+
+
+
+
+class TestOnboardDiagnose(unittest.TestCase):
+
+    def setUp(self):
+
+        main.onboard_diagnosis_counts.clear()
+
+        main.onboard_diagnosis_total = 0
+
+
+
+    def test_detects_auth_401_signature_or_timestamp(self):
+
+        payload = {
+
+            "node_id": "node_test",
+
+            "auth_status": "401",
+
+            "registered": True,
+
+        }
+
+        resp = client.post("/onboard/diagnose", json=payload)
+
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["root_cause"], "auth_401_signature_or_timestamp")
+
+        self.assertEqual(data["severity"], "high")
+
+        self.assertGreaterEqual(data["telemetry"]["total_requests"], 1)
+
+
+
+    def test_detects_ghost_online_without_ws(self):
+
+        payload = {
+
+            "node_id": "node_test",
+
+            "registered": True,
+
+            "ws_connected": False,
+
+            "heartbeat_seconds_ago": 15,
+
+            "auth_status": "ok",
+
+        }
+
+        resp = client.post("/onboard/diagnose", json=payload)
+
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["root_cause"], "ghost_online_no_ws_presence")
+
+        self.assertEqual(data["severity"], "high")
+
+
+
+    def test_returns_healthy_or_insufficient_signal_when_no_fault(self):
+
+        payload = {
+
+            "node_id": "node_test",
+
+            "registered": True,
+
+            "ws_connected": True,
+
+            "auth_status": "ok",
+
+            "dm_status": "ok",
+
+            "listener_contract_ok": True,
+
+            "ai_configured": True,
+
+        }
+
+        resp = client.post("/onboard/diagnose", json=payload)
+
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["root_cause"], "healthy_or_insufficient_signal")
+
+        self.assertEqual(data["severity"], "info")
+
+
+
+    def test_detects_auth_403_unregistered_or_policy(self):
+
+        payload = {
+
+            "node_id": "node_test",
+
+            "auth_status": "403",
+
+            "registered": False,
+
+        }
+
+        resp = client.post("/onboard/diagnose", json=payload)
+
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["root_cause"], "auth_403_unregistered_or_policy")
+
+        self.assertEqual(data["severity"], "high")
+
+
+
+    def test_detects_dm_pending_target_offline_or_route_issue(self):
+
+        payload = {
+
+            "node_id": "node_test",
+
+            "registered": True,
+
+            "ws_connected": True,
+
+            "auth_status": "ok",
+
+            "dm_status": "pending",
+
+        }
+
+        resp = client.post("/onboard/diagnose", json=payload)
+
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["root_cause"], "dm_pending_target_offline_or_route_issue")
+
+        self.assertEqual(data["severity"], "medium")
+
+
+
+    def test_detects_listener_payload_contract_mismatch(self):
+
+        payload = {
+
+            "node_id": "node_test",
+
+            "registered": True,
+
+            "ws_connected": True,
+
+            "auth_status": "ok",
+
+            "dm_status": "ok",
+
+            "listener_contract_ok": False,
+
+        }
+
+        resp = client.post("/onboard/diagnose", json=payload)
+
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["root_cause"], "listener_payload_contract_mismatch")
+
+        self.assertEqual(data["severity"], "medium")
+
+
+
+    def test_detects_heartbeat_interval_or_clock_drift(self):
+
+        payload = {
+
+            "node_id": "node_test",
+
+            "registered": True,
+
+            "ws_connected": True,
+
+            "auth_status": "ok",
+
+            "dm_status": "ok",
+
+            "listener_contract_ok": True,
+
+            "ai_configured": True,
+
+            "clock_skew_seconds": 400,
+
+        }
+
+        resp = client.post("/onboard/diagnose", json=payload)
+
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["root_cause"], "heartbeat_interval_or_clock_drift")
+
+        self.assertEqual(data["severity"], "medium")
+
+
+
+    def test_detects_ai_provider_config_invalid(self):
+
+        payload = {
+
+            "node_id": "node_test",
+
+            "registered": True,
+
+            "ws_connected": True,
+
+            "auth_status": "ok",
+
+            "dm_status": "ok",
+
+            "listener_contract_ok": True,
+
+            "ai_configured": False,
+
+        }
+
+        resp = client.post("/onboard/diagnose", json=payload)
+
+        self.assertEqual(resp.status_code, 200, f"Diagnose failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertEqual(data["root_cause"], "ai_provider_config_invalid")
+
+        self.assertEqual(data["severity"], "low")
+
+
+
+
+
+class TestRegistryHeartbeatPresence(unittest.TestCase):
+
+    def test_heartbeat_online_without_websocket_forces_offline(self):
+
+        node_priv, node_pub, node_id = _make_identity()
+
+        _register(node_pub)
+
+        heartbeat_payload = json.dumps({"availability": "online"})
+
+        headers = _auth_headers(node_priv, node_id, heartbeat_payload)
+
+        heartbeat_response = client.post("/registry/heartbeat", content=heartbeat_payload, headers=headers)
+
+        self.assertEqual(heartbeat_response.status_code, 200, f"Heartbeat failed: {heartbeat_response.text}")
+
+        self.assertEqual(heartbeat_response.json()["availability"], "offline")
+
+
+
+        registry_response = client.get(f"/registry/{node_id}")
+
+        self.assertEqual(registry_response.status_code, 200, f"Registry read failed: {registry_response.text}")
+
+        self.assertEqual(registry_response.json()["availability"], "offline")
+
+
+
+
+
+class TestMeshAssembly(unittest.TestCase):
+
+    def setUp(self):
+
+        conn = db._get_conn()
+
+        conn.execute("UPDATE agent_registry SET availability = 'offline'")
+
+        conn.commit()
+
+        db._release_conn(conn)
+
+        main.mesh_assemblies.clear()
+
+        main.connected_nodes.clear()
+
+
+
+    def _register_with_mesh_metadata(
+
+        self,
+
+        role: str,
+
+        *,
+
+        provider: str,
+
+        thinking_mode: str,
+
+        alias: str,
+
+        availability: str = "online",
+
+    ):
+
+        priv, pub, node_id = _make_identity()
+
+        _register(pub)
+
+        # Mesh role selection treats websocket presence as source of truth.
+
+        main.connected_nodes[node_id] = object()
+
+        update_payload = json.dumps(
+
+            {
+
+                "alias": alias,
+
+                "availability": availability,
+
+                "metadata": {
+
+                    "ai_provider": provider,
+
+                    "ai_status": "online",
+
+                    "thinking_mode": thinking_mode,
+
+                    "mesh_role_preference": role,
+
+                },
+
+            }
+
+        )
+
+        headers = _auth_headers(priv, node_id, update_payload)
+
+        resp = client.post("/registry/update", content=update_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Registry update failed: {resp.text}")
+
+        return priv, node_id
+
+
+
+    def test_mesh_assemble_complete_with_four_roles(self):
+
+        requester_priv, requester_id = self._register_with_mesh_metadata(
+
+            "strategist",
+
+            provider="deepseek",
+
+            thinking_mode="reasoning",
+
+            alias="Hermes",
+
+        )
+
+        self._register_with_mesh_metadata(
+
+            "implementer",
+
+            provider="yunwu",
+
+            thinking_mode="code_reading",
+
+            alias="Alisa",
+
+        )
+
+        self._register_with_mesh_metadata(
+
+            "facilitator",
+
+            provider="template",
+
+            thinking_mode="aggregation",
+
+            alias="Hub-Sentinel",
+
+        )
+
+        self._register_with_mesh_metadata(
+
+            "scout",
+
+            provider="echo",
+
+            thinking_mode="ack_only",
+
+            alias="Moltbot",
+
+        )
+
+
+
+        payload = json.dumps({"trigger": "brainstorm", "timeout_seconds": 180})
+
+        headers = _auth_headers(requester_priv, requester_id, payload)
+
+        resp = client.post("/mesh/assemble", content=payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Assemble failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertTrue(data["complete"])
+
+        self.assertEqual(
+
+            set(data["roles"].keys()),
+
+            {"strategist", "implementer", "facilitator", "scout"},
+
+        )
+
+
+
+    def test_mesh_assemble_degraded_when_insufficient_nodes(self):
+
+        requester_priv, requester_id = self._register_with_mesh_metadata(
+
+            "strategist",
+
+            provider="deepseek",
+
+            thinking_mode="reasoning",
+
+            alias="Solo",
+
+        )
+
+        payload = json.dumps({"trigger": "incident"})
+
+        headers = _auth_headers(requester_priv, requester_id, payload)
+
+        resp = client.post("/mesh/assemble", content=payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Assemble failed: {resp.text}")
+
+        data = resp.json()
+
+        self.assertFalse(data["complete"])
+
+        self.assertIn("degraded_warning", data)
+
+        self.assertIn("strategist", data["roles"])
+
+
+
+    def test_mesh_status_reports_drop_and_reassignment(self):
+
+        requester_priv, requester_id = self._register_with_mesh_metadata(
+
+            "strategist",
+
+            provider="deepseek",
+
+            thinking_mode="reasoning",
+
+            alias="Hermes",
+
+        )
+
+        self._register_with_mesh_metadata(
+
+            "implementer",
+
+            provider="yunwu",
+
+            thinking_mode="code_reading",
+
+            alias="Alisa",
+
+        )
+
+        self._register_with_mesh_metadata(
+
+            "facilitator",
+
+            provider="template",
+
+            thinking_mode="aggregation",
+
+            alias="Hub-Sentinel",
+
+        )
+
+        self._register_with_mesh_metadata(
+
+            "scout",
+
+            provider="echo",
+
+            thinking_mode="ack_only",
+
+            alias="Moltbot",
+
+        )
+
+        self._register_with_mesh_metadata(
+
+            "scout",
+
+            provider="echo",
+
+            thinking_mode="ack_only",
+
+            alias="Backup-Scout",
+
+        )
+
+
+
+        assemble_payload = json.dumps({"trigger": "planning"})
+
+        assemble_headers = _auth_headers(requester_priv, requester_id, assemble_payload)
+
+        assemble_resp = client.post("/mesh/assemble", content=assemble_payload, headers=assemble_headers)
+
+        self.assertEqual(assemble_resp.status_code, 200, f"Assemble failed: {assemble_resp.text}")
+
+        assembly = assemble_resp.json()
+
+        scout_node_id = assembly["roles"]["scout"]["node_id"]
+
+        db.update_registry_availability(scout_node_id, "offline", time.time())
+
+
+
+        status_headers = _auth_headers(requester_priv, requester_id, "")
+
+        status_resp = client.get(
+
+            f"/mesh/status?assembly_id={assembly['assembly_id']}",
+
+            headers=status_headers,
+
+        )
+
+        self.assertEqual(status_resp.status_code, 200, f"Status failed: {status_resp.text}")
+
+        status_data = status_resp.json()
+
+        self.assertFalse(status_data["complete"])
+
+        self.assertIn("scout", status_data["dropped_roles"])
+
+        self.assertIn("scout", status_data["reassignment_suggestions"])
+
+        self.assertNotEqual(
+
+            status_data["reassignment_suggestions"]["scout"]["node_id"],
+
+            scout_node_id,
+
+        )
+
+
+
+
+
+class TestBrainstormSessions(unittest.TestCase):
+
+    def setUp(self):
+
+        main.brainstorm_sessions.clear()
+
+
+
+    def test_create_post_and_read_session(self):
+
+        owner_priv, owner_pub, owner_id = _make_identity()
+
+        p1_priv, p1_pub, p1_id = _make_identity()
+
+        p2_priv, p2_pub, p2_id = _make_identity()
+
+        _register(owner_pub)
+
+        _register(p1_pub)
+
+        _register(p2_pub)
+
+
+
+        create_payload = json.dumps(
+
+            {
+
+                "owner_id": owner_id,
+
+                "participants": [p1_id, p2_id],
+
+                "topic": "Loop-free architecture",
+
+            }
+
+        )
+
+        create_headers = _auth_headers(owner_priv, owner_id, create_payload)
+
+        create_resp = client.post("/brainstorm/sessions/create", content=create_payload, headers=create_headers)
+
+        self.assertEqual(create_resp.status_code, 200, f"Create failed: {create_resp.text}")
+
+        session_id = create_resp.json()["session_id"]
+
+
+
+        post_payload = json.dumps(
+
+            {
+
+                "session_id": session_id,
+
+                "message": "I suggest we add a shared session timeline.",
+
+            }
+
+        )
+
+        post_headers = _auth_headers(p1_priv, p1_id, post_payload)
+
+        post_resp = client.post("/brainstorm/sessions/post", content=post_payload, headers=post_headers)
+
+        self.assertEqual(post_resp.status_code, 200, f"Post failed: {post_resp.text}")
+
+
+
+        get_headers = _auth_headers(p2_priv, p2_id, "")
+
+        get_resp = client.get(f"/brainstorm/sessions/{session_id}", headers=get_headers)
+
+        self.assertEqual(get_resp.status_code, 200, f"Get failed: {get_resp.text}")
+
+        data = get_resp.json()
+
+        self.assertEqual(data["topic"], "Loop-free architecture")
+
+        self.assertEqual(data["message_count"], 1)
+
+        self.assertEqual(data["messages"][0]["sender_id"], p1_id)
+
+
+
+    def test_non_participant_cannot_post(self):
+
+        owner_priv, owner_pub, owner_id = _make_identity()
+
+        p1_priv, p1_pub, p1_id = _make_identity()
+
+        outsider_priv, outsider_pub, outsider_id = _make_identity()
+
+        _register(owner_pub)
+
+        _register(p1_pub)
+
+        _register(outsider_pub)
+
+
+
+        create_payload = json.dumps({"owner_id": owner_id, "participants": [p1_id]})
+
+        create_headers = _auth_headers(owner_priv, owner_id, create_payload)
+
+        create_resp = client.post("/brainstorm/sessions/create", content=create_payload, headers=create_headers)
+
+        self.assertEqual(create_resp.status_code, 200)
+
+        session_id = create_resp.json()["session_id"]
+
+
+
+        post_payload = json.dumps({"session_id": session_id, "message": "Intruding message"})
+
+        post_headers = _auth_headers(outsider_priv, outsider_id, post_payload)
+
+        post_resp = client.post("/brainstorm/sessions/post", content=post_payload, headers=post_headers)
+
+        self.assertEqual(post_resp.status_code, 403)
+
+
+
+
+
+def tearDownModule():
+
+    """Clean up test database."""
+
+    try:
+
+        os.remove(_test_db)
+
+    except OSError:
+
+        pass
+
+
+
+class TestBiddingTimeout(unittest.TestCase):
+
+    """Test bidding task timeout + refund flow"""
+
+
+
+    def test_stale_bidding_task_expired_and_refunded(self):
+
+        """Verify stale bidding tasks are expired and bounty refunded to consumer"""
+
+        # Setup: consumer and provider
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(provider_pub)
+
+
+
+        # Get initial balance
+
+        resp = client.get(f"/balance/{consumer_id}")
+
+        initial_balance = resp.json()["balance_seconds"]
+
+
+
+        # Submit task with bounty (escrow created)
+
+        bounty = 1.0
+
+        task_payload = json.dumps({
+
+            "consumer_id": consumer_id,
+
+            "payload": "Stale task that will timeout",
+
+            "bounty": bounty,
+
+        })
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+
+        task_id = resp.json()["task_id"]
+
+
+
+        # Verify balance is escrowed (reduced by bounty)
+
+        resp = client.get(f"/balance/{consumer_id}")
+
+        self.assertLess(resp.json()["balance_seconds"], initial_balance,
+
+                       "Consumer balance should decrease by bounty")
+
+
+
+        # Simulate task aging: directly update task's updated_at in DB to be old
+
+        # (In real system, timeout worker does this after ASSIGNMENT_TIMEOUT_SECONDS)
+
+        import time as t
+
+        old_time = t.time() - 7200  # 2 hours ago (well beyond 1 hour timeout)
+
+        conn = db._get_conn()
+
+        conn.execute(
+
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+
+            (old_time, task_id)
+
+        )
+
+        conn.commit()
+
+        db._release_conn(conn)
+
+
+
+        # Run the bidding timeout sweep
+
+        import asyncio
+
+        from main import _sweep_bidding_timeouts
+
+        loop = asyncio.new_event_loop()
+
+        try:
+
+            loop.run_until_complete(_sweep_bidding_timeouts())
+
+        finally:
+
+            loop.close()
+
+
+
+        # Verify task status from DB helper (not /tasks/{task_id}, which does not exist)
+
+        task = db.get_task(task_id)
+
+        self.assertIsNotNone(task)
+
+        self.assertEqual(task["status"], "expired", "Task should be expired after timeout")
+
+
+
+        # Verify consumer balance is restored (refunded)
+
+        resp = client.get(f"/balance/{consumer_id}")
+
+        self.assertEqual(resp.json()["balance_seconds"], initial_balance,
+
+                        "Consumer balance should be restored after refund")
+
+
+
+    def test_assigned_data_market_timeout_refunds_buyer_escrow(self):
+
+        seller_priv, seller_pub, seller_id = _make_identity()
+
+        buyer_priv, buyer_pub, buyer_id = _make_identity()
+
+        _register(seller_pub)
+
+        _register(buyer_pub)
+
+
+
+        seller_before = client.get(f"/balance/{seller_id}").json()["balance_seconds"]
+
+        buyer_before = client.get(f"/balance/{buyer_id}").json()["balance_seconds"]
+
+        task_payload = json.dumps(
+
+            {
+
+                "consumer_id": seller_id,
+
+                "payload": "Premium dataset",
+
+                "bounty": -0.5,
+
+                "secret_data": "encrypted-premium-data",
+
+            }
+
+        )
+
+        headers = _auth_headers(seller_priv, seller_id, task_payload)
+
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+
+        task_id = resp.json()["task_id"]
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": buyer_id})
+
+        headers = _auth_headers(buyer_priv, buyer_id, bid_payload)
+
+        resp = client.post("/tasks/bid", content=bid_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Bid failed: {resp.text}")
+
+        self.assertEqual(resp.json()["status"], "accepted")
+
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before - 0.5)
+
+
+
+        old_time = time.time() - 7200
+
+        conn = db._get_conn()
+
+        conn.execute(
+
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+
+            (old_time, task_id)
+
+        )
+
+        conn.commit()
+
+        db._release_conn(conn)
+
+
+
+        import asyncio
+
+        from main import _sweep_assigned_timeouts
+
+        loop = asyncio.new_event_loop()
+
+        try:
+
+            loop.run_until_complete(_sweep_assigned_timeouts())
+
+        finally:
+
+            loop.close()
+
+
+
+        task = db.get_task(task_id)
+
+        self.assertEqual(task["status"], "expired")
+
+        self.assertEqual(client.get(f"/balance/{buyer_id}").json()["balance_seconds"], buyer_before)
+
+        self.assertEqual(client.get(f"/balance/{seller_id}").json()["balance_seconds"], seller_before)
+
+
+
+    def test_rebroadcast_limit_expires_after_max_rebroadcasts(self):
+
+        """When TIMEOUT_POLICY=rebroadcast, task should requeue up to MAX_REBROADCAST_COUNT then expire and refund."""
+
+        old_policy = main.TIMEOUT_POLICY
+
+        old_max = main.MAX_REBROADCAST_COUNT
+
+        main.TIMEOUT_POLICY = "rebroadcast"
+
+        main.MAX_REBROADCAST_COUNT = 2
+
+        try:
+
+            consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+            provider_priv, provider_pub, provider_id = _make_identity()
+
+            _register(consumer_pub)
+
+            _register(provider_pub)
+
+
+
+            consumer_before = client.get(f"/balance/{consumer_id}").json()["balance_seconds"]
+
+
+
+            task_payload = json.dumps({"consumer_id": consumer_id, "payload": "rebroadcast me", "bounty": 1.0})
+
+            headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+            submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+            self.assertEqual(submit.status_code, 200, submit.text)
+
+            task_id = submit.json()["task_id"]
+
+
+
+            bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+            headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+            self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+            self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before - 1.0)
+
+
+
+            import asyncio
+
+            from main import _sweep_assigned_timeouts
+
+
+
+            for i in range(3):
+
+                old_time = time.time() - 7200
+
+                conn = db._get_conn()
+
+                conn.execute("UPDATE tasks SET updated_at = ? WHERE task_id = ?", (old_time, task_id))
+
+                conn.commit()
+
+                db._release_conn(conn)
+
+
+
+                loop = asyncio.new_event_loop()
+
+                try:
+
+                    loop.run_until_complete(_sweep_assigned_timeouts())
+
+                finally:
+
+                    loop.close()
+
+
+
+                task = db.get_task(task_id)
+
+                if i < 2:
+
+                    self.assertEqual(task["status"], "bidding", f"Expected bidding after requeue {i+1}, got {task['status']}")
+
+                    self.assertEqual(task.get("rebroadcast_count", 0), i + 1)
+
+                    # Re-bid so next sweep can requeue again
+
+                    bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+                    headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+                    self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+                else:
+
+                    self.assertEqual(task["status"], "expired", f"Expected expired after hitting limit on iteration {i+1}, got {task['status']}")
+
+                    self.assertEqual(task.get("rebroadcast_count", 0), 2)
+
+
+
+            self.assertEqual(client.get(f"/balance/{consumer_id}").json()["balance_seconds"], consumer_before)
+
+        finally:
+
+            main.TIMEOUT_POLICY = old_policy
+
+            main.MAX_REBROADCAST_COUNT = old_max
+
+
+
+class TestConsumerDefinedTimeout(unittest.TestCase):
+
+    """Per-task consumer timeout should override global default within bounds."""
+
+
+
+    def test_consumer_timeout_expires_task_earlier(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        _register(consumer_pub)
+
+
+
+        resp = client.get(f"/balance/{consumer_id}")
+
+        initial_balance = resp.json()["balance_seconds"]
+
+
+
+        bounty = 1.0
+
+        task_payload = json.dumps({
+
+            "consumer_id": consumer_id,
+
+            "payload": "Expire me quickly",
+
+            "bounty": bounty,
+
+            "expires_in_seconds": 60,
+
+        })
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+        resp = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+        self.assertEqual(resp.status_code, 200, f"Submit failed: {resp.text}")
+
+        task_id = resp.json()["task_id"]
+
+
+
+        # This is older than the consumer timeout (60s) but younger than global default (3600s).
+
+        old_time = time.time() - 120
+
+        conn = db._get_conn()
+
+        conn.execute(
+
+            "UPDATE tasks SET updated_at = ? WHERE task_id = ?",
+
+            (old_time, task_id)
+
+        )
+
+        conn.commit()
+
+        db._release_conn(conn)
+
+
+
+        import asyncio
+
+        from main import _sweep_bidding_timeouts
+
+        loop = asyncio.new_event_loop()
+
+        try:
+
+            loop.run_until_complete(_sweep_bidding_timeouts())
+
+        finally:
+
+            loop.close()
+
+
+
+        task = db.get_task(task_id)
+
+        self.assertIsNotNone(task)
+
+        self.assertEqual(task["status"], "expired")
+
+
+
+        resp = client.get(f"/balance/{consumer_id}")
+
+        self.assertEqual(resp.json()["balance_seconds"], initial_balance)
+
+
+
+
+
+if __name__ == "__main__":
+
+    unittest.main()
+
+
+
+
+
+
+
+class TestAutomatedVerifier(unittest.TestCase):
+
+
+
+    """Test lean automated verifier prototype."""
+
+
+
+
+
+
+
+    def test_automated_verifier_accepts_valid_json_result(self):
+
+
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+
+
+        _register(consumer_pub)
+
+
+
+        _register(provider_pub)
+
+
+
+
+
+
+
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
+
+
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+
+
+        self.assertEqual(submit.status_code, 200, submit.text)
+
+
+
+        task_id = submit.json()["task_id"]
+
+
+
+
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+
+
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+
+
+
+
+
+
+        result_payload = json.dumps({"result": "success"})
+
+
+
+        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
+
+
+
+        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
+
+
+
+        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
+
+
+
+        self.assertEqual(complete.status_code, 200, complete.text)
+
+
+
+
+
+
+
+        # Admin triggers automated verification
+
+
+
+        verify_payload = json.dumps({"task_id": task_id})
+
+
+
+        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
+
+
+
+        self.assertEqual(verify_resp.status_code, 200, f"Verify failed: {verify_resp.text}")
+
+
+
+        result = verify_resp.json()
+
+
+
+        self.assertEqual(result["status"], "verified")
+
+
+
+        self.assertEqual(result["task_id"], task_id)
+
+
+
+
+
+
+
+        # Task should be completed
+
+
+
+        task = db.get_task(task_id)
+
+
+
+        self.assertEqual(task["status"], "completed")
+
+
+
+
+
+
+
+    def test_automated_verifier_rejects_invalid_json(self):
+
+
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+
+
+        _register(consumer_pub)
+
+
+
+        _register(provider_pub)
+
+
+
+
+
+
+
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
+
+
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+
+
+        self.assertEqual(submit.status_code, 200, submit.text)
+
+
+
+        task_id = submit.json()["task_id"]
+
+
+
+
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+
+
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+
+
+
+
+
+
+        result_payload = "not valid json"
+
+
+
+        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
+
+
+
+        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
+
+
+
+        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
+
+
+
+        self.assertEqual(complete.status_code, 200, complete.text)
+
+
+
+
+
+
+
+        # Admin triggers automated verification
+
+
+
+        verify_payload = json.dumps({"task_id": task_id})
+
+
+
+        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
+
+
+
+        self.assertEqual(verify_resp.status_code, 400, f"Expected rejection: {verify_resp.text}")
+
+
+
+
+
+
+
+    def test_automated_verifier_rejects_empty_result(self):
+
+
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+
+
+        provider_priv, provider_pub, provider_id = _make_identity()
+
+
+
+        _register(consumer_pub)
+
+
+
+        _register(provider_pub)
+
+
+
+
+
+
+
+        task_payload = json.dumps({"consumer_id": consumer_id, "payload": "test", "bounty": 1.0, "verifier_type": "automated"})
+
+
+
+        headers = _auth_headers(consumer_priv, consumer_id, task_payload)
+
+
+
+        submit = client.post("/tasks/submit", content=task_payload, headers=headers)
+
+
+
+        self.assertEqual(submit.status_code, 200, submit.text)
+
+
+
+        task_id = submit.json()["task_id"]
+
+
+
+
+
+
+
+        bid_payload = json.dumps({"task_id": task_id, "provider_id": provider_id})
+
+
+
+        headers = _auth_headers(provider_priv, provider_id, bid_payload)
+
+
+
+        self.assertEqual(client.post("/tasks/bid", content=bid_payload, headers=headers).status_code, 200)
+
+
+
+
+
+
+
+        result_payload = "   "  # whitespace-only should be rejected
+
+
+
+        complete_body = json.dumps({"task_id": task_id, "provider_id": provider_id, "result_payload": result_payload})
+
+
+
+        complete_headers = _auth_headers(provider_priv, provider_id, complete_body)
+
+
+
+        complete = client.post("/tasks/complete", content=complete_body, headers=complete_headers)
+
+
+
+        self.assertEqual(complete.status_code, 200, complete.text)
+
+
+
+
+
+
+
+        # Admin triggers automated verification
+
+
+
+        verify_payload = json.dumps({"task_id": task_id})
+
+
+
+        verify_resp = client.post("/tasks/verify/automated", json=json.loads(verify_payload), headers={"x-mep-admin-key": "test-admin-key"})
+
+
+
         self.assertEqual(verify_resp.status_code, 400, f"Expected rejection: {verify_resp.text}")

--- a/tests/test_node_task_envelope.py
+++ b/tests/test_node_task_envelope.py
@@ -51,3 +51,46 @@ def test_build_task_envelope_for_chat_and_data_markets():
         "payment_direction": "receiver_to_sender",
     }
     assert data["secret_data"] == "encrypted-data"
+
+
+def test_build_task_envelope_preserves_structured_task_metadata():
+    body = build_task_envelope(
+        "node_consumer",
+        "Audit this repository.",
+        0.0,
+        intent_type="repo_audit.request",
+        intent_priority="high",
+        target_capability="repo_audit",
+        expected_output={
+            "result_type": "repo_audit_result",
+            "format": "json",
+            "artifact_allowed": True,
+        },
+        task_title="Repo audit: github.com/WUAIBING/MEP",
+        task_inputs={
+            "repo_audit": {
+                "repo_url": "github.com/WUAIBING/MEP",
+                "audit_type": "architecture_audit",
+                "max_findings": 5,
+            }
+        },
+    )
+
+    assert body["intent"] == {"type": "repo_audit.request", "priority": "high"}
+    assert body["task"] == {
+        "instructions": "Audit this repository.",
+        "expected_output": {
+            "result_type": "repo_audit_result",
+            "format": "json",
+            "artifact_allowed": True,
+        },
+        "title": "Repo audit: github.com/WUAIBING/MEP",
+        "inputs": {
+            "repo_audit": {
+                "repo_url": "github.com/WUAIBING/MEP",
+                "audit_type": "architecture_audit",
+                "max_findings": 5,
+            }
+        },
+    }
+    assert body["routing"] == {"target_capability": "repo_audit"}

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -108,6 +108,58 @@ class TestSharedMEPClient(unittest.TestCase):
         )
         self.assertEqual(body["secret_data"], "encrypted-data")
 
+    def test_submit_repo_audit_builds_structured_repo_audit_request(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+
+            response = asyncio.run(
+                client.submit_repo_audit(
+                    "github.com/WUAIBING/MEP",
+                    audit_type="architecture_audit",
+                    ref="main",
+                    max_findings=7,
+                    inline_summary_max_chars=7000,
+                    artifact_preference="artifact_preferred",
+                    target_node="node_repo_bot",
+                )
+            )
+
+        self.assertEqual(response["json"]["task_id"], "task_123456")
+        body = json.loads(session.post.call_args.kwargs["data"])
+        self.assertEqual(body["intent"], {"type": "repo_audit.request", "priority": "high"})
+        self.assertEqual(body["routing"], {"target_node_id": "node_repo_bot", "target_capability": "repo_audit"})
+        self.assertEqual(body["task"]["title"], "Repo audit: github.com/WUAIBING/MEP")
+        self.assertEqual(
+            body["task"]["inputs"],
+            {
+                "repo_audit": {
+                    "repo_url": "github.com/WUAIBING/MEP",
+                    "audit_type": "architecture_audit",
+                    "max_findings": 7,
+                    "artifact_preference": "artifact_preferred",
+                    "inline_summary_max_chars": 7000,
+                    "ref": "main",
+                }
+            },
+        )
+        self.assertEqual(
+            body["task"]["expected_output"],
+            {
+                "result_type": "repo_audit_result",
+                "format": "json",
+                "artifact_allowed": True,
+                "inline_summary_max_chars": 7000,
+            },
+        )
+        self.assertIn("architecture_audit repo audit", body["task"]["instructions"])
+        self.assertIn("ref main", body["task"]["instructions"])
+        self.assertIn("include its URI", body["task"]["instructions"])
+
     def test_submit_task_preserves_200_error_body(self):
         response_body = {"status": "error", "detail": "Target node not currently connected to Hub"}
         with (


### PR DESCRIPTION
Summary: add structured repo-audit kickoff support, preserve structured task metadata through hub submit, bid, pending recovery, and queued DM replay, and add regression tests. Testing: python -m pytest tests/test_node_task_envelope.py tests/test_shared_mep_client.py tests/test_hub_api.py -q