### PR TITLE
Harden minimal hub deploy path

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -190,14 +190,30 @@ docker-compose ps
 
 ## Step 10: Update the Hub
 
+Use one clean deployment checkout for the live Hub. Do not build production from an old hand-maintained folder with local edits, or the live Hub can drift away from the merged repo code.
+
 When new versions are released:
 
 ```bash
 cd ~/mep-hub/MEP
-git pull origin main
-docker-compose down
-docker-compose build --no-cache
-docker-compose up -d
+git fetch origin
+export MEP_HUB_LOGS_DIR=~/mep-hub/MEP/hub_data
+./scripts/deploy_hub.sh origin/main
+```
+
+The deploy script does four things:
+
+1. Refuses to deploy from a dirty working tree
+2. Resolves the exact target commit SHA and checks it out
+3. Rebuilds and restarts only `mep-hub`
+4. Calls `http://127.0.0.1:8000/version` and verifies the live Hub reports the same `build_sha`
+
+Set `MEP_HUB_LOGS_DIR` when you deploy from a clean checkout but want to keep using the existing production log volume.
+
+You can also deploy an exact merged commit instead of `origin/main`:
+
+```bash
+./scripts/deploy_hub.sh 0bac07cc65da3b878971abebbfb95a239cd757d3
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,13 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./hub_data:/app/logs
+      - ${MEP_HUB_LOGS_DIR:-./hub_data}:/app/logs
     environment:
       - TZ=UTC
       - MEP_DATABASE_URL=${MEP_DATABASE_URL:?Set MEP_DATABASE_URL}
+      - MEP_BUILD_SHA=${MEP_BUILD_SHA:-dev}
+      - MEP_BUILD_TIME=${MEP_BUILD_TIME:-unknown}
+      - MEP_DEPLOY_SOURCE=${MEP_DEPLOY_SOURCE:-docker-compose}
     depends_on:
       - postgres
 

--- a/hub/main.py
+++ b/hub/main.py
@@ -69,6 +69,18 @@ mesh_lock = asyncio.Lock()
 CALL_RELAY_ENABLED = os.getenv("MEP_CALL_RELAY_ENABLED", "1") not in ("0", "false", "False")
 
 
+def _hub_build_info() -> dict[str, str]:
+    build_sha = str(os.getenv("MEP_BUILD_SHA", "unknown") or "unknown").strip() or "unknown"
+    build_time = str(os.getenv("MEP_BUILD_TIME", "unknown") or "unknown").strip() or "unknown"
+    deploy_source = str(os.getenv("MEP_DEPLOY_SOURCE", "unknown") or "unknown").strip() or "unknown"
+    return {
+        "app_version": app.version,
+        "build_sha": build_sha,
+        "build_time": build_time,
+        "deploy_source": deploy_source,
+    }
+
+
 async def _call_relay_send(node_id: str, message: dict) -> bool:
     """Deliver a call.* event to a node's current live socket (used by CallRelay)."""
     ws = connected_nodes.get(node_id)
@@ -1683,6 +1695,15 @@ async def start_timeout_worker():
     await _reconcile_live_registry_presence()
     asyncio.create_task(_assignment_timeout_worker())
     asyncio.create_task(_maintenance_worker())
+    build_info = _hub_build_info()
+    log_event(
+        "hub_build_info",
+        f"Hub build {build_info['build_sha']} ({build_info['deploy_source']})",
+        app_version=build_info["app_version"],
+        build_sha=build_info["build_sha"],
+        build_time=build_info["build_time"],
+        deploy_source=build_info["deploy_source"],
+    )
     if REQUIRE_TLS:
         log_event("transport_policy", "TLS enforcement enabled", require_tls=True, trust_proxy_proto=TRUST_PROXY_PROTO)
     else:
@@ -3041,6 +3062,18 @@ async def health_check():
     }
 
 
+@app.get("/version")
+async def hub_version():
+    build_info = _hub_build_info()
+    return {
+        "status": "ok",
+        "app_version": build_info["app_version"],
+        "build_sha": build_info["build_sha"],
+        "build_time": build_info["build_time"],
+        "deploy_source": build_info["deploy_source"],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Diagnostic Endpoint — tiered approach (per Hermes DM discussion)
 # ---------------------------------------------------------------------------
@@ -3465,6 +3498,7 @@ async def anti_loop_reset(channel: Optional[str] = None, x_mep_admin_key: Option
 
 @app.get("/", response_class=HTMLResponse)
 async def hub_landing(request: Request):
+    build_info = _hub_build_info()
     async with node_lock:
         online_count = len(connected_nodes)
     async with task_lock:
@@ -3508,7 +3542,7 @@ async def hub_landing(request: Request):
 <body>
   <div class="card">
     <div class="label">Welcome to MEP Hub 0</div>
-    <div>Version {app.version} Uptime {uptime} Status {status}</div>
+    <div>Version {build_info["app_version"]} Uptime {uptime} Status {status}</div>
     <div class="row">
       <div>
         <div class="kpi">{online_count}</div>
@@ -3526,6 +3560,10 @@ async def hub_landing(request: Request):
     <div class="section">
       <div class="label">Docs</div>
       <div><a href="https://github.com/WUAIBING/MEP/blob/main/README.md">GitHub README</a></div>
+    </div>
+    <div class="section">
+      <div class="label">Build</div>
+      <div class="mono">SHA={build_info["build_sha"]}<br>Time={build_info["build_time"]}<br>Source={build_info["deploy_source"]}<br>Version URL={base_url}/version</div>
     </div>
     <div class="section">
       <div class="label">How to connect</div>

--- a/hub/main.py
+++ b/hub/main.py
@@ -70,9 +70,9 @@ CALL_RELAY_ENABLED = os.getenv("MEP_CALL_RELAY_ENABLED", "1") not in ("0", "fals
 
 
 def _hub_build_info() -> dict[str, str]:
-    build_sha = str(os.getenv("MEP_BUILD_SHA", "unknown") or "unknown").strip() or "unknown"
-    build_time = str(os.getenv("MEP_BUILD_TIME", "unknown") or "unknown").strip() or "unknown"
-    deploy_source = str(os.getenv("MEP_DEPLOY_SOURCE", "unknown") or "unknown").strip() or "unknown"
+    build_sha = str(os.getenv("MEP_BUILD_SHA", "")).strip() or "unknown"
+    build_time = str(os.getenv("MEP_BUILD_TIME", "")).strip() or "unknown"
+    deploy_source = str(os.getenv("MEP_DEPLOY_SOURCE", "")).strip() or "unknown"
     return {
         "app_version": app.version,
         "build_sha": build_sha,

--- a/scripts/deploy_hub.sh
+++ b/scripts/deploy_hub.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET_REF="${1:-origin/main}"
+
+require_clean_tree() {
+  if [[ -n "$(git -C "$ROOT_DIR" status --porcelain --untracked-files=no)" ]]; then
+    echo "Refusing deploy: working tree is dirty in $ROOT_DIR" >&2
+    exit 1
+  fi
+}
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required tool: $1" >&2
+    exit 1
+  fi
+}
+
+require_tool git
+require_tool docker
+require_tool curl
+require_tool python3
+
+require_clean_tree
+
+git -C "$ROOT_DIR" fetch origin
+TARGET_SHA="$(git -C "$ROOT_DIR" rev-parse "$TARGET_REF")"
+git -C "$ROOT_DIR" checkout --force "$TARGET_SHA"
+
+export MEP_BUILD_SHA="$TARGET_SHA"
+export MEP_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+export MEP_DEPLOY_SOURCE="scripts/deploy_hub.sh"
+
+cd "$ROOT_DIR"
+docker compose up -d --build mep-hub
+
+VERSION_JSON="$(curl -fsS http://127.0.0.1:8000/version)"
+printf '%s' "$VERSION_JSON" | python3 - "$TARGET_SHA" <<'PY'
+import json
+import sys
+
+expected_sha = sys.argv[1]
+payload = json.loads(sys.stdin.read())
+
+if payload.get("build_sha") != expected_sha:
+    raise SystemExit(f"deploy smoke check failed: expected {expected_sha}, got {payload.get('build_sha')}")
+
+print(json.dumps(payload, indent=2))
+PY
+
+echo "Hub deploy smoke check passed for $TARGET_SHA"

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -138,6 +138,24 @@ class TestHealthEndpoint(unittest.TestCase):
         self.assertEqual(data["build_sha"], "abc123def")
         self.assertEqual(data["build_time"], "2026-07-06T13:30:00Z")
         self.assertEqual(data["deploy_source"], "scripts/deploy_hub.sh")
+
+    def test_version_falls_back_when_build_metadata_is_missing_or_blank(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "MEP_BUILD_SHA": "",
+                "MEP_BUILD_TIME": "   ",
+                "MEP_DEPLOY_SOURCE": "",
+            },
+            clear=False,
+        ):
+            resp = client.get("/version")
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["build_sha"], "unknown")
+        self.assertEqual(data["build_time"], "unknown")
+        self.assertEqual(data["deploy_source"], "unknown")
 
 
 class TestRegistration(unittest.TestCase):

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -118,6 +118,26 @@ class TestHealthEndpoint(unittest.TestCase):
         data = resp.json()
         self.assertEqual(data["status"], "ok")
         self.assertIn("metrics", data)
+
+    def test_version_reports_build_metadata_from_environment(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "MEP_BUILD_SHA": "abc123def",
+                "MEP_BUILD_TIME": "2026-07-06T13:30:00Z",
+                "MEP_DEPLOY_SOURCE": "scripts/deploy_hub.sh",
+            },
+            clear=False,
+        ):
+            resp = client.get("/version")
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "ok")
+        self.assertEqual(data["app_version"], app.version)
+        self.assertEqual(data["build_sha"], "abc123def")
+        self.assertEqual(data["build_time"], "2026-07-06T13:30:00Z")
+        self.assertEqual(data["deploy_source"], "scripts/deploy_hub.sh")
 
 
 class TestRegistration(unittest.TestCase):
@@ -948,6 +968,43 @@ class TestThreeMarketSpecConformance(unittest.TestCase):
         self.assertEqual(task["task"]["inputs"]["repo_audit"]["repo_url"], "github.com/WUAIBING/MEP")
         self.assertEqual(task["task"]["expected_output"]["result_type"], "repo_audit_result")
         self.assertEqual(task["intent"], {"type": "repo_audit.request"})
+
+    def test_live_targeted_delivery_preserves_structured_repo_audit_metadata(self):
+        sender_priv, sender_pub, sender_id = _make_identity()
+        _, target_pub, target_id = _make_identity()
+        _register(sender_pub)
+        _register(target_pub)
+
+        live_ws = _FakeWebSocket()
+        main.connected_nodes[target_id] = live_ws
+        try:
+            task_id = self._submit_spec_task(
+                sender_priv,
+                sender_id,
+                instructions="Audit github.com/WUAIBING/MEP.",
+                bounty_ns=0,
+                market="chat",
+                payment_direction="none",
+                target_node=target_id,
+                target_capability="repo_audit",
+                intent_type="repo_audit.request",
+                expected_output={"result_type": "repo_audit_result", "format": "json"},
+                task_title="Repo audit: github.com/WUAIBING/MEP",
+                task_inputs={"repo_audit": {"repo_url": "github.com/WUAIBING/MEP", "max_findings": 5}},
+            )
+        finally:
+            main.connected_nodes.pop(target_id, None)
+
+        self.assertEqual(len(live_ws.sent), 1)
+        event = live_ws.sent[0]
+        self.assertEqual(event["event"], "new_task")
+        task = event["data"]
+        self.assertEqual(task["id"], task_id)
+        self.assertEqual(task["intent"], {"type": "repo_audit.request"})
+        self.assertEqual(task["model_requirement"], "repo_audit")
+        self.assertEqual(task["task"]["title"], "Repo audit: github.com/WUAIBING/MEP")
+        self.assertEqual(task["task"]["expected_output"]["result_type"], "repo_audit_result")
+        self.assertEqual(task["task"]["inputs"]["repo_audit"]["repo_url"], "github.com/WUAIBING/MEP")
 
     def test_bid_response_preserves_structured_task_metadata(self):
         consumer_priv, consumer_pub, consumer_id = _make_identity()


### PR DESCRIPTION
Summary: add Hub build/version visibility, add an exact-SHA deploy script and docs, make the Hub log volume configurable for clean deploy checkouts, and cover structured repo_audit live delivery plus version reporting with targeted tests. Testing: python -m pytest tests/test_hub_api.py -k " version_reports_build_metadata_from_environment or live_targeted_delivery_preserves_structured_repo_audit_metadata or pending_tasks_endpoint_preserves_structured_task_metadata\