### PR TITLE
Harden repo audit workspace fetch

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -1515,7 +1515,7 @@ class WorkspaceManager:
         self.base_dir = os.path.abspath(base_dir)
         os.makedirs(self.base_dir, exist_ok=True)
 
-    def _run_git(self, cwd: str, args: list[str]) -> tuple[int, str]:
+    def _run_git(self, cwd: str, args: list[str], *, timeout_seconds: int = 60) -> tuple[int, str]:
         try:
             result = subprocess.run(
                 ["git", *args],
@@ -1523,7 +1523,7 @@ class WorkspaceManager:
                 capture_output=True,
                 text=True,
                 check=False,
-                timeout=60,
+                timeout=timeout_seconds,
             )
             return result.returncode, (result.stdout + result.stderr).strip()
         except Exception as exc:  # noqa: BLE001
@@ -1593,26 +1593,60 @@ class WorkspaceManager:
         normalized_repo_url = self._normalize_repo_clone_url(repo_url)
         if not normalized_repo_url:
             return False, "repo_url is empty"
+        git_timeout_seconds = _env_positive_int("MEP_REPO_AUDIT_GIT_TIMEOUT_SECONDS", 180)
+        target_ref = str(ref or "").strip()
+        fetch_ref = target_ref.removeprefix("origin/") if target_ref.startswith("origin/") else target_ref
         workspace_path = os.path.join(self.base_dir, "repo-audit", self._workspace_slug(normalized_repo_url))
         os.makedirs(os.path.dirname(workspace_path), exist_ok=True)
         if not os.path.exists(os.path.join(workspace_path, ".git")):
             print(f"[mep repo_audit] cloning {normalized_repo_url} into {workspace_path}")
-            code, out = self._run_git(os.path.dirname(workspace_path), ["clone", normalized_repo_url, os.path.basename(workspace_path)])
+            clone_args = ["clone", "--no-tags"]
+            if fetch_ref:
+                clone_args.extend(["--single-branch", "--branch", fetch_ref])
+            clone_args.extend([normalized_repo_url, os.path.basename(workspace_path)])
+            code, out = self._run_git(
+                os.path.dirname(workspace_path),
+                clone_args,
+                timeout_seconds=git_timeout_seconds,
+            )
             if code != 0:
-                return False, f"clone failed: {out}"
-        print(f"[mep repo_audit] fetching workspace for {normalized_repo_url}")
-        code, out = self._run_git(workspace_path, ["fetch", "--all", "--tags"])
-        if code != 0:
-            return False, f"fetch failed: {out}"
-        target_ref = str(ref or "").strip()
-        checkout_candidates = [target_ref] if target_ref else []
+                if fetch_ref:
+                    fallback_clone_args = ["clone", "--no-tags", normalized_repo_url, os.path.basename(workspace_path)]
+                    code, out = self._run_git(
+                        os.path.dirname(workspace_path),
+                        fallback_clone_args,
+                        timeout_seconds=git_timeout_seconds,
+                    )
+                if code != 0:
+                    return False, f"clone failed: {out}"
+        fetch_plans: list[list[str]] = []
+        if fetch_ref:
+            fetch_plans.append(["fetch", "--no-tags", "origin", fetch_ref])
+        fetch_plans.append(["fetch", "--no-tags", "origin"])
+        last_fetch_error = ""
+        for fetch_args in fetch_plans:
+            print(f"[mep repo_audit] fetching workspace for {normalized_repo_url} with {' '.join(fetch_args[1:])}")
+            code, out = self._run_git(workspace_path, fetch_args, timeout_seconds=git_timeout_seconds)
+            if code == 0:
+                last_fetch_error = ""
+                break
+            last_fetch_error = out
+        if last_fetch_error:
+            return False, f"fetch failed: {last_fetch_error}"
+        checkout_candidates = ["FETCH_HEAD"] if target_ref else []
+        if target_ref:
+            checkout_candidates.append(target_ref)
         if target_ref and not target_ref.startswith("origin/"):
             checkout_candidates.append(f"origin/{target_ref}")
         if not checkout_candidates:
             checkout_candidates = ["origin/HEAD"]
         last_error = ""
         for candidate in checkout_candidates:
-            code, out = self._run_git(workspace_path, ["checkout", "--force", candidate])
+            code, out = self._run_git(
+                workspace_path,
+                ["checkout", "--force", candidate],
+                timeout_seconds=git_timeout_seconds,
+            )
             if code == 0:
                 return True, workspace_path
             last_error = out

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -1636,6 +1636,62 @@ class TestWorkspaceReviewContext(unittest.TestCase):
         self.assertIn("README.md", ctx)
         self.assertIn("runtime_main", ctx)
 
+    def test_sync_repo_audit_workspace_fetches_target_ref_without_all_tags(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wm = mep_runtime.WorkspaceManager(tmp)
+            workspace_path = os.path.join(
+                tmp,
+                "repo-audit",
+                wm._workspace_slug("https://github.com/WUAIBING/MEP.git"),  # noqa: SLF001
+            )
+            os.makedirs(os.path.join(workspace_path, ".git"), exist_ok=True)
+            calls: list[tuple[str, list[str], int]] = []
+
+            def fake_run_git(cwd, args, *, timeout_seconds=60):
+                calls.append((cwd, list(args), timeout_seconds))
+                if args[:4] == ["fetch", "--no-tags", "origin", "main"]:
+                    return 0, "fetched"
+                if args[:3] == ["checkout", "--force", "FETCH_HEAD"]:
+                    return 0, "checked out"
+                return 0, ""
+
+            with patch.object(wm, "_run_git", side_effect=fake_run_git):
+                ok, path = wm.sync_repo_audit_workspace("github.com/WUAIBING/MEP", "main")
+
+        self.assertTrue(ok)
+        self.assertEqual(path, workspace_path)
+        self.assertEqual(calls[0][1], ["fetch", "--no-tags", "origin", "main"])
+        self.assertEqual(calls[1][1], ["checkout", "--force", "FETCH_HEAD"])
+        self.assertTrue(all("--all" not in args and "--tags" not in args for _cwd, args, _timeout in calls))
+
+    def test_sync_repo_audit_workspace_uses_repo_audit_git_timeout_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wm = mep_runtime.WorkspaceManager(tmp)
+            workspace_path = os.path.join(
+                tmp,
+                "repo-audit",
+                wm._workspace_slug("https://github.com/WUAIBING/MEP.git"),  # noqa: SLF001
+            )
+            os.makedirs(os.path.join(workspace_path, ".git"), exist_ok=True)
+            calls: list[tuple[str, list[str], int]] = []
+
+            def fake_run_git(cwd, args, *, timeout_seconds=60):
+                calls.append((cwd, list(args), timeout_seconds))
+                if args[:3] == ["checkout", "--force", "FETCH_HEAD"]:
+                    return 0, "checked out"
+                return 0, "ok"
+
+            with (
+                patch.dict(os.environ, {"MEP_REPO_AUDIT_GIT_TIMEOUT_SECONDS": "240"}),
+                patch.object(wm, "_run_git", side_effect=fake_run_git),
+            ):
+                ok, path = wm.sync_repo_audit_workspace("github.com/WUAIBING/MEP", "main")
+
+        self.assertTrue(ok)
+        self.assertEqual(path, workspace_path)
+        self.assertTrue(calls)
+        self.assertTrue(all(timeout == 240 for _cwd, _args, timeout in calls))
+
     def test_render_structured_repo_audit_filters_findings_to_inventory(self):
         task_data = {
             "intent": {"type": "repo_audit.request"},


### PR DESCRIPTION
Summary: make repo_audit workspace sync use targeted no-tags fetches instead of broad fetch --all --tags, add a dedicated repo-audit git timeout, and cover the new fetch path with focused runtime tests. Testing: python -m pytest tests/test_node_runtime.py -k " sync_repo_audit_workspace or process_task_appends_synced_repo_audit_context_and_inventory or process_task_fails_closed_when_repo_audit_workspace_sync_fails or build_repo_audit_context_returns_inventory_and_key_files\