### PR TITLE
Keep stdio adapters alive without stdin

### DIFF
--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -22,6 +22,12 @@ class StdioAdapter:
         self._recent_interbot_results: dict[str, dict[str, Any]] = {}
         self.live_call_enabled = os.getenv("MEP_LIVE_CALL_ENABLED", "0") not in ("0", "false", "False", "")
         self.call_auto_accept = os.getenv("MEP_CALL_AUTO_ACCEPT", "0") not in ("0", "false", "False", "")
+        self.noninteractive_keepalive = os.getenv("MEP_NONINTERACTIVE_KEEPALIVE", "0") not in (
+            "0",
+            "false",
+            "False",
+            "",
+        )
         self._call_seq_by_context: dict[str, int] = {}
 
     async def _handle_result(self, data: dict) -> None:
@@ -1163,8 +1169,12 @@ class StdioAdapter:
             "mepdmx, mepdmlist, mepdmsnapshot, mepdmhumanapproval, mepdmverdict, mepdmreplysafe, "
             "mepdata, mepcancel, mepresult, mepbalance, exit"
         )
-        loop = asyncio.get_running_loop()
         try:
+            if self.noninteractive_keepalive:
+                print(f"[{self.platform_name}] noninteractive keepalive enabled; stdin loop disabled")
+                await listener
+                return
+            loop = asyncio.get_running_loop()
             keep_going = True
             while keep_going:
                 line = await loop.run_in_executor(None, input, f"{self.platform_name}> ")

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -17,6 +17,24 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
         adapter = StdioAdapter("codex", "codex-agent", "unused.pem")
         return adapter, client
 
+    async def test_run_in_noninteractive_keepalive_mode_skips_stdin_loop(self):
+        with patch.dict(os.environ, {"MEP_NONINTERACTIVE_KEEPALIVE": "true"}):
+            adapter, client = self._make_adapter()
+        client.register = AsyncMock()
+        client.listen_results = AsyncMock(return_value=None)
+        client.stop = unittest.mock.Mock()
+
+        with (
+            patch("builtins.input", side_effect=AssertionError("stdin should not be read")),
+            patch("builtins.print") as print_mock,
+        ):
+            await adapter.run()
+
+        client.register.assert_awaited_once()
+        client.listen_results.assert_awaited_once()
+        client.stop.assert_called_once()
+        print_mock.assert_any_call("[codex] noninteractive keepalive enabled; stdin loop disabled")
+
     async def test_handle_result_stores_structured_interbot_payload(self):
         adapter, client = self._make_adapter()
         payload = json.dumps(


### PR DESCRIPTION
## Summary
- keep stdio adapters alive in noninteractive systemd mode instead of reading stdin
- add regression coverage for noninteractive keepalive behavior
- preserve interactive stdin loop for local adapter use

## Testing
- python -m pytest -q tests/test_stdio_adapter.py