### PR TITLE
Keep stdio adapters alive without stdin

### DIFF
--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -22,6 +22,12 @@ class StdioAdapter:
         self._recent_interbot_results: dict[str, dict[str, Any]] = {}
         self.live_call_enabled = os.getenv("MEP_LIVE_CALL_ENABLED", "0") not in ("0", "false", "False", "")
         self.call_auto_accept = os.getenv("MEP_CALL_AUTO_ACCEPT", "0") not in ("0", "false", "False", "")
+        self.noninteractive_keepalive = os.getenv("MEP_NONINTERACTIVE_KEEPALIVE", "0") not in (
+            "0",
+            "false",
+            "False",
+            "",
+        )
         self._call_seq_by_context: dict[str, int] = {}
 
     async def _handle_result(self, data: dict) -> None:
@@ -1163,8 +1169,12 @@ class StdioAdapter:
             "mepdmx, mepdmlist, mepdmsnapshot, mepdmhumanapproval, mepdmverdict, mepdmreplysafe, "
             "mepdata, mepcancel, mepresult, mepbalance, exit"
         )
-        loop = asyncio.get_running_loop()
         try:
+            if self.noninteractive_keepalive:
+                print(f"[{self.platform_name}] noninteractive keepalive enabled; stdin loop disabled")
+                await listener
+                return
+            loop = asyncio.get_running_loop()
             keep_going = True
             while keep_going:
                 line = await loop.run_in_executor(None, input, f"{self.platform_name}> ")

--- a/tests/test_stdio_adapter.py
+++ b/tests/test_stdio_adapter.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import tempfile
@@ -40,6 +41,36 @@ class TestStdioAdapter(unittest.IsolatedAsyncioTestCase):
         print_mock.assert_any_call(
             "[codex] stored structured dm result task_review_request context=pr154-review"
         )
+
+    async def test_run_keeps_listener_alive_without_stdin_when_noninteractive(self):
+        adapter, client = self._make_adapter()
+        adapter.noninteractive_keepalive = True
+        listener_started = asyncio.Event()
+        listener_released = asyncio.Event()
+
+        async def _fake_listener(_result_cb, _event_cb):
+            listener_started.set()
+            await listener_released.wait()
+
+        client.register = AsyncMock()
+        client.listen_results = AsyncMock(side_effect=_fake_listener)
+
+        with patch("builtins.input", side_effect=AssertionError("input should not be called")), patch(
+            "builtins.print"
+        ) as print_mock:
+            run_task = asyncio.create_task(adapter.run())
+            await listener_started.wait()
+            await asyncio.sleep(0)
+            self.assertFalse(run_task.done())
+            run_task.cancel()
+            listener_released.set()
+            with self.assertRaises(asyncio.CancelledError):
+                await run_task
+
+        client.register.assert_awaited_once()
+        client.listen_results.assert_awaited_once()
+        client.stop.assert_called_once()
+        print_mock.assert_any_call("[codex] noninteractive keepalive enabled; stdin loop disabled")
 
     async def test_dispatch_line_structured_dm_accepts_session_safety_flags(self):
         adapter, client = self._make_adapter()


### PR DESCRIPTION
## Summary
- add a noninteractive keepalive mode to the shared stdio adapter so systemd-launched bots do not crash on stdin EOF
- keep the websocket listener alive when MEP_NONINTERACTIVE_KEEPALIVE=true`n- add a regression test proving noninteractive mode never touches input and keeps the listener running

## Testing
- python -m pytest -q tests/test_stdio_adapter.py