### PR TITLE
Finalize bridge status persistence

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -3079,33 +3079,46 @@ class GitHubToMEPBridgeService:
         expected_target = claims.get("target_node_id")
         if expected_target and update.target_node_id and expected_target != update.target_node_id:
             raise HTTPException(status_code=403, detail="target_node_id mismatch")
-        self.store.update_execution(
-            update.bridge_id,
-            status=update.status,
-            task_id=update.task_id,
-            action=update.action,
-        )
-        refreshed = self.store.get_execution(update.bridge_id)
         resolved_action = update.action
-        if refreshed is None:
-            raise HTTPException(status_code=404, detail="Unknown bridge_id")
+        refreshed = execution
         if str(update.status).strip().lower() == "completed":
-            resolved_action, suppression_reason, review_result = self._write_back_to_github(refreshed, update)
+            resolved_action, suppression_reason, review_result = self._write_back_to_github(execution, update)
+            retry_queued = False
             if resolved_action == "suppressed":
-                retry_count = int(refreshed.get("retry_count") or 0)
+                retry_count = int(execution.get("retry_count") or 0)
                 if retry_count < 2 and self._suppression_reason_allows_retry(suppression_reason):  # MAX_RETRIES = 2
-                    retry_queued = await self._issue_retry_task(refreshed, suppression_reason)
+                    retry_queued = await self._issue_retry_task(execution, suppression_reason)
                     if retry_queued:
                         resolved_action = "retrying"
-            if resolved_action != update.action:
-                self.store.update_execution(update.bridge_id, action=resolved_action)
-                refreshed = self.store.get_execution(update.bridge_id) or refreshed
             if review_result is not None:
                 review_result["resolved_action"] = resolved_action
-                review_result["retry_queued"] = resolved_action == "retrying"
+                review_result["retry_queued"] = retry_queued
+                if retry_queued:
+                    refreshed = self.store.get_execution(update.bridge_id) or execution
                 review_result["retry_count"] = int(refreshed.get("retry_count") or 0)
-                self.store.update_execution(update.bridge_id, review_result=review_result)
-                refreshed = self.store.get_execution(update.bridge_id) or refreshed
+            if retry_queued:
+                self.store.update_execution(
+                    update.bridge_id,
+                    action=resolved_action,
+                    review_result=review_result,
+                )
+            else:
+                self.store.update_execution(
+                    update.bridge_id,
+                    status=update.status,
+                    task_id=update.task_id,
+                    action=resolved_action,
+                    review_result=review_result,
+                )
+            refreshed = self.store.get_execution(update.bridge_id) or refreshed
+        else:
+            self.store.update_execution(
+                update.bridge_id,
+                status=update.status,
+                task_id=update.task_id,
+                action=update.action,
+            )
+            refreshed = self.store.get_execution(update.bridge_id) or execution
         event = NormalizedGitHubEvent(
             delivery_id="",
             source_event="",

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1087,14 +1087,71 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(update_mock.call_args.kwargs["task_id"], "task-completed-atomic")
         self.assertEqual(update_mock.call_args.kwargs["action"], "reviewed")
         self.assertTrue(update_mock.call_args.kwargs["review_result"]["published"])
+        self.assertEqual(
+            update_mock.call_args.kwargs["review_result"],
+            {
+                "published": True,
+                "suppressed": False,
+                "resolved_action": "reviewed",
+                "retry_queued": False,
+                "retry_count": 0,
+            },
+        )
 
         execution = self.store.get_execution(bridge_id)
         assert execution is not None
         self.assertEqual(execution["status"], "completed")
         self.assertEqual(execution["task_id"], "task-completed-atomic")
         self.assertEqual(execution["action"], "reviewed")
-        self.assertTrue(execution["review_result"]["published"])
-        self.assertFalse(execution["review_result"]["retry_queued"])
+        self.assertEqual(
+            execution["review_result"],
+            {
+                "published": True,
+                "suppressed": False,
+                "resolved_action": "reviewed",
+                "retry_queued": False,
+                "retry_count": 0,
+            },
+        )
+
+    def test_completed_status_callback_preserves_retrying_execution_state(self):
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=247),
+            delivery_id="delivery-completed-retrying-state",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-completed-retrying",
+                "detail": "Too short review",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(len(self.submission.calls), 2)
+        self.assertIn("action: retrying", self.notifier.calls[-1]["text"])
+
+        execution = self.store.get_execution(bridge_id)
+        assert execution is not None
+        self.assertEqual(execution["status"], "queued")
+        self.assertEqual(execution["task_id"], "task-2")
+        self.assertEqual(execution["action"], "retrying")
+        self.assertEqual(execution["retry_count"], 1)
+        self.assertEqual(execution["review_result"]["resolved_action"], "retrying")
+        self.assertTrue(execution["review_result"]["retry_queued"])
+        self.assertEqual(execution["review_result"]["retry_count"], 1)
+        self.assertTrue(execution["review_result"]["suppressed"])
+        self.assertFalse(execution["review_result"]["published"])
 
     def test_review_benchmarks_endpoint_returns_seeded_catalog(self):
         response = self.client.get("/bridge/review-benchmarks")

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1047,6 +1047,55 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(payload["summary"]["feedback_pending_count"], 1)
         self.assertEqual(payload["summary"]["feedback_label_coverage"], 0.0)
 
+    def test_completed_status_callback_persists_final_state_in_single_write(self):
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=248),
+            delivery_id="delivery-completed-atomic",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        with patch.object(
+            self.service,
+            "_write_back_to_github",
+            return_value=("reviewed", None, {"published": True, "suppressed": False}),
+        ) as writeback_mock, patch.object(
+            self.store,
+            "update_execution",
+            wraps=self.store.update_execution,
+        ) as update_mock:
+            status_response = self.client.post(
+                "/bridge/status",
+                json={
+                    "bridge_id": bridge_id,
+                    "status": "completed",
+                    "target_node_id": "node_target",
+                    "task_id": "task-completed-atomic",
+                    "action": "reviewed",
+                    "detail": "Grounded final review body.",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        writeback_mock.assert_called_once()
+        self.assertEqual(update_mock.call_count, 1)
+        self.assertEqual(update_mock.call_args.args[0], bridge_id)
+        self.assertEqual(update_mock.call_args.kwargs["status"], "completed")
+        self.assertEqual(update_mock.call_args.kwargs["task_id"], "task-completed-atomic")
+        self.assertEqual(update_mock.call_args.kwargs["action"], "reviewed")
+        self.assertTrue(update_mock.call_args.kwargs["review_result"]["published"])
+
+        execution = self.store.get_execution(bridge_id)
+        assert execution is not None
+        self.assertEqual(execution["status"], "completed")
+        self.assertEqual(execution["task_id"], "task-completed-atomic")
+        self.assertEqual(execution["action"], "reviewed")
+        self.assertTrue(execution["review_result"]["published"])
+        self.assertFalse(execution["review_result"]["retry_queued"])
+
     def test_review_benchmarks_endpoint_returns_seeded_catalog(self):
         response = self.client.get("/bridge/review-benchmarks")
         self.assertEqual(response.status_code, 200, response.text)


### PR DESCRIPTION
## Summary
- finalize completed bridge callbacks in a single final-state DB write when no retry is queued
- preserve the retry path while appending resolved action and review metadata after retry submission
- add a focused regression test to prevent half-finished eview_result_json exposure

## Testing
- python -m pytest -q tests/test_github_bridge.py -k " completed_status_callback_persists_final_state_in_single_write or review_trials_endpoint_returns_latest_trial_results\