### PR TITLE
Add same-file repo audit veto gate

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -664,7 +664,8 @@ def _system_prompt_for_task(
             '"findings": [{"file": string, "title": string, "category": string, "severity": "high|medium|low", '
             '"confidence": "high|medium|low", "invariant": string, "failure_mode": string, "proof_type": string, '
             '"fix_priority": "fix_now|next_change|later", "developer_impact": string, "evidence": string, '
-            '"supporting_files": [string], "contradiction_check": string, "contradicted_by": [string], "next_step": string}], '
+            '"supporting_files": [string], "same_file_check": string, "same_file_contradicted_by": [string], '
+            '"contradiction_check": string, "contradicted_by": [string], "next_step": string}], '
             '"near_misses": [{"file": string, "title": string, "reason_not_published": string}], '
             '"observations": [{"file": string, "note": string}], '
             '"artifact_recommended": boolean}. '
@@ -680,6 +681,8 @@ def _system_prompt_for_task(
             "Only publish a finding when the supplied repo context directly supports it. "
             "Every published finding must name the impacted file, explain the developer impact, cite concrete evidence from the supplied repo context, and give one short next step. "
             "For every high-severity finding, include `supporting_files` with the impacted file plus at least one additional deep-read file that proves the caller, guard, or enforcement path. "
+            "For every high-severity finding, fill `same_file_check` with the exact guard, branch, condition, or identifier from the impacted file that you checked to rule out a local contradiction. "
+            "If the impacted file itself contains a nearby guard, branch, or identifier that weakens the claim, list it in `same_file_contradicted_by` and demote the claim into `near_misses` instead of publishing it as a finding. "
             "Use `contradiction_check` to say which neighboring guard, caller, or enforcement path you checked for contradictory evidence before publishing the claim. "
             "If any supplied file or identifier materially weakens the claim, list it in `contradicted_by` and demote the claim into `near_misses` instead of publishing it as a finding. "
             "If a candidate issue is plausible but did not clear the publication bar, put it in `near_misses` with a short reason instead of promoting it to a finding. "
@@ -1105,7 +1108,9 @@ def _verification_system_prompt_for_repo_audit(task_data: dict[str, Any], *, rev
         "For every published finding, set `file` to one tracked file from the supplied inventory and make the finding invariant-backed, failure-specific, and developer-impactful. "
         "Every published finding file must also appear in `files_deep_read`. "
         "Every published finding must cite at least one exact identifier, config key, test, or code path from the supplied workspace context in `evidence`; generic statements like 'this file controls the path' are not enough. "
-        "For every high-severity finding, include `supporting_files` with the impacted file plus at least one additional deep-read file that proves the caller, guard, or enforcement path, and fill `contradiction_check` with the contradictory guard or caller path you checked before publishing. "
+        "For every high-severity finding, include `supporting_files` with the impacted file plus at least one additional deep-read file that proves the caller, guard, or enforcement path. "
+        "Also fill `same_file_check` with the exact guard, branch, condition, or identifier from the impacted file that you checked to rule out a same-file contradiction, and fill `contradiction_check` with the contradictory guard or caller path you checked before publishing. "
+        "If `same_file_contradicted_by` is non-empty, do not publish that claim as a finding; move it to `near_misses` instead. "
         "If `contradicted_by` is non-empty, do not publish that claim as a finding; move it to `near_misses` instead. "
         "Prefer one to three high-value verified findings over a longer list of generic concerns. "
         "Downgrade or discard candidates that are weakly evidenced, hygiene-only, redundant, or not specific enough to change developer behavior. "
@@ -1630,6 +1635,12 @@ def _render_structured_repo_audit_with_task_data(
                 item.get("supporting_files"),
                 allowed_path_keys=allowed_path_keys,
             )
+            same_file_check = _clean_review_text(item.get("same_file_check"), max_chars=220)
+            same_file_contradicted_by = _clean_review_list(
+                item.get("same_file_contradicted_by"),
+                max_items=4,
+                max_chars=140,
+            )
             contradiction_check = _clean_review_text(item.get("contradiction_check"), max_chars=220)
             contradicted_by = _clean_review_list(item.get("contradicted_by"), max_items=4, max_chars=140)
             next_step = _clean_review_text(item.get("next_step"), max_chars=220)
@@ -1662,6 +1673,18 @@ def _render_structured_repo_audit_with_task_data(
                         f"`{matched}` - {title_for_near_miss}: The claim was withheld because high-severity findings must cite at least one additional deep-read supporting file."
                     )
                     continue
+                if not same_file_check or _is_weak_review_text(same_file_check):
+                    title_for_near_miss = title.rstrip(".:; ")
+                    rendered_near_misses.append(
+                        f"`{matched}` - {title_for_near_miss}: The claim was withheld because high-severity findings must describe the same-file contradiction check that ruled out a nearby guard or branch."
+                    )
+                    continue
+                if same_file_contradicted_by:
+                    title_for_near_miss = title.rstrip(".:; ")
+                    rendered_near_misses.append(
+                        f"`{matched}` - {title_for_near_miss}: The claim was withheld because same-file contradictory evidence remained ({'; '.join(same_file_contradicted_by[:2])})."
+                    )
+                    continue
                 if not contradiction_check or _is_weak_review_text(contradiction_check):
                     title_for_near_miss = title.rstrip(".:; ")
                     rendered_near_misses.append(
@@ -1689,6 +1712,8 @@ def _render_structured_repo_audit_with_task_data(
                     "Supporting files: "
                     + ", ".join(f"`{path}`" for path in supporting_files[:4])
                 )
+            if same_file_check:
+                finding_bits.append(f"Same-file check: {same_file_check}")
             if contradiction_check:
                 finding_bits.append(f"Contradiction check: {contradiction_check}")
             if next_step:

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -1903,6 +1903,7 @@ class TestWorkspaceReviewContext(unittest.TestCase):
                             "developer_impact": "Otherwise the audit can publish an ungrounded result after a partial bootstrap failure.",
                             "evidence": "This file controls the audit workspace bootstrap path.",
                             "supporting_files": ["node/mep_runtime.py", "README.md"],
+                            "same_file_check": "Checked the local publish guard in node/mep_runtime.py and did not find a same-file branch that permits publication after _repo_audit_contract_failure.",
                             "contradiction_check": "Checked the repo audit task contract description in README.md for a contradictory fail-open path and did not find one.",
                             "next_step": "Keep refusing repo_audit tasks whenever the workspace bootstrap or inventory load is incomplete.",
                         },
@@ -2114,6 +2115,108 @@ class TestWorkspaceReviewContext(unittest.TestCase):
             rendered,
         )
 
+    def test_render_structured_repo_audit_high_severity_findings_require_same_file_check(self):
+        task_data = {
+            "intent": {"type": "repo_audit.request"},
+            "task": {
+                "inputs": {
+                    "repo_audit": {
+                        "repo_url": "github.com/WUAIBING/MEP",
+                        "ref": "main",
+                        "inventory_paths": ["README.md", "hub/main.py", "node/mep_runtime.py"],
+                    }
+                }
+            },
+        }
+        rendered = mep_runtime._render_structured_repo_audit_with_task_data(  # noqa: SLF001
+            json.dumps(
+                {
+                    "summary": "Audited the workspace-backed repo context.",
+                    "repo_overview": "Reviewed runtime bootstrap and publish gating.",
+                    "files_deep_read": ["README.md", "node/mep_runtime.py", "hub/main.py"],
+                    "findings": [
+                        {
+                            "file": "node/mep_runtime.py",
+                            "title": "Runtime sync path should fail closed on missing workspace context",
+                            "category": "correctness",
+                            "severity": "high",
+                            "confidence": "high",
+                            "invariant": "Repo audit must fail closed if workspace grounding is incomplete.",
+                            "failure_mode": "A partial bootstrap can still reach result publication without an authoritative inventory.",
+                            "proof_type": "cross_file_interaction",
+                            "fix_priority": "fix_now",
+                            "developer_impact": "Otherwise the audit can publish an ungrounded result after a partial bootstrap failure.",
+                            "evidence": "sync_repo_audit_workspace prepares the workspace before the runtime publishes a result.",
+                            "supporting_files": ["node/mep_runtime.py", "hub/main.py"],
+                            "contradiction_check": "Checked the caller-side publish path in hub/main.py for an enforcing guard and did not find one.",
+                            "next_step": "Keep refusing repo_audit tasks whenever the workspace bootstrap or inventory load is incomplete.",
+                        }
+                    ],
+                }
+            ),
+            max_chars=4000,
+            task_data=task_data,
+        )
+
+        self.assertIn("## Repo Audit Summary", rendered)
+        self.assertNotIn("[high/high/fix_now] Runtime sync path should fail closed on missing workspace context", rendered)
+        self.assertIn(
+            "Near misses: `node/mep_runtime.py` - Runtime sync path should fail closed on missing workspace context: The claim was withheld because high-severity findings must describe the same-file contradiction check that ruled out a nearby guard or branch.",
+            rendered,
+        )
+
+    def test_render_structured_repo_audit_withholds_same_file_contradicted_high_severity_finding(self):
+        task_data = {
+            "intent": {"type": "repo_audit.request"},
+            "task": {
+                "inputs": {
+                    "repo_audit": {
+                        "repo_url": "github.com/WUAIBING/MEP",
+                        "ref": "main",
+                        "inventory_paths": ["bridge/github_to_mep.py", "docs/external-bridge/README.md", "README.md"],
+                    }
+                }
+            },
+        }
+        rendered = mep_runtime._render_structured_repo_audit_with_task_data(  # noqa: SLF001
+            json.dumps(
+                {
+                    "summary": "Audited bridge trigger enforcement and configuration docs.",
+                    "repo_overview": "Reviewed bridge trigger gating and its documented operator controls.",
+                    "files_deep_read": ["bridge/github_to_mep.py", "docs/external-bridge/README.md"],
+                    "findings": [
+                        {
+                            "file": "bridge/github_to_mep.py",
+                            "title": "MEP_BRIDGE_MAINTAINER_ONLY is not enforced",
+                            "category": "automation/writeback safety",
+                            "severity": "high",
+                            "confidence": "high",
+                            "invariant": "Maintainer-only bridge mode must reject trigger authors whose GitHub association is not allowed.",
+                            "failure_mode": "A non-maintainer can mention the bot and still cause automated bridge task submission.",
+                            "proof_type": "cross_file_interaction",
+                            "fix_priority": "fix_now",
+                            "developer_impact": "That would let untrusted GitHub users trigger autonomous review and approval actions.",
+                            "evidence": "The maintainer-only config is documented for the external bridge runtime.",
+                            "supporting_files": ["bridge/github_to_mep.py", "docs/external-bridge/README.md"],
+                            "same_file_check": "Checked the trigger extraction path in bridge/github_to_mep.py for a local author-association guard before trigger parsing.",
+                            "same_file_contradicted_by": ["bridge/github_to_mep.py rejects disallowed author_association before extracting triggers"],
+                            "contradiction_check": "Checked the docs in docs/external-bridge/README.md for the operator-facing maintainer-only requirement.",
+                            "next_step": "Keep the author-association gate fail-closed before bot trigger extraction.",
+                        }
+                    ],
+                }
+            ),
+            max_chars=4000,
+            task_data=task_data,
+        )
+
+        self.assertIn("## Repo Audit Summary", rendered)
+        self.assertNotIn("[high/high/fix_now] MEP_BRIDGE_MAINTAINER_ONLY is not enforced", rendered)
+        self.assertIn(
+            "Near misses: `bridge/github_to_mep.py` - MEP_BRIDGE_MAINTAINER_ONLY is not enforced: The claim was withheld because same-file contradictory evidence remained (bridge/github_to_mep.py rejects disallowed author_association before extracting triggers).",
+            rendered,
+        )
+
     def test_render_structured_repo_audit_withholds_contradicted_high_severity_finding(self):
         task_data = {
             "intent": {"type": "repo_audit.request"},
@@ -2147,6 +2250,7 @@ class TestWorkspaceReviewContext(unittest.TestCase):
                             "developer_impact": "That would break node identity trust across authenticated hub requests.",
                             "evidence": "verify_signature only verifies the supplied public key bytes.",
                             "supporting_files": ["hub/auth.py", "hub/main.py"],
+                            "same_file_check": "Checked hub/auth.py for a same-file registry lookup or fallback branch before verify_signature returns.",
                             "contradiction_check": "Checked verify_request in hub/main.py for a registry lookup before the auth helper is called.",
                             "contradicted_by": ["hub/main.py verify_request loads pub_pem via db.get_pub_pem(x_mep_nodeid) before calling verify_signature"],
                             "next_step": "Keep the registry lookup anchored in the request verification path.",


### PR DESCRIPTION
## Summary
- require high-severity repo-audit findings to describe the same-file contradiction check they performed
- veto high-severity findings when same-file contradictory evidence is still present
- cover the new same-file fail-closed rules with focused renderer tests

## Testing
- python -m pytest tests/test_node_runtime.py -k " repo_audit or candidate_coverage or deep_read or contradicted\