### PR TITLE
fix(deploy): harden hub release sync

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -190,31 +190,43 @@ docker-compose ps
 
 ## Step 10: Update the Hub
 
-Use one clean deployment checkout for the live Hub. Do not build production from an old hand-maintained folder with local edits, or the live Hub can drift away from the merged repo code.
+Prefer the release deploy path below for production. It deploys from a fresh release checkout, keeps `.env` and `hub_data` outside the code tree, pins the Docker compose project name, and refuses to cut over if the old live checkout has unknown dirty source edits unless you explicitly allow it.
 
-When new versions are released:
+### Production-safe release deploy
+
+Start from one clean source checkout that can resolve `origin/main`, but do not point production at that checkout directly:
 
 ```bash
 cd ~/mep-hub/MEP
 git fetch origin
-export MEP_HUB_LOGS_DIR=~/mep-hub/MEP/hub_data
-./scripts/deploy_hub.sh origin/main
+
+export MEP_DEPLOY_COMPOSE_PROJECT_NAME=mep
+export MEP_DEPLOY_ALLOW_DIRTY_LIVE_TREE=1
+export MEP_DEPLOY_ENV_FILE=~/mep-hub/MEP/.env
+export MEP_DEPLOY_HUB_DATA_DIR=~/mep-hub/MEP/hub_data
+
+./scripts/deploy_hub_release.sh origin/main
 ```
 
-The deploy script does four things:
+The release deploy script does seven things:
 
-1. Refuses to deploy from a dirty working tree
-2. Resolves the exact target commit SHA and checks it out
-3. Rebuilds and restarts only `mep-hub`
-4. Calls `http://127.0.0.1:8000/version` and verifies the live Hub reports the same `build_sha`
+1. Resolves the exact target commit SHA from the clean source checkout
+2. Archives the current live checkout state if it has dirty tracked or untracked files
+3. Refuses the cutover unless `MEP_DEPLOY_ALLOW_DIRTY_LIVE_TREE=1` is set
+4. Creates or reuses a fresh release checkout under `~/mep-hub/releases/<sha>`
+5. Reuses the shared `.env` file and `hub_data` directory instead of copying production state into the repo tree
+6. Starts `mep-hub` with a fixed compose project name such as `mep` so the Hub reconnects to the production `postgres` network instead of creating a new isolated network
+7. Calls `http://127.0.0.1:8000/version` and verifies the live Hub reports the same `build_sha`
 
-Set `MEP_HUB_LOGS_DIR` when you deploy from a clean checkout but want to keep using the existing production log volume.
-
-You can also deploy an exact merged commit instead of `origin/main`:
+If you need to deploy an exact merged commit instead of `origin/main`:
 
 ```bash
-./scripts/deploy_hub.sh 0bac07cc65da3b878971abebbfb95a239cd757d3
+./scripts/deploy_hub_release.sh 0bac07cc65da3b878971abebbfb95a239cd757d3
 ```
+
+### Legacy in-place deploy
+
+`./scripts/deploy_hub.sh` still exists for a dedicated clean deployment checkout. It now also pins the compose project name via `MEP_DEPLOY_COMPOSE_PROJECT_NAME`, but it is not the preferred production path when live drift is possible.
 
 ---
 

--- a/OPERATOR_CHECKLIST.md
+++ b/OPERATOR_CHECKLIST.md
@@ -73,36 +73,38 @@ codex> mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-
 - `target_node` usage is always `node_id`, never display nickname.
 
 ## Daily Git Hygiene (Server)
-- In repo path, run:
+- Keep one clean source checkout that only exists to resolve target SHAs for deploy.
+- Treat the old live checkout as evidence/debug state, not the place production builds should run from.
+- Before upgrade:
   - `git fetch origin --prune`
-  - compare `HEAD` vs `origin/main`
-- If behind:
-  - backup current state (status, HEAD, diff)
-  - preserve local edits (stash/backup branch)
-  - pull with `--ff-only`
-- Avoid upgrade if repo has unknown uncommitted changes until backed up.
+  - compare source-checkout `HEAD` vs `origin/main`
+  - inspect whether the old live checkout has unknown dirty source edits
+- Avoid upgrade if the live checkout is dirty until its state is archived.
 
 ## Safe Upgrade Procedure
 1. Backup:
-   - Save `git status`, `git rev-parse HEAD`, `git diff` into timestamped backup dir.
+   - Save old live checkout `git status`, `git rev-parse HEAD`, `git diff` into a timestamped backup dir.
 2. Preserve local edits:
-   - create stash or local backup branch.
+   - archive dirty live-tree diffs before cutover; do not rely on an untracked stash on the production box.
 3. Upgrade:
-   - `git pull --ff-only origin main`
+   - run `./scripts/deploy_hub_release.sh <target-ref-or-sha>` from the clean source checkout
+   - set `MEP_DEPLOY_COMPOSE_PROJECT_NAME=mep`
+   - set `MEP_DEPLOY_ENV_FILE` and `MEP_DEPLOY_HUB_DATA_DIR` to the shared production paths
 4. Restart:
-   - `docker compose up -d --build --no-deps mep-hub`
+   - let the release deploy script rebuild and restart only `mep-hub`
 5. Validate:
    - `GET /health` is healthy
+   - `GET /version` reports the expected `build_sha`
    - `mep-hub` container is `Up`
 6. Report:
    - new commit SHA
    - health summary
-   - remaining local modifications and stashes
+   - archived live-tree backup path if one was created
 
 ## Incident Response
 - If startup fails after upgrade:
   - capture logs first
-  - restore last known good commit or re-apply preserved stash
+  - redeploy the last known good SHA with `./scripts/deploy_hub_release.sh <sha>`
   - restore service availability before deeper debugging
 - If auth/signature failures spike:
   - verify node clocks (timestamp skew window)

--- a/scripts/deploy_hub.sh
+++ b/scripts/deploy_hub.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TARGET_REF="${1:-origin/main}"
+COMPOSE_PROJECT_NAME="${MEP_DEPLOY_COMPOSE_PROJECT_NAME:-mep}"
 
 require_clean_tree() {
   if [[ -n "$(git -C "$ROOT_DIR" status --porcelain --untracked-files=no)" ]]; then
@@ -34,7 +35,7 @@ export MEP_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 export MEP_DEPLOY_SOURCE="scripts/deploy_hub.sh"
 
 cd "$ROOT_DIR"
-docker compose up -d --build mep-hub
+docker compose --project-name "$COMPOSE_PROJECT_NAME" up -d --build mep-hub
 
 VERSION_JSON="$(curl -fsS http://127.0.0.1:8000/version)"
 printf '%s' "$VERSION_JSON" | python3 - "$TARGET_SHA" <<'PY'

--- a/scripts/deploy_hub.sh
+++ b/scripts/deploy_hub.sh
@@ -38,12 +38,13 @@ cd "$ROOT_DIR"
 docker compose --project-name "$COMPOSE_PROJECT_NAME" up -d --build mep-hub
 
 VERSION_JSON="$(curl -fsS http://127.0.0.1:8000/version)"
-printf '%s' "$VERSION_JSON" | python3 - "$TARGET_SHA" <<'PY'
+VERSION_JSON="$VERSION_JSON" python3 - "$TARGET_SHA" <<'PY'
 import json
+import os
 import sys
 
 expected_sha = sys.argv[1]
-payload = json.loads(sys.stdin.read())
+payload = json.loads(os.environ["VERSION_JSON"])
 
 if payload.get("build_sha") != expected_sha:
     raise SystemExit(f"deploy smoke check failed: expected {expected_sha}, got {payload.get('build_sha')}")

--- a/scripts/deploy_hub_release.sh
+++ b/scripts/deploy_hub_release.sh
@@ -86,7 +86,10 @@ prepare_release_checkout() {
     fi
   else
     rm -rf "$release_dir"
-    git clone "$SOURCE_REPO" "$release_dir" >/dev/null 2>&1
+    git clone "$SOURCE_REPO" "$release_dir" >/dev/null 2>&1 || {
+      echo "git clone failed: $SOURCE_REPO" >&2
+      exit 1
+    }
   fi
 
   git -C "$release_dir" fetch origin >/dev/null 2>&1
@@ -111,12 +114,13 @@ verify_version() {
   local version_json=""
 
   version_json="$(curl -fsS "$VERSION_URL")"
-  printf '%s' "$version_json" | python3 - "$expected_sha" <<'PY'
+  VERSION_JSON="$version_json" python3 - "$expected_sha" <<'PY'
 import json
+import os
 import sys
 
 expected_sha = sys.argv[1]
-payload = json.loads(sys.stdin.read())
+payload = json.loads(os.environ["VERSION_JSON"])
 
 if payload.get("build_sha") != expected_sha:
     raise SystemExit(
@@ -146,11 +150,16 @@ export MEP_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 export MEP_DEPLOY_SOURCE="scripts/deploy_hub_release.sh"
 export MEP_HUB_LOGS_DIR="$SHARED_HUB_DATA_DIR"
 
+docker compose \
+  --project-name "$COMPOSE_PROJECT_NAME" \
+  -f "$RELEASE_DIR/docker-compose.yml" \
+  build mep-hub
+
 docker rm -f mep-hub >/dev/null 2>&1 || true
 docker compose \
   --project-name "$COMPOSE_PROJECT_NAME" \
   -f "$RELEASE_DIR/docker-compose.yml" \
-  up -d --build --no-deps mep-hub
+  up -d --no-build --no-deps mep-hub
 
 verify_version "$TARGET_SHA"
 ln -sfn "$RELEASE_DIR" "$CURRENT_LINK"

--- a/scripts/deploy_hub_release.sh
+++ b/scripts/deploy_hub_release.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET_REF="${1:-origin/main}"
+
+SOURCE_REPO="${MEP_DEPLOY_SOURCE_REPO:-$ROOT_DIR}"
+DEPLOY_BASE_DIR="${MEP_DEPLOY_BASE_DIR:-$HOME/mep-hub}"
+RELEASES_DIR="${MEP_DEPLOY_RELEASES_DIR:-$DEPLOY_BASE_DIR/releases}"
+CURRENT_LINK="${MEP_DEPLOY_CURRENT_LINK:-$RELEASES_DIR/current}"
+LIVE_REPO_DIR="${MEP_DEPLOY_LIVE_REPO_DIR:-$DEPLOY_BASE_DIR/MEP}"
+ARCHIVE_DIR="${MEP_DEPLOY_ARCHIVE_DIR:-$DEPLOY_BASE_DIR/live-hotfix-backups}"
+SHARED_ENV_FILE="${MEP_DEPLOY_ENV_FILE:-$LIVE_REPO_DIR/.env}"
+SHARED_HUB_DATA_DIR="${MEP_DEPLOY_HUB_DATA_DIR:-$LIVE_REPO_DIR/hub_data}"
+COMPOSE_PROJECT_NAME="${MEP_DEPLOY_COMPOSE_PROJECT_NAME:-mep}"
+VERSION_URL="${MEP_DEPLOY_VERSION_URL:-http://127.0.0.1:8000/version}"
+ALLOW_DIRTY_LIVE_TREE="${MEP_DEPLOY_ALLOW_DIRTY_LIVE_TREE:-0}"
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required tool: $1" >&2
+    exit 1
+  fi
+}
+
+require_clean_tree() {
+  if [[ -n "$(git -C "$1" status --porcelain --untracked-files=no)" ]]; then
+    echo "Refusing deploy: source checkout is dirty: $1" >&2
+    exit 1
+  fi
+}
+
+ensure_git_repo() {
+  if ! git -C "$1" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Not a git repository: $1" >&2
+    exit 1
+  fi
+}
+
+archive_live_tree_if_needed() {
+  local live_status=""
+  local timestamp=""
+  local backup_dir=""
+
+  if [[ ! -d "$LIVE_REPO_DIR" ]]; then
+    return 0
+  fi
+  if ! git -C "$LIVE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Refusing deploy: live repo dir is not a git checkout: $LIVE_REPO_DIR" >&2
+    exit 1
+  fi
+
+  live_status="$(git -C "$LIVE_REPO_DIR" status --porcelain)"
+  if [[ -z "$live_status" ]]; then
+    return 0
+  fi
+
+  timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  backup_dir="$ARCHIVE_DIR/$timestamp"
+  mkdir -p "$backup_dir"
+
+  git -C "$LIVE_REPO_DIR" status --short > "$backup_dir/status.txt"
+  git -C "$LIVE_REPO_DIR" rev-parse HEAD > "$backup_dir/head.txt"
+  git -C "$LIVE_REPO_DIR" diff --binary > "$backup_dir/tracked.patch"
+  git -C "$LIVE_REPO_DIR" diff --binary --cached > "$backup_dir/staged.patch"
+  git -C "$LIVE_REPO_DIR" ls-files --others --exclude-standard > "$backup_dir/untracked.txt"
+
+  echo "Archived dirty live checkout to $backup_dir" >&2
+
+  if [[ "$ALLOW_DIRTY_LIVE_TREE" != "1" ]]; then
+    echo "Refusing deploy: live repo checkout is dirty. Review the archived patch set or rerun with MEP_DEPLOY_ALLOW_DIRTY_LIVE_TREE=1." >&2
+    exit 1
+  fi
+}
+
+prepare_release_checkout() {
+  local target_sha="$1"
+  local release_dir="$RELEASES_DIR/$target_sha"
+
+  mkdir -p "$RELEASES_DIR"
+
+  if [[ -d "$release_dir/.git" ]]; then
+    if [[ -n "$(git -C "$release_dir" status --porcelain --untracked-files=no)" ]]; then
+      echo "Refusing deploy: release checkout is dirty: $release_dir" >&2
+      exit 1
+    fi
+  else
+    rm -rf "$release_dir"
+    git clone "$SOURCE_REPO" "$release_dir" >/dev/null 2>&1
+  fi
+
+  git -C "$release_dir" fetch origin >/dev/null 2>&1
+  git -C "$release_dir" checkout --force "$target_sha" >/dev/null 2>&1
+
+  if [[ ! -f "$SHARED_ENV_FILE" ]]; then
+    echo "Missing shared env file: $SHARED_ENV_FILE" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$SHARED_HUB_DATA_DIR")"
+  mkdir -p "$SHARED_HUB_DATA_DIR"
+  rm -rf "$release_dir/hub_data"
+  ln -sfn "$SHARED_HUB_DATA_DIR" "$release_dir/hub_data"
+  ln -sfn "$SHARED_ENV_FILE" "$release_dir/.env"
+
+  printf '%s\n' "$release_dir"
+}
+
+verify_version() {
+  local expected_sha="$1"
+  local version_json=""
+
+  version_json="$(curl -fsS "$VERSION_URL")"
+  printf '%s' "$version_json" | python3 - "$expected_sha" <<'PY'
+import json
+import sys
+
+expected_sha = sys.argv[1]
+payload = json.loads(sys.stdin.read())
+
+if payload.get("build_sha") != expected_sha:
+    raise SystemExit(
+        f"deploy smoke check failed: expected {expected_sha}, got {payload.get('build_sha')}"
+    )
+
+print(json.dumps(payload, indent=2))
+PY
+}
+
+require_tool git
+require_tool docker
+require_tool curl
+require_tool python3
+
+ensure_git_repo "$SOURCE_REPO"
+require_clean_tree "$SOURCE_REPO"
+
+git -C "$SOURCE_REPO" fetch origin
+TARGET_SHA="$(git -C "$SOURCE_REPO" rev-parse "$TARGET_REF")"
+
+archive_live_tree_if_needed
+RELEASE_DIR="$(prepare_release_checkout "$TARGET_SHA")"
+
+export MEP_BUILD_SHA="$TARGET_SHA"
+export MEP_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+export MEP_DEPLOY_SOURCE="scripts/deploy_hub_release.sh"
+export MEP_HUB_LOGS_DIR="$SHARED_HUB_DATA_DIR"
+
+docker rm -f mep-hub >/dev/null 2>&1 || true
+docker compose \
+  --project-name "$COMPOSE_PROJECT_NAME" \
+  -f "$RELEASE_DIR/docker-compose.yml" \
+  up -d --build --no-deps mep-hub
+
+verify_version "$TARGET_SHA"
+ln -sfn "$RELEASE_DIR" "$CURRENT_LINK"
+
+echo "Hub release deploy smoke check passed for $TARGET_SHA"
+echo "Release checkout: $RELEASE_DIR"


### PR DESCRIPTION
## Summary
- add a production-safe Hub release deploy script that deploys from a fresh checkout instead of the old live repo tree
- archive and optionally refuse dirty live checkouts before cutover, while reusing shared .env and hub_data paths
- pin the compose project name for Hub deploys and update deployment/operator docs to match the production-safe flow

## Validation
- Git Bash: ash -n scripts/deploy_hub.sh scripts/deploy_hub_release.sh
- VS Code diagnostics: DEPLOYMENT.md, OPERATOR_CHECKLIST.md, scripts/deploy_hub_release.sh
