### PR TITLE
Improve review-mode grounding and suppress no-finding filler

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -26,6 +26,7 @@ from node.task_envelope import build_task_envelope
 SUPPORTED_GITHUB_EVENTS = {"issue_comment", "pull_request", "pull_request_review_comment"}
 DEFAULT_TRIGGER_VERBS = {
     "review": "code.review.request",
+    "rereview": "code.review.request",
     "analyze": "analysis.request",
     "check": "code.review.request",
     "comment": "code.review.comment",
@@ -1185,6 +1186,7 @@ class GitHubToMEPBridgeService:
             "source_event": github_event,
             "source_action": action,
             "trigger_verb": first_verb,
+            "review_mode": self._review_mode_for_verb(first_verb),
         }
         review_context = ""
         if entity_type == "pr":
@@ -1206,6 +1208,7 @@ class GitHubToMEPBridgeService:
             actor_login=actor_login,
             action=action,
             imperative_verb=first_verb,
+            review_mode=self._review_mode_for_verb(first_verb),
             trigger_text=trigger_text,
             review_context=review_context,
         )
@@ -1250,9 +1253,14 @@ class GitHubToMEPBridgeService:
         if not command_match:
             return None
         verb = re.sub(r"[\s-]+", "", command_match.group("verb").strip().lower())
-        if verb == "rereview":
-            return "review"
         return verb
+
+    @staticmethod
+    def _review_mode_for_verb(verb: str) -> str:
+        normalized = str(verb or "").strip().lower()
+        if normalized == "rereview":
+            return "recheck_review"
+        return "discovery_review"
 
     def _extract_triggers(self, text: str) -> list[TriggerMatch]:
         """Extract ALL actionable @alias verb mentions from text."""
@@ -1878,6 +1886,7 @@ class GitHubToMEPBridgeService:
         actor_login: str,
         action: str,
         imperative_verb: str,
+        review_mode: str,
         trigger_text: str,
         review_context: str = "",
     ) -> str:
@@ -1894,6 +1903,7 @@ class GitHubToMEPBridgeService:
             f"Actor: @{actor_login}\n"
             f"Webhook action: {action}\n"
             f"Requested verb: {imperative_verb}\n"
+            f"Review mode: {review_mode}\n"
             "Instructions:\n"
             f"{clipped_trigger}"
         )
@@ -2033,7 +2043,7 @@ class GitHubToMEPBridgeService:
         imperative_verb = str(execution.get("imperative_verb") or "").strip().lower()
         if intent_type == "code.review.approve" or imperative_verb == "approve":
             return "approved"
-        if intent_type == "code.review.request" or imperative_verb in {"review", "check"}:
+        if intent_type == "code.review.request" or imperative_verb in {"review", "check", "rereview"}:
             return "reviewed"
         if intent_type == "code.review.comment" or imperative_verb == "comment":
             return "commented"
@@ -2422,9 +2432,6 @@ class GitHubToMEPBridgeService:
         if checks_performed:
             score += 1
             reasons.append("explicit_checks")
-        if why_no_finding and not has_findings:
-            score += 1
-            reasons.append("why_no_finding")
         if mentions_tests:
             score += 1
             reasons.append("test_awareness")
@@ -2625,7 +2632,7 @@ class GitHubToMEPBridgeService:
                 reviewability_bucket == "standard"
                 and anchored_paths
                 and not has_findings
-                and (checks_performed or risk_areas_checked or why_no_finding)
+                and (checks_performed or risk_areas_checked)
             ):
                 return sanitized, snapshot, score, reasons
             return None
@@ -2685,6 +2692,7 @@ class GitHubToMEPBridgeService:
         suppression_reason: Optional[str],
     ) -> dict[str, Any]:
         review_package = snapshot.get("review_package") or {}
+        github_inputs = self._execution_github_inputs(execution)
         ci_checks = snapshot.get("ci_checks") or {}
         anchored_paths = snapshot.get("anchored_paths") or set()
         changed_tokens = snapshot.get("changed_tokens") or set()
@@ -2715,6 +2723,7 @@ class GitHubToMEPBridgeService:
             "issue_number": int(execution.get("issue_number") or 0),
             "target_alias": str(execution.get("target_alias") or ""),
             "intent_type": str(execution.get("intent_type") or ""),
+            "review_mode": str(github_inputs.get("review_mode") or "discovery_review"),
             "head_sha": str(review_package.get("head_sha") or ""),
             "ci_state": str(ci_checks.get("state") or "none"),
             "ci_has_checks": bool(ci_checks.get("has_checks")),

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -502,6 +502,14 @@ def _task_is_approval_review(task_data: dict[str, Any]) -> bool:
     return _review_intent_type(task_data) == "code.review.approve"
 
 
+def _review_mode_for_task(task_data: dict[str, Any]) -> str:
+    github_inputs = _review_github_inputs(task_data)
+    review_mode = _clean_review_label(github_inputs.get("review_mode"), max_chars=40).lower()
+    if review_mode == "recheck_review":
+        return "recheck_review"
+    return "discovery_review"
+
+
 def _review_lenses_for_task(task_data: dict[str, Any]) -> list[str]:
     github_inputs = _review_github_inputs(task_data)
     touched_paths = _clean_review_list(github_inputs.get("touched_paths"), max_items=8, max_chars=120)
@@ -696,6 +704,7 @@ def _system_prompt_for_task(
     if _task_requires_review_prompt(task_data):
         github_inputs = _review_github_inputs(task_data)
         approval_mode = _task_is_approval_review(task_data)
+        review_mode = _review_mode_for_task(task_data)
         workspace_path = str(github_inputs.get("local_workspace_path") or "").strip()
         workspace_hint = ""
         if workspace_path:
@@ -705,6 +714,18 @@ def _system_prompt_for_task(
                 "treat that material as the authoritative code context. Base findings on what the full files and "
                 "verification output actually show. Do not claim code is truncated, missing, or a placeholder because "
                 "of how the input is formatted or because a file body was shortened for length."
+            )
+        review_mode_hint = ""
+        if review_mode == "recheck_review":
+            review_mode_hint = (
+                " Review mode is `recheck_review`. Treat this as a follow-up verification pass on a PR that was already reviewed once. "
+                "Bias toward confirming whether the current diff still leaves a concrete blocker, disproving stale or weak earlier claims, "
+                "and checking whether the changed tests and enforcement paths now line up. Do not invent fresh low-signal concerns just to say something new."
+            )
+        else:
+            review_mode_hint = (
+                " Review mode is `discovery_review`. Treat this as the first serious review pass and spend your budget hunting for the single "
+                "highest-value correctness, regression, edge-case, or missing-validation issue before you summarize."
             )
         approval_hint = ""
         if approval_mode:
@@ -720,7 +741,7 @@ def _system_prompt_for_task(
             "Your primary job is to find the highest-value correctness, regression, edge-case, or missing-validation risk in the supplied PR context before you summarize anything. "
             "Review the provided GitHub PR context and return ONLY a JSON object with this schema: "
             '{"summary": string, "observation": string, "touched_paths": [string], "tests_reviewed": [string], '
-            '"risk_areas_checked": [string], "checks_performed": [string], "why_no_finding": string, '
+            '"risk_areas_checked": [string], "checks_performed": [string], '
             '"verified_identifiers": [string], '
             '"findings": [{"file": string, "issue": string, "rationale": string}], '
             '"approval_recommendation": "approve" | "comment" | "request_changes" | "abstain"}. '
@@ -728,18 +749,18 @@ def _system_prompt_for_task(
             "Use `observation` for one concrete non-blocking review note tied to the actual diff. "
             "Use `risk_areas_checked` for 1-4 concrete risk themes you examined in the changed code. "
             "Use `checks_performed` for 1-4 specific verification steps you actually performed against the diff, tests, or workspace excerpts. "
-            "When findings are empty, `why_no_finding` must explain why the changed behavior looks safe based on those checks; do not use it for generic praise. "
+            "When findings are empty, keep `summary` verdict-style and `observation` concrete; do not add filler sections or generic praise. "
             "Use `verified_identifiers` for exact function/variable/class names copied from changed lines in the supplied diff or workspace excerpts. "
             "Prefer real touched files and tests from the supplied GitHub inputs for `touched_paths` and `tests_reviewed`. "
             "For no-finding reviews, always anchor the output to the actual diff: include at least one touched path in `touched_paths`, "
             "include 1-3 exact changed-line identifiers in `verified_identifiers` when the review context provides them, "
-            "and make `summary`, `observation`, and `why_no_finding` explicitly about that changed behavior rather than generic quality praise. "
-            "If you mention code behavior in `observation` or `why_no_finding`, tie it to the same touched path or changed identifiers. "
+            "and make `summary` and `observation` explicitly about that changed behavior rather than generic quality praise. "
+            "If you mention code behavior in `summary` or `observation`, tie it to the same touched path or changed identifiers. "
             "Only include a finding when it is directly supported by the provided diff, file list, PR description, or patch excerpts. "
             "Do not speculate about unseen code, do not ask for more context, and do not include chain-of-thought or any text outside the JSON object. "
-            "If the change looks good, keep findings empty, use summary to state the overall conclusion, list the risk areas and checks you covered, explain why no finding is warranted, keep observation concrete, and set approval_recommendation to approve or comment. "
+            "If the change looks good, keep findings empty, use summary to state the overall conclusion, list the risk areas and checks you covered, keep observation concrete, and set approval_recommendation to approve or comment. "
             "Diff restatement without risk coverage is not a sufficient review. Keep the "
-            f"response within {review_max_chars} characters.{approval_hint}{workspace_hint}"
+            f"response within {review_max_chars} characters.{review_mode_hint}{approval_hint}{workspace_hint}"
         )
     return (
         "You are a helpful MEP (Miao Exchange Protocol) bot. "
@@ -751,6 +772,12 @@ def _system_prompt_for_task(
 def _candidate_system_prompt_for_task(task_data: dict[str, Any], *, review_max_chars: int) -> str:
     if not _task_requires_review_prompt(task_data):
         return _system_prompt_for_task(task_data, generic_max_chars=500, review_max_chars=review_max_chars)
+    review_mode = _review_mode_for_task(task_data)
+    mode_hint = (
+        "This is a recheck, so prefer verifying unresolved regression hypotheses, stale review claims, and test/enforcement alignment over opening a brand-new low-signal search space. "
+        if review_mode == "recheck_review"
+        else "This is a discovery pass, so optimize for finding the strongest previously-unreported bug or regression risk first. "
+    )
     return (
         "You are the candidate-generation pass for a MEP GitHub code review. "
         "Scan the supplied PR context, diff excerpts, risk pack, workspace context, and verification output. "
@@ -760,6 +787,7 @@ def _candidate_system_prompt_for_task(task_data: dict[str, Any], *, review_max_c
         "Prefer at most one candidate per lens, rank the highest-impact candidate first, and bias toward correctness, trust-boundary, state-transition, rollback, migration, and test-gap risks over style comments. "
         "Each candidate must be concrete, tied to a changed file, and phrased as a potential bug or regression worth verifying. "
         "Use `evidence` for 1-3 exact identifiers, tests, or changed behaviors from the supplied context that make the hypothesis worth verifying. "
+        f"{mode_hint}"
         "Do not summarize the PR. Do not give praise. Do not include chain-of-thought. "
         "If nothing looks risky enough to verify, return an empty `risk_candidates` list and use `coverage` to note what you inspected."
     )
@@ -769,6 +797,12 @@ def _verification_system_prompt_for_task(task_data: dict[str, Any], *, review_ma
     base = _system_prompt_for_task(task_data, generic_max_chars=500, review_max_chars=review_max_chars)
     if not _task_requires_review_prompt(task_data):
         return base
+    review_mode = _review_mode_for_task(task_data)
+    mode_hint = (
+        "Because this is `recheck_review`, explicitly look for evidence that earlier concerns were fixed, contradicted by the current diff, or demoted by the changed tests and enforcement path. "
+        if review_mode == "recheck_review"
+        else "Because this is `discovery_review`, prioritize confirming the strongest fresh candidate rather than spreading attention across many medium-signal ideas. "
+    )
     return (
         f"{base} This is the verification pass. The user message may include provisional candidate risks from an earlier pass. "
         "Treat those candidates as hypotheses only. Promote a candidate into `findings` only when the supplied diff, workspace context, tests, or verification output directly support it. "
@@ -776,9 +810,10 @@ def _verification_system_prompt_for_task(task_data: dict[str, Any], *, review_ma
         "Prefer the single highest-impact verified finding over multiple medium-signal findings. Publish a second finding only when it is independent, well-supported, and similarly important. "
         "Downgrade or discard candidates that are weakly evidenced, redundant with a stronger finding, or true but too low-value to be a meaningful review comment. "
         "Reject any candidate that relies only on nearby file context, naming similarity, or speculation. "
-        "If no candidate survives verification, keep `findings` empty, explain the checks you performed, and explicitly state why no finding is warranted. "
+        "If no candidate survives verification, keep `findings` empty, explain the checks you performed, and keep the summary grounded in the reviewed changed behavior. "
         "For that no-finding case, still return a grounded review: populate `touched_paths` from the real diff, populate `verified_identifiers` from changed lines when available, "
-        "and make `summary`, `observation`, and `why_no_finding` cite the reviewed changed behavior instead of generic praise. "
+        "and make `summary` and `observation` cite the reviewed changed behavior instead of generic praise. "
+        f"{mode_hint}"
         "In approval mode, any surviving finding must force `approval_recommendation` away from `approve`."
     )
 
@@ -872,7 +907,9 @@ def _approval_detail_supports_publishable_approval(
         return False
     if "## Review Findings" in text:
         return False
-    if "Touched paths reviewed:" not in text or "Why no finding:" not in text:
+    if "## Review Summary" not in text or "Touched paths reviewed:" not in text:
+        return False
+    if "Checks performed:" not in text or "Risk areas checked:" not in text:
         return False
     github_inputs = _review_github_inputs(task_data or {})
     touched_tests = _clean_review_list(github_inputs.get("touched_tests"), max_items=3, max_chars=120)
@@ -1304,11 +1341,6 @@ def _render_default_structured_review(
         verified_identifiers=verified_identifiers,
         task_data=task_data,
     )
-    why_no_finding = _default_no_finding_reason(
-        touched_paths=touched_paths,
-        verified_identifiers=verified_identifiers,
-        tests_reviewed=tests_reviewed,
-    )
     summary = _clean_review_text(summary_hint, max_chars=500)
     if _is_weak_review_text(summary):
         summary = ""
@@ -1317,7 +1349,14 @@ def _render_default_structured_review(
             touched_paths=touched_paths,
             verified_identifiers=verified_identifiers,
         )
+    observation = _default_review_observation(
+        touched_paths=touched_paths,
+        verified_identifiers=verified_identifiers,
+        tests_reviewed=tests_reviewed,
+    )
     sections = ["## Review Summary", summary]
+    if observation:
+        sections.append(f"Observation: {observation}")
     if touched_paths:
         sections.append("Touched paths reviewed: " + ", ".join(f"`{path}`" for path in touched_paths))
     if tests_reviewed:
@@ -1326,8 +1365,6 @@ def _render_default_structured_review(
         sections.append("Risk areas checked: " + ", ".join(risk_areas_checked))
     if checks_performed:
         sections.append("Checks performed: " + ", ".join(checks_performed))
-    if why_no_finding:
-        sections.append(f"Why no finding: {why_no_finding}")
     if verified_identifiers:
         sections.append("Changed identifiers verified: " + ", ".join(f"`{name}`" for name in verified_identifiers))
     return _finalize_model_reply("\n\n".join(sections), max_chars=max_chars)
@@ -1851,9 +1888,9 @@ def _render_structured_review_with_task_data(
     checks_performed = _clean_review_list(parsed.get("checks_performed"), max_items=4, max_chars=120)
     verified_identifiers = _clean_review_list(parsed.get("verified_identifiers"), max_items=4, max_chars=80)
     verified_identifiers = _filter_review_list_to_allowed(verified_identifiers, allowed_identifiers)
-    why_no_finding = _clean_review_text(parsed.get("why_no_finding"), max_chars=400)
-    if _is_weak_review_text(why_no_finding):
-        why_no_finding = ""
+    legacy_no_finding = _clean_review_text(parsed.get("why_no_finding"), max_chars=400)
+    if _is_weak_review_text(legacy_no_finding):
+        legacy_no_finding = ""
     findings_raw = parsed.get("findings")
     findings: list[str] = []
     allowed_path_keys = {item.lower(): item for item in allowed_paths}
@@ -1892,18 +1929,14 @@ def _render_structured_review_with_task_data(
                 verified_identifiers=verified_identifiers,
                 task_data=task_data,
             )
-        if not why_no_finding:
-            why_no_finding = _default_no_finding_reason(
-                touched_paths=touched_paths,
-                verified_identifiers=verified_identifiers,
-                tests_reviewed=tests_reviewed,
-            )
         if not summary:
             summary = _default_review_summary(
                 touched_paths=touched_paths,
                 verified_identifiers=verified_identifiers,
             )
-        if not observation and not summary and (touched_paths or verified_identifiers):
+        if not observation and legacy_no_finding:
+            observation = legacy_no_finding
+        if not observation and (touched_paths or verified_identifiers):
             observation = _default_review_observation(
                 touched_paths=touched_paths,
                 verified_identifiers=verified_identifiers,
@@ -1932,8 +1965,6 @@ def _render_structured_review_with_task_data(
             sections.append("Checks performed: " + ", ".join(checks_performed))
         if verified_identifiers:
             sections.append("Changed identifiers verified: " + ", ".join(f"`{name}`" for name in verified_identifiers))
-        if why_no_finding:
-            sections.append(f"Why no finding: {why_no_finding}")
         for index, finding in enumerate(findings, start=1):
             sections.append(f"{index}. {finding}")
     elif summary:
@@ -1951,8 +1982,6 @@ def _render_structured_review_with_task_data(
             sections.append("Checks performed: " + ", ".join(checks_performed))
         if verified_identifiers:
             sections.append("Changed identifiers verified: " + ", ".join(f"`{name}`" for name in verified_identifiers))
-        if why_no_finding:
-            sections.append(f"Why no finding: {why_no_finding}")
     else:
         sections.append("## Review Summary")
         sections.append(
@@ -1968,8 +1997,6 @@ def _render_structured_review_with_task_data(
             sections.append("Checks performed: " + ", ".join(checks_performed))
         if verified_identifiers:
             sections.append("Changed identifiers verified: " + ", ".join(f"`{name}`" for name in verified_identifiers))
-        if why_no_finding:
-            sections.append(f"Why no finding: {why_no_finding}")
     rendered = "\n\n".join(section for section in sections if section.strip())
     return _finalize_model_reply(rendered, max_chars=max_chars)
 

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -279,7 +279,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         ):
             self.assertEqual(
                 self.service._extract_trigger(body),
-                ("review", "code.review.request"),
+                ("rereview", "code.review.request"),
             )
 
     def test_duplicate_delivery_is_deduplicated(self):
@@ -450,6 +450,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(github_inputs["delivery_id"], "delivery-package")
         self.assertEqual(github_inputs["head_sha"], "1234567890abcdef")
         self.assertEqual(github_inputs["base_sha"], "fedcba0987654321")
+        self.assertEqual(github_inputs["review_mode"], "discovery_review")
         self.assertEqual(
             github_inputs["touched_paths"],
             ["hub/db.py", "tests/test_github_bridge.py"],
@@ -475,6 +476,25 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertIn("Deterministic risk pack:", instructions)
         self.assertIn("Hunk-centered context pack:", instructions)
         self.assertIn("Changed identifiers: write_state, test_review_package", instructions)
+        self.assertIn("Review mode: discovery_review", instructions)
+
+    def test_rereview_trigger_sets_recheck_review_mode_in_github_inputs(self):
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel rereview this PR"),
+            delivery_id="delivery-rereview-mode",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        self._flush_context(response.json()["context_id"])
+
+        envelope = self.submission.calls[0]["envelope"]
+        github_inputs = envelope["task"]["inputs"]["github"]
+        instructions = envelope["task"]["instructions"]
+
+        self.assertEqual(github_inputs["trigger_verb"], "rereview")
+        self.assertEqual(github_inputs["review_mode"], "recheck_review")
+        self.assertIn("Requested verb: rereview", instructions)
+        self.assertIn("Review mode: recheck_review", instructions)
 
     def test_pr_review_package_detects_singular_test_path_and_security_tag(self):
         self.github_session.get_responses = [

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -421,6 +421,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         changed_identifiers: Optional[list[str]] = None,
         touched_paths: Optional[list[str]] = None,
         touched_tests: Optional[list[str]] = None,
+        review_mode: str = "discovery_review",
     ) -> dict:
         identifiers = changed_identifiers or [
             "_record_pending_task_poll_failure",
@@ -453,6 +454,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
                                 "repo_full_name": "WUAIBING/MEP",
                                 "entity_type": "pr",
                                 "number": 246,
+                                "review_mode": review_mode,
                                 "touched_paths": github_touched_paths,
                                 "touched_tests": github_touched_tests,
                                 "risk_pack": {
@@ -504,10 +506,11 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn('"tests_reviewed": [string]', prompt)
         self.assertIn('"risk_areas_checked": [string]', prompt)
         self.assertIn('"checks_performed": [string]', prompt)
-        self.assertIn('"why_no_finding": string', prompt)
+        self.assertNotIn('"why_no_finding": string', prompt)
         self.assertIn('"approval_recommendation"', prompt)
         self.assertIn("highest-value correctness, regression, edge-case", prompt)
         self.assertIn("always anchor the output to the actual diff", prompt)
+        self.assertIn("Review mode is `discovery_review`.", prompt)
 
     def test_approval_review_prompt_requires_verified_identifiers_and_test_awareness(self):
         task_data = self._bridge_review_task_data(intent_type="code.review.approve")
@@ -524,6 +527,18 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("state the scope is low-risk", prompt)
         self.assertIn("checks are pending or failing", prompt)
         self.assertIn("Diff restatement without risk coverage is not a sufficient review", prompt)
+
+    def test_recheck_review_prompt_mentions_follow_up_verification_mode(self):
+        task_data = self._bridge_review_task_data(review_mode="recheck_review")
+        prompt = mep_runtime._system_prompt_for_task(  # noqa: SLF001
+            task_data,
+            generic_max_chars=300,
+            review_max_chars=1000,
+        )
+
+        self.assertIn("Review mode is `recheck_review`.", prompt)
+        self.assertIn("follow-up verification pass", prompt)
+        self.assertIn("Do not invent fresh low-signal concerns", prompt)
 
     def test_review_lenses_include_bridge_safety_focus(self):
         lenses = mep_runtime._review_lenses_for_task(self._bridge_review_task_data())  # noqa: SLF001
@@ -633,7 +648,8 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("Tests reviewed: `tests/test_github_bridge.py`", reply)
         self.assertIn("Risk areas checked:", reply)
         self.assertIn("Checks performed:", reply)
-        self.assertIn("Why no finding:", reply)
+        self.assertIn("Observation:", reply)
+        self.assertNotIn("Why no finding:", reply)
 
     def test_structured_review_falls_back_to_github_inputs_for_paths_and_tests(self):
         rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
@@ -701,8 +717,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
             "Tests reviewed: `tests/test_github_bridge.py`\n\n"
             "Risk areas checked: approval gating, changed-line anchoring\n\n"
             "Checks performed: traced approval suppression branches, compared changed identifiers against the diff\n\n"
-            "Changed identifiers verified: `_score_review_quality`, `_approval_quality_failure`\n\n"
-            "Why no finding: The changed-line evidence and test-aware approval gate stay aligned, so no concrete blocker remains."
+            "Changed identifiers verified: `_score_review_quality`, `_approval_quality_failure`"
         )
 
         action = mep_runtime.RuntimeNode._bridge_status_action(  # noqa: SLF001
@@ -732,7 +747,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
 
         self.assertIn("Risk areas checked: trial persistence, endpoint decoding", rendered)
         self.assertIn("Checks performed: verified suppression and publish paths mention `review_result_json`, checked `/bridge/review-trials` returns stored review metadata", rendered)
-        self.assertIn("Why no finding: The new writes and reads stay consistent across both persistence paths, so the telemetry path looks low-risk.", rendered)
+        self.assertNotIn("Why no finding:", rendered)
 
     def test_structured_review_fills_no_finding_defaults_from_task_data(self):
         rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
@@ -753,7 +768,8 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("Touched paths reviewed: `hub/auth.py`, `hub/db.py`, `hub/models.py`", rendered)
         self.assertIn("Risk areas checked:", rendered)
         self.assertIn("Checks performed:", rendered)
-        self.assertIn("Why no finding:", rendered)
+        self.assertIn("Observation:", rendered)
+        self.assertNotIn("Why no finding:", rendered)
         self.assertIn("Changed identifiers verified: `verify_signature`, `_evict_expired_nonces`, `NodeRegistration`", rendered)
 
     def test_structured_review_rewrites_generic_no_finding_text_to_grounded_anchors(self):
@@ -778,7 +794,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("Changed identifiers verified: `verify_signature`, `_evict_expired_nonces`", rendered)
         self.assertIn("The patch looks good overall.", rendered)
         self.assertIn("Observation: The change is well-structured.", rendered)
-        self.assertIn("Why no finding: No issues found after review.", rendered)
+        self.assertNotIn("Why no finding:", rendered)
 
     def test_structured_review_synthesizes_grounded_summary_from_non_json_reply(self):
         rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
@@ -795,7 +811,8 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("Touched paths reviewed: `hub/auth.py`, `hub/db.py`, `hub/models.py`, `hub/requirements.txt`", rendered)
         self.assertIn("Risk areas checked:", rendered)
         self.assertIn("Checks performed:", rendered)
-        self.assertIn("Why no finding:", rendered)
+        self.assertIn("Observation:", rendered)
+        self.assertNotIn("Why no finding:", rendered)
         self.assertIn("Changed identifiers verified: `verify_signature`, `_evict_expired_nonces`", rendered)
 
     def test_structured_review_drops_findings_without_allowed_changed_identifiers(self):
@@ -1050,8 +1067,7 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
             "Tests reviewed: `tests/test_github_bridge.py`\n\n"
             "Risk areas checked: approval gating, changed-line anchoring\n\n"
             "Checks performed: traced approval suppression branches, compared changed identifiers against the diff\n\n"
-            "Changed identifiers verified: `_score_review_quality`, `_approval_quality_failure`\n\n"
-            "Why no finding: The changed-line evidence and test-aware approval gate stay aligned, so no concrete blocker remains."
+            "Changed identifiers verified: `_score_review_quality`, `_approval_quality_failure`"
         )
         task_data = TestRuntimeReviewPrompts._bridge_review_task_data(  # noqa: SLF001
             intent_type="code.review.approve",


### PR DESCRIPTION
Summary: preserve explicit recheck review mode, suppress default no-finding filler, and lock the new review contract with tests. Validation: python -m pytest tests/test_node_runtime.py tests/test_github_bridge.py