### PR TITLE
Harden persistent bot identity paths

### DIFF
--- a/clients/adapters/mep_codex_provider.py
+++ b/clients/adapters/mep_codex_provider.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import os
 import re
-import tempfile
 import time
 import urllib.parse
 from typing import Any
@@ -14,6 +13,7 @@ from clients.shared.execution_bridge import (
     is_execution_request,
     render_execution_result,
 )
+from clients.shared.identity_paths import remember_identity, resolve_identity_key_path
 from clients.shared.mep_client import MEPClient
 from clients.shared.manifest import load_manifest
 
@@ -27,10 +27,12 @@ os.environ["NO_PROXY"] = "*"
 class CodexProvider:
     def __init__(self) -> None:
         self.manifest = load_manifest()
-        key_path = (
-            os.getenv("MEP_BOT_KEY_PATH")
-            or (self.manifest.key_path if self.manifest else None)
-            or os.path.join(tempfile.gettempdir(), "mep_codex_provider.pem")
+        stable_alias = os.getenv("MEP_ALIAS") or (self.manifest.alias if self.manifest else None)
+        key_path = resolve_identity_key_path(
+            explicit_key_path=os.getenv("MEP_BOT_KEY_PATH"),
+            manifest_key_path=self.manifest.key_path if self.manifest else None,
+            alias_hint=stable_alias,
+            create_if_missing=True,
         )
         hub_url = os.getenv("HUB_URL") or (self.manifest.hub_url if self.manifest else None)
         ws_url = os.getenv("WS_URL") or (self.manifest.ws_url if self.manifest else None)
@@ -46,6 +48,7 @@ class CodexProvider:
             self.alias = alias_prefix
         else:
             self.alias = f"{alias_prefix} {self.client.node_id}"
+        remember_identity(self.client.identity.key_path, stable_alias or self.alias)
         self.heartbeat_seconds = int(
             os.getenv("MEP_HEARTBEAT_SECONDS")
             or (self.manifest.heartbeat_seconds if self.manifest else 30)

--- a/clients/adapters/mep_discord_adapter.py
+++ b/clients/adapters/mep_discord_adapter.py
@@ -1,18 +1,20 @@
 import os
 import shlex
-import tempfile
 
 import discord
 from discord.ext import commands
 
 from clients.shared.commands import parse_task_args
+from clients.shared.identity_paths import remember_identity, resolve_identity_key_path
 from clients.shared.mep_client import MEPClient
 
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 DEFAULT_BOUNTY = float(os.getenv("MEP_DEFAULT_BOUNTY", "5.0"))
-DISCORD_KEY_PATH = os.getenv(
-    "MEP_DISCORD_KEY_PATH",
-    os.path.join(tempfile.gettempdir(), "mep_discord_adapter.pem"),
+DISCORD_ALIAS = os.getenv("MEP_ALIAS", "discord-agent")
+DISCORD_KEY_PATH = resolve_identity_key_path(
+    explicit_key_path=os.getenv("MEP_DISCORD_KEY_PATH") or os.getenv("MEP_BOT_KEY_PATH"),
+    alias_hint=DISCORD_ALIAS,
+    create_if_missing=True,
 )
 MAX_OUTPUT_CHARS = int(os.getenv("MEP_DISCORD_MAX_OUTPUT_CHARS", "1800"))
 
@@ -27,6 +29,7 @@ intents = discord.Intents.default()
 intents.message_content = True
 bot = commands.Bot(command_prefix="!", intents=intents)
 client = MEPClient(DISCORD_KEY_PATH)
+remember_identity(client.identity.key_path, DISCORD_ALIAS)
 
 
 @bot.event

--- a/clients/shared/identity_paths.py
+++ b/clients/shared/identity_paths.py
@@ -315,6 +315,9 @@ def resolve_identity_key_path(
                 f"multiple local identities match alias={alias_hint!r}; pass --key-path explicitly"
             )
         return remember_identity(matches[0], alias_hint)
+    if create_if_missing and alias_hint:
+        created = create_new_local_identity(default_key_dir())
+        return remember_identity(created, alias_hint)
     if alias_hint and len(candidates) == 1:
         raise RuntimeKeyPathError(
             f"no local identity matches alias={alias_hint!r}; pass --key-path explicitly"

--- a/clients/shared/identity_paths.py
+++ b/clients/shared/identity_paths.py
@@ -1,0 +1,334 @@
+import hashlib
+import json
+import os
+import time
+from typing import Optional
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from clients.shared.identity import MEPIdentity
+
+LEGACY_RUNTIME_KEY_NAME = "mep_runtime.pem"
+IDENTITY_REGISTRY_NAME = "bots.json"
+
+
+class RuntimeKeyPathError(ValueError):
+    """Raised when persistent identity selection is ambiguous or missing."""
+
+
+def _user_home_dir() -> str:
+    expanded = os.path.expanduser("~")
+    if expanded and expanded not in {"~", "~/"}:
+        return os.path.abspath(expanded)
+    for env_name in ("USERPROFILE", "HOME"):
+        raw = os.getenv(env_name)
+        if raw and raw not in {"~", "~/"}:
+            return os.path.abspath(raw)
+    home_drive = os.getenv("HOMEDRIVE")
+    home_path = os.getenv("HOMEPATH")
+    if home_drive and home_path:
+        return os.path.abspath(f"{home_drive}{home_path}")
+    return os.path.abspath(os.getcwd())
+
+
+def find_git_root(start_path: Optional[str] = None) -> Optional[str]:
+    current = os.path.abspath(start_path or os.getcwd())
+    while True:
+        git_marker = os.path.join(current, ".git")
+        if os.path.isdir(git_marker) or os.path.isfile(git_marker):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None
+        current = parent
+
+
+def default_key_dir() -> str:
+    explicit = os.getenv("MEP_KEY_DIR")
+    if explicit:
+        return explicit
+    return os.path.join(_user_home_dir(), ".mep")
+
+
+def legacy_key_dirs(start_path: Optional[str] = None) -> list[str]:
+    git_root = find_git_root(start_path)
+    if not git_root:
+        return []
+    repo_local = os.path.join(git_root, ".mep")
+    canonical_default = os.path.normcase(os.path.abspath(default_key_dir()))
+    canonical_repo = os.path.normcase(os.path.abspath(repo_local))
+    if canonical_repo == canonical_default:
+        return []
+    return [repo_local]
+
+
+def default_key_path() -> str:
+    explicit = os.getenv("MEP_PROVIDER_KEY_PATH")
+    if explicit:
+        return explicit
+    return os.path.join(default_key_dir(), LEGACY_RUNTIME_KEY_NAME)
+
+
+def ensure_key_parent(path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+
+
+def same_path(left: str, right: str) -> bool:
+    return os.path.normcase(os.path.abspath(left)) == os.path.normcase(os.path.abspath(right))
+
+
+def canonical_key_path(key_dir: str, node_id: str) -> str:
+    return os.path.join(key_dir, f"{node_id}.pem")
+
+
+def enc_key_path(key_path: str) -> str:
+    return f"{key_path}.x25519.pem"
+
+
+def legacy_enc_key_path(key_path: str) -> str:
+    return key_path.replace(".pem", "_enc.pem")
+
+
+def pending_key_path(key_dir: str) -> str:
+    return os.path.join(key_dir, f".pending-runtime-{os.getpid()}-{int(time.time() * 1000)}.pem")
+
+
+def is_identity_key_file(filename: str) -> bool:
+    return (
+        filename.endswith(".pem")
+        and not filename.endswith("_enc.pem")
+        and not filename.endswith(".x25519.pem")
+        and not filename.startswith(".pending-runtime-")
+    )
+
+
+def list_local_identity_key_paths(key_dir: str) -> list[str]:
+    if not os.path.isdir(key_dir):
+        return []
+    return [
+        os.path.join(key_dir, name)
+        for name in sorted(os.listdir(key_dir))
+        if is_identity_key_file(name) and os.path.isfile(os.path.join(key_dir, name))
+    ]
+
+
+def move_file_if_present(source: str, destination: str) -> None:
+    if same_path(source, destination) or not os.path.exists(source):
+        return
+    ensure_key_parent(destination)
+    os.replace(source, destination)
+
+
+def alias_sidecar_path(key_path: str) -> str:
+    return f"{key_path}.alias"
+
+
+def write_alias_sidecar(key_path: str, alias: str) -> None:
+    ensure_key_parent(alias_sidecar_path(key_path))
+    with open(alias_sidecar_path(key_path), "w", encoding="utf-8") as handle:
+        handle.write(alias.strip() + "\n")
+
+
+def read_alias_sidecar(key_path: str) -> Optional[str]:
+    path = alias_sidecar_path(key_path)
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as handle:
+        alias = handle.read().strip()
+    return alias or None
+
+
+def _derive_node_id_from_signing_key(key_path: str) -> str:
+    with open(key_path, "rb") as handle:
+        private_key = serialization.load_pem_private_key(handle.read(), password=None)
+    if not isinstance(private_key, ed25519.Ed25519PrivateKey):
+        raise ValueError("Unsupported private key type")
+    pub_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    return f"node_{hashlib.sha256(pub_pem.encode('utf-8')).hexdigest()[:12]}"
+
+
+def canonicalize_local_identity(key_path: str, key_dir: str) -> str:
+    node_id = _derive_node_id_from_signing_key(key_path)
+    canonical_path = canonical_key_path(key_dir, node_id)
+    if same_path(key_path, canonical_path):
+        return canonical_path
+
+    move_file_if_present(key_path, canonical_path)
+    move_file_if_present(enc_key_path(key_path), enc_key_path(canonical_path))
+    move_file_if_present(legacy_enc_key_path(key_path), legacy_enc_key_path(canonical_path))
+
+    source_alias = alias_sidecar_path(key_path)
+    dest_alias = alias_sidecar_path(canonical_path)
+    if os.path.exists(source_alias) and not os.path.exists(dest_alias):
+        move_file_if_present(source_alias, dest_alias)
+
+    return canonical_path
+
+
+def _identity_registry_path() -> str:
+    return os.path.join(default_key_dir(), IDENTITY_REGISTRY_NAME)
+
+
+def _load_identity_registry() -> dict:
+    path = _identity_registry_path()
+    if not os.path.exists(path):
+        return {"aliases": {}, "nodes": {}}
+    with open(path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        return {"aliases": {}, "nodes": {}}
+    payload.setdefault("aliases", {})
+    payload.setdefault("nodes", {})
+    return payload
+
+
+def _save_identity_registry(payload: dict) -> None:
+    path = _identity_registry_path()
+    ensure_key_parent(path)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+
+
+def remember_identity(key_path: str, alias: Optional[str] = None) -> str:
+    resolved = os.path.abspath(key_path)
+    if not os.path.exists(resolved):
+        return resolved
+    node_id = _derive_node_id_from_signing_key(resolved)
+    payload = _load_identity_registry()
+    node_entry = {
+        "key_path": resolved,
+        "updated_at": int(time.time()),
+    }
+    if alias:
+        alias_clean = alias.strip()
+        if alias_clean:
+            node_entry["alias"] = alias_clean
+            payload["aliases"][alias_clean] = {"key_path": resolved, "node_id": node_id}
+            write_alias_sidecar(resolved, alias_clean)
+    payload["nodes"][node_id] = node_entry
+    _save_identity_registry(payload)
+    return resolved
+
+
+def _lookup_registry_alias(alias_hint: Optional[str]) -> Optional[str]:
+    if not alias_hint:
+        return None
+    payload = _load_identity_registry()
+    entry = payload.get("aliases", {}).get(alias_hint)
+    if not isinstance(entry, dict):
+        return None
+    key_path = entry.get("key_path")
+    if not isinstance(key_path, str) or not key_path:
+        return None
+    if not os.path.exists(key_path):
+        return None
+    remember_identity(key_path, alias_hint)
+    return key_path
+
+
+def _collect_identity_candidates(search_dirs: list[str], alias_hint: Optional[str]) -> tuple[list[str], list[str]]:
+    matches: list[str] = []
+    candidates: list[str] = []
+    seen_paths: set[str] = set()
+    for key_dir in search_dirs:
+        for path in list_local_identity_key_paths(key_dir):
+            canonical = canonicalize_local_identity(path, key_dir)
+            normed = os.path.normcase(os.path.abspath(canonical))
+            if normed in seen_paths:
+                continue
+            seen_paths.add(normed)
+            candidates.append(canonical)
+            if alias_hint and read_alias_sidecar(canonical) == alias_hint:
+                matches.append(canonical)
+    return matches, candidates
+
+
+def choose_existing_local_identity(key_dir: str, cli_alias: Optional[str]) -> Optional[str]:
+    candidates = list_local_identity_key_paths(key_dir)
+    if not candidates:
+        return None
+    if cli_alias:
+        matching = [path for path in candidates if read_alias_sidecar(path) == cli_alias]
+        if len(matching) == 1:
+            return canonicalize_local_identity(matching[0], key_dir)
+        if len(matching) > 1:
+            raise RuntimeKeyPathError(
+                f"multiple local identities in {key_dir} use alias={cli_alias!r}; pass --key-path explicitly"
+            )
+        if len(candidates) == 1:
+            raise RuntimeKeyPathError(
+                f"no local identity in {key_dir} matches alias={cli_alias!r}; pass --key-path explicitly"
+            )
+    if len(candidates) == 1:
+        return canonicalize_local_identity(candidates[0], key_dir)
+    raise RuntimeKeyPathError(
+        f"multiple local identities found in {key_dir}; pass --key-path or --alias for an existing node"
+    )
+
+
+def create_new_local_identity(key_dir: str) -> str:
+    os.makedirs(key_dir, exist_ok=True)
+    pending_path = pending_key_path(key_dir)
+    MEPIdentity(pending_path)
+    created = canonicalize_local_identity(pending_path, key_dir)
+    remember_identity(created)
+    return created
+
+
+def resolve_identity_key_path(
+    *,
+    explicit_key_path: Optional[str] = None,
+    manifest_key_path: Optional[str] = None,
+    alias_hint: Optional[str] = None,
+    create_if_missing: bool = False,
+    start_path: Optional[str] = None,
+) -> str:
+    if explicit_key_path:
+        remember_identity(explicit_key_path, alias_hint)
+        return explicit_key_path
+    if manifest_key_path:
+        remember_identity(manifest_key_path, alias_hint)
+        return manifest_key_path
+
+    registry_match = _lookup_registry_alias(alias_hint)
+    if registry_match:
+        return registry_match
+
+    search_dirs = [default_key_dir(), *legacy_key_dirs(start_path)]
+    deduped: list[str] = []
+    seen_dirs: set[str] = set()
+    for key_dir in search_dirs:
+        normed = os.path.normcase(os.path.abspath(key_dir))
+        if normed in seen_dirs:
+            continue
+        seen_dirs.add(normed)
+        deduped.append(key_dir)
+
+    matches, candidates = _collect_identity_candidates(deduped, alias_hint)
+    if matches:
+        if len(matches) > 1:
+            raise RuntimeKeyPathError(
+                f"multiple local identities match alias={alias_hint!r}; pass --key-path explicitly"
+            )
+        return remember_identity(matches[0], alias_hint)
+    if alias_hint and len(candidates) == 1:
+        raise RuntimeKeyPathError(
+            f"no local identity matches alias={alias_hint!r}; pass --key-path explicitly"
+        )
+    if len(candidates) == 1:
+        return remember_identity(candidates[0], alias_hint)
+    if len(candidates) > 1:
+        raise RuntimeKeyPathError(
+            "multiple local identities found across persistent key directories; "
+            "pass --key-path or --alias for an existing node"
+        )
+    if create_if_missing:
+        created = create_new_local_identity(default_key_dir())
+        return remember_identity(created, alias_hint)
+    raise RuntimeKeyPathError(
+        f"no local identity found in {default_key_dir()}; run `init`/`up` first or pass --key-path explicitly"
+    )

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -2,12 +2,12 @@ import asyncio
 import json
 import os
 import shlex
-import tempfile
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
 
 from clients.shared.commands import parse_task_args
+from clients.shared.identity_paths import remember_identity, resolve_identity_key_path
 from clients.shared.mep_client import MEPClient
 
 DEFAULT_BOUNTY = float(os.getenv("MEP_DEFAULT_BOUNTY", "5.0"))
@@ -15,11 +15,17 @@ DEFAULT_BOUNTY = float(os.getenv("MEP_DEFAULT_BOUNTY", "5.0"))
 
 class StdioAdapter:
     def __init__(self, platform_name: str, default_model: str, key_file_name: str):
-        key_path = os.getenv("MEP_BOT_KEY_PATH", os.path.join(tempfile.gettempdir(), key_file_name))
+        alias = os.getenv("MEP_ALIAS", platform_name)
+        key_path = resolve_identity_key_path(
+            explicit_key_path=os.getenv("MEP_BOT_KEY_PATH"),
+            alias_hint=alias,
+            create_if_missing=True,
+        )
         self.platform_name = platform_name
         self.default_model = default_model
         self.client = MEPClient(key_path)
-        self.alias = os.getenv("MEP_ALIAS", platform_name)
+        self.alias = alias
+        remember_identity(self.client.identity.key_path, self.alias)
         self._recent_interbot_results: dict[str, dict[str, Any]] = {}
         self.live_call_enabled = os.getenv("MEP_LIVE_CALL_ENABLED", "0") not in ("0", "false", "False", "")
         self.call_auto_accept = os.getenv("MEP_CALL_AUTO_ACCEPT", "0") not in ("0", "false", "False", "")

--- a/clients/shared/stdio_adapter.py
+++ b/clients/shared/stdio_adapter.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from clients.shared.commands import parse_task_args
-from clients.shared.identity_paths import remember_identity, resolve_identity_key_path
+from clients.shared.identity_paths import default_key_dir, remember_identity, resolve_identity_key_path
 from clients.shared.mep_client import MEPClient
 
 DEFAULT_BOUNTY = float(os.getenv("MEP_DEFAULT_BOUNTY", "5.0"))
@@ -16,8 +16,11 @@ DEFAULT_BOUNTY = float(os.getenv("MEP_DEFAULT_BOUNTY", "5.0"))
 class StdioAdapter:
     def __init__(self, platform_name: str, default_model: str, key_file_name: str):
         alias = os.getenv("MEP_ALIAS", platform_name)
+        explicit_key_path = os.getenv("MEP_BOT_KEY_PATH")
+        if not explicit_key_path:
+            explicit_key_path = os.path.join(default_key_dir(), key_file_name)
         key_path = resolve_identity_key_path(
-            explicit_key_path=os.getenv("MEP_BOT_KEY_PATH"),
+            explicit_key_path=explicit_key_path,
             alias_hint=alias,
             create_if_missing=True,
         )

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -36,6 +36,11 @@ try:
 except ImportError:  # pragma: no cover - direct file execution from node/ may not see repo root
     MEPClient = None  # type: ignore[assignment]
 
+try:
+    from clients.shared import identity_paths
+except ImportError:  # pragma: no cover - direct file execution from node/ may not see repo root
+    identity_paths = None  # type: ignore[assignment]
+
 
 DEFAULT_HUB_URL = os.getenv("HUB_URL", "http://localhost:8000")
 DEFAULT_WS_URL = os.getenv("WS_URL", "ws://localhost:8000")
@@ -98,6 +103,8 @@ def _env_positive_int(name: str, default: int) -> int:
 
 
 def _find_git_root(start_path: Optional[str] = None) -> Optional[str]:
+    if identity_paths is not None:
+        return identity_paths.find_git_root(start_path)
     current = os.path.abspath(start_path or os.getcwd())
     while True:
         git_marker = os.path.join(current, ".git")
@@ -110,16 +117,17 @@ def _find_git_root(start_path: Optional[str] = None) -> Optional[str]:
 
 
 def _default_key_dir() -> str:
+    if identity_paths is not None:
+        return identity_paths.default_key_dir()
     explicit = os.getenv("MEP_KEY_DIR")
     if explicit:
         return explicit
-    git_root = _find_git_root()
-    if git_root:
-        return os.path.join(git_root, ".mep")
     return os.path.join(os.path.expanduser("~"), ".mep")
 
 
 def _default_key_path() -> str:
+    if identity_paths is not None:
+        return identity_paths.default_key_path()
     explicit = os.getenv("MEP_PROVIDER_KEY_PATH")
     if explicit:
         return explicit
@@ -127,26 +135,39 @@ def _default_key_path() -> str:
 
 
 def _ensure_key_parent(path: str) -> None:
+    if identity_paths is not None:
+        identity_paths.ensure_key_parent(path)
+        return
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
 
 def _same_path(left: str, right: str) -> bool:
+    if identity_paths is not None:
+        return identity_paths.same_path(left, right)
     return os.path.normcase(os.path.abspath(left)) == os.path.normcase(os.path.abspath(right))
 
 
 def _canonical_key_path(key_dir: str, node_id: str) -> str:
+    if identity_paths is not None:
+        return identity_paths.canonical_key_path(key_dir, node_id)
     return os.path.join(key_dir, f"{node_id}.pem")
 
 
 def _enc_key_path(key_path: str) -> str:
+    if identity_paths is not None:
+        return identity_paths.enc_key_path(key_path)
     return key_path.replace(".pem", "_enc.pem")
 
 
 def _pending_key_path(key_dir: str) -> str:
+    if identity_paths is not None:
+        return identity_paths.pending_key_path(key_dir)
     return os.path.join(key_dir, f".pending-runtime-{os.getpid()}-{int(time.time() * 1000)}.pem")
 
 
 def _is_identity_key_file(filename: str) -> bool:
+    if identity_paths is not None:
+        return identity_paths.is_identity_key_file(filename)
     return (
         filename.endswith(".pem")
         and not filename.endswith("_enc.pem")
@@ -155,6 +176,8 @@ def _is_identity_key_file(filename: str) -> bool:
 
 
 def _list_local_identity_key_paths(key_dir: str) -> list[str]:
+    if identity_paths is not None:
+        return identity_paths.list_local_identity_key_paths(key_dir)
     if not os.path.isdir(key_dir):
         return []
     return [
@@ -165,6 +188,9 @@ def _list_local_identity_key_paths(key_dir: str) -> list[str]:
 
 
 def _move_file_if_present(source: str, destination: str) -> None:
+    if identity_paths is not None:
+        identity_paths.move_file_if_present(source, destination)
+        return
     if _same_path(source, destination) or not os.path.exists(source):
         return
     _ensure_key_parent(destination)
@@ -172,15 +198,22 @@ def _move_file_if_present(source: str, destination: str) -> None:
 
 
 def _alias_sidecar_path(key_path: str) -> str:
+    if identity_paths is not None:
+        return identity_paths.alias_sidecar_path(key_path)
     return f"{key_path}.alias"
 
 
 def _write_alias_sidecar(key_path: str, alias: str) -> None:
+    if identity_paths is not None:
+        identity_paths.write_alias_sidecar(key_path, alias)
+        return
     with open(_alias_sidecar_path(key_path), "w", encoding="utf-8") as handle:
         handle.write(alias.strip() + "\n")
 
 
 def _read_alias_sidecar(key_path: str) -> Optional[str]:
+    if identity_paths is not None:
+        return identity_paths.read_alias_sidecar(key_path)
     path = _alias_sidecar_path(key_path)
     if not os.path.exists(path):
         return None
@@ -198,11 +231,16 @@ def _resolve_runtime_alias(key_path: str, cli_alias: Optional[str], *, node_id: 
     return node_id
 
 
-class RuntimeKeyPathError(ValueError):
-    """Raised when runtime identity selection is ambiguous or missing."""
+if identity_paths is not None:
+    RuntimeKeyPathError = identity_paths.RuntimeKeyPathError
+else:
+    class RuntimeKeyPathError(ValueError):
+        """Raised when runtime identity selection is ambiguous or missing."""
 
 
 def _canonicalize_local_identity(key_path: str, key_dir: str) -> str:
+    if identity_paths is not None:
+        return identity_paths.canonicalize_local_identity(key_path, key_dir)
     identity = MEPIdentity(key_path)
     canonical_path = _canonical_key_path(key_dir, identity.node_id)
     if _same_path(key_path, canonical_path):
@@ -220,6 +258,8 @@ def _canonicalize_local_identity(key_path: str, key_dir: str) -> str:
 
 
 def _choose_existing_local_identity(key_dir: str, cli_alias: Optional[str]) -> Optional[str]:
+    if identity_paths is not None:
+        return identity_paths.choose_existing_local_identity(key_dir, cli_alias)
     candidates = _list_local_identity_key_paths(key_dir)
     if not candidates:
         return None
@@ -246,12 +286,20 @@ def _choose_existing_local_identity(key_dir: str, cli_alias: Optional[str]) -> O
 
 
 def _create_new_local_identity(key_dir: str) -> str:
+    if identity_paths is not None:
+        return identity_paths.create_new_local_identity(key_dir)
     os.makedirs(key_dir, exist_ok=True)
     pending_path = _pending_key_path(key_dir)
     return _canonicalize_local_identity(pending_path, key_dir)
 
 
 def _resolve_default_runtime_key_path(command: str, cli_alias: Optional[str]) -> str:
+    if identity_paths is not None:
+        return identity_paths.resolve_identity_key_path(
+            explicit_key_path=os.getenv("MEP_PROVIDER_KEY_PATH"),
+            alias_hint=cli_alias,
+            create_if_missing=command in {"init", "up"},
+        )
     explicit = os.getenv("MEP_PROVIDER_KEY_PATH")
     if explicit:
         return explicit

--- a/tests/test_execution_bridge.py
+++ b/tests/test_execution_bridge.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -104,6 +105,7 @@ def test_prepare_dm_reply_payload_requires_encryption(monkeypatch, tmp_path: Pat
 
 def test_codex_provider_routes_execution_dm_to_bridge(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("MEP_PRIVACY_MODE", "plaintext_only")
+    monkeypatch.setenv("MEP_KEY_DIR", str(tmp_path / ".mep-home"))
     provider = CodexProvider()
     fake_session = _FakeSession()
     provider.client.session = fake_session
@@ -147,3 +149,19 @@ def test_codex_provider_routes_execution_dm_to_bridge(monkeypatch, tmp_path: Pat
     assert "FILE_EDITED yes." in result_payload
     assert "FILE scripts/github-actions/verify_checkout_provenance.sh." in result_payload
     assert "BRANCH feat/runtime-bridge." in result_payload
+
+
+def test_codex_provider_uses_persistent_identity_store(monkeypatch, tmp_path: Path) -> None:
+    store_dir = tmp_path / ".mep-home"
+    monkeypatch.setenv("MEP_KEY_DIR", str(store_dir))
+    monkeypatch.delenv("MEP_BOT_KEY_PATH", raising=False)
+    monkeypatch.delenv("MEP_MANIFEST_PATH", raising=False)
+    monkeypatch.setenv("MEP_ALIAS", "Persistent Codex")
+
+    provider = CodexProvider()
+
+    assert Path(provider.client.identity.key_path).parent == store_dir
+    assert provider.client.identity.key_path.endswith(".pem")
+    registry = json.loads((store_dir / "bots.json").read_text(encoding="utf-8"))
+    assert registry["aliases"]["Persistent Codex"]["key_path"] == provider.client.identity.key_path
+    assert os.path.exists(provider.client.identity.key_path)

--- a/tests/test_identity_paths.py
+++ b/tests/test_identity_paths.py
@@ -1,0 +1,67 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from clients.shared.identity import MEPIdentity
+from clients.shared import identity_paths
+
+
+class TestIdentityPaths(unittest.TestCase):
+    def test_default_key_dir_uses_shared_home_resolver(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {}, clear=True):
+                with patch("clients.shared.identity_paths._user_home_dir", return_value=tmpdir):
+                    self.assertEqual(identity_paths.default_key_dir(), os.path.join(tmpdir, ".mep"))
+
+    def test_resolve_identity_key_path_creates_stable_home_identity_and_registry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"MEP_KEY_DIR": tmpdir}, clear=False):
+                key_path = identity_paths.resolve_identity_key_path(
+                    alias_hint="alpha-bot",
+                    create_if_missing=True,
+                )
+
+            self.assertTrue(key_path.startswith(tmpdir))
+            self.assertTrue(os.path.exists(key_path))
+            self.assertEqual(identity_paths.read_alias_sidecar(key_path), "alpha-bot")
+            with open(os.path.join(tmpdir, "bots.json"), "r", encoding="utf-8") as handle:
+                registry = json.load(handle)
+            self.assertEqual(registry["aliases"]["alpha-bot"]["key_path"], key_path)
+
+    def test_resolve_identity_key_path_recovers_registered_alias_across_worktrees(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_local = os.path.join(tmpdir, "repo_a", ".mep")
+            os.makedirs(repo_local, exist_ok=True)
+            key_path = os.path.join(repo_local, "auditor.pem")
+            MEPIdentity(key_path)
+            with patch.dict(os.environ, {"MEP_KEY_DIR": os.path.join(tmpdir, "home_store")}, clear=False):
+                identity_paths.remember_identity(key_path, "Trae Repo Auditor")
+                recovered = identity_paths.resolve_identity_key_path(alias_hint="Trae Repo Auditor")
+
+            self.assertEqual(os.path.abspath(recovered), os.path.abspath(key_path))
+
+    def test_resolve_identity_key_path_recovers_legacy_repo_local_identity(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = os.path.join(tmpdir, "repo")
+            nested = os.path.join(repo_root, "node")
+            os.makedirs(nested, exist_ok=True)
+            os.makedirs(os.path.join(repo_root, ".git"), exist_ok=True)
+            legacy_dir = os.path.join(repo_root, ".mep")
+            os.makedirs(legacy_dir, exist_ok=True)
+            key_path = os.path.join(legacy_dir, "legacy.pem")
+            identity = MEPIdentity(key_path)
+            identity_paths.write_alias_sidecar(key_path, "legacy-bot")
+
+            with patch.dict(os.environ, {}, clear=True):
+                with patch("os.getcwd", return_value=nested):
+                    recovered = identity_paths.resolve_identity_key_path(
+                        alias_hint="legacy-bot",
+                        start_path=nested,
+                    )
+
+            self.assertEqual(
+                os.path.abspath(recovered),
+                os.path.abspath(os.path.join(legacy_dir, f"{identity.node_id}.pem")),
+            )

--- a/tests/test_identity_paths.py
+++ b/tests/test_identity_paths.py
@@ -30,6 +30,26 @@ class TestIdentityPaths(unittest.TestCase):
                 registry = json.load(handle)
             self.assertEqual(registry["aliases"]["alpha-bot"]["key_path"], key_path)
 
+    def test_resolve_identity_key_path_creates_new_alias_when_store_has_other_bot(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"MEP_KEY_DIR": tmpdir}, clear=False):
+                alpha_key = identity_paths.resolve_identity_key_path(
+                    alias_hint="alpha-bot",
+                    create_if_missing=True,
+                )
+                beta_key = identity_paths.resolve_identity_key_path(
+                    alias_hint="beta-bot",
+                    create_if_missing=True,
+                )
+
+            self.assertNotEqual(os.path.abspath(alpha_key), os.path.abspath(beta_key))
+            self.assertEqual(identity_paths.read_alias_sidecar(alpha_key), "alpha-bot")
+            self.assertEqual(identity_paths.read_alias_sidecar(beta_key), "beta-bot")
+            with open(os.path.join(tmpdir, "bots.json"), "r", encoding="utf-8") as handle:
+                registry = json.load(handle)
+            self.assertEqual(registry["aliases"]["alpha-bot"]["key_path"], alpha_key)
+            self.assertEqual(registry["aliases"]["beta-bot"]["key_path"], beta_key)
+
     def test_resolve_identity_key_path_recovers_registered_alias_across_worktrees(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_local = os.path.join(tmpdir, "repo_a", ".mep")

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -1726,7 +1726,7 @@ class TestRuntimeKeyDirResolution(unittest.TestCase):
 
     def test_main_rejects_run_without_key_when_identity_selection_is_ambiguous(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch.object(mep_runtime, "_default_key_dir", return_value=tmpdir):
+            with patch.dict(os.environ, {"MEP_KEY_DIR": tmpdir}, clear=False):
                 MEPIdentity(os.path.join(tmpdir, "alpha.pem"))
                 MEPIdentity(os.path.join(tmpdir, "beta.pem"))
 


### PR DESCRIPTION
## Summary
- add a shared persistent identity-path resolver for bot runtimes and providers
- move default persistent bot identities to a stable home-level .mep store while still honoring explicit env and manifest key paths
- recover older repo-local identities by alias, record alias-to-key metadata in a local registry, and remove temp-key fallback from shared bot entrypoints

## Why
- bots were losing continuity across sessions and worktrees because some entrypoints still defaulted to temp PEMs
- runtime identity selection existed, but it was not shared across all bot paths and repo-local defaults made worktree switches brittle
- this patch keeps identity recovery generic and data-driven without hardcoding any alias or node id

## Validation
- python -m pytest tests/test_identity_paths.py tests/test_execution_bridge.py tests/test_node_runtime.py