### PR TITLE
Implement issue #297 governance V1 hooks

### DIFF
--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -33,6 +33,8 @@ DEFAULT_EXECUTION_MUST_INCLUDE = [
 ]
 REVIEW_VERDICTS = {"approve", "approve_with_conditions", "request_changes", "block"}
 HUMAN_APPROVAL_DECISION_TYPES = {"merge_decision", "deploy_decision", "policy_decision"}
+GOVERNANCE_CLASSIFICATIONS = {"safe", "approval_required", "forbidden"}
+GOVERNANCE_APPROVAL_STATUSES = {"pending", "approved", "denied"}
 
 
 class MEPClient:
@@ -339,6 +341,7 @@ class MEPClient:
         trace_id: Optional[str] = None,
         task_title: Optional[str] = None,
         session_safety: Optional[dict[str, Any]] = None,
+        governance: Optional[dict[str, Any]] = None,
         turn_index: Optional[int] = None,
     ) -> dict[str, Any]:
         message_uuid = message_id or str(uuid.uuid4())
@@ -357,6 +360,9 @@ class MEPClient:
             normalized_session_safety["started_at_ms"] = timestamp_ms
         if normalized_session_safety:
             inputs["session_safety"] = normalized_session_safety
+        normalized_governance = self._normalize_governance_input(governance) if governance else None
+        if normalized_governance:
+            inputs["governance"] = normalized_governance
         if expected_output_must_include:
             task_payload["expected_output"]["must_include"] = list(expected_output_must_include)
         if inputs:
@@ -413,6 +419,7 @@ class MEPClient:
         message_id: Optional[str] = None,
         trace_id: Optional[str] = None,
         session_safety: Optional[dict[str, Any]] = None,
+        governance: Optional[dict[str, Any]] = None,
         turn_index: Optional[int] = None,
     ) -> dict:
         envelope = self.build_interbot_message(
@@ -434,6 +441,7 @@ class MEPClient:
             message_id=message_id,
             trace_id=trace_id,
             session_safety=session_safety,
+            governance=governance,
             turn_index=turn_index,
         )
         response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
@@ -531,6 +539,7 @@ class MEPClient:
         max_cost_seconds: Optional[float] = None,
         human_note: Optional[str] = None,
         session_safety: Optional[dict[str, Any]] = None,
+        governance: Optional[dict[str, Any]] = None,
         turn_index: Optional[int] = None,
     ) -> dict[str, Any]:
         constraints: dict[str, Any] = {}
@@ -562,6 +571,7 @@ class MEPClient:
             constraints=constraints or None,
             human_note=human_note,
             session_safety=session_safety,
+            governance=governance,
             turn_index=turn_index,
         )
 
@@ -583,6 +593,7 @@ class MEPClient:
         max_cost_seconds: Optional[float] = None,
         human_note: Optional[str] = None,
         session_safety: Optional[dict[str, Any]] = None,
+        governance: Optional[dict[str, Any]] = None,
         turn_index: Optional[int] = None,
     ) -> dict:
         envelope = self.build_execution_request_message(
@@ -601,6 +612,7 @@ class MEPClient:
             max_cost_seconds=max_cost_seconds,
             human_note=human_note,
             session_safety=session_safety,
+            governance=governance,
             turn_index=turn_index,
         )
         response = await self.submit_task(json.dumps(envelope), 0.0, None, target_node)
@@ -896,6 +908,13 @@ class MEPClient:
         if normalized_next_action:
             message_lines.append(f"Recommended next action: {normalized_next_action}")
 
+        governance_payload = self.build_governance_metadata(
+            classification="approval_required",
+            reason=f"human approval required for {normalized_decision_type}",
+            disclosure_scope=[normalized_decision_type],
+            approval_status="pending",
+        )
+
         return self.build_interbot_message(
             "\n".join(message_lines),
             target_node,
@@ -910,6 +929,7 @@ class MEPClient:
             human_note=human_note,
             task_title="Human approval request",
             task_inputs={"human_approval_request": approval_payload},
+            governance=governance_payload,
             turn_index=turn_index,
         )
 
@@ -1154,6 +1174,57 @@ class MEPClient:
         return normalized
 
     @classmethod
+    def build_governance_metadata(
+        cls,
+        *,
+        classification: str,
+        reason: str,
+        disclosure_scope: Optional[list[str]] = None,
+        redaction_applied: bool = False,
+        approval_status: Optional[str] = None,
+        approval_context_id: Optional[str] = None,
+        approved_by: Optional[str] = None,
+    ) -> dict[str, Any]:
+        normalized_classification = classification.strip().lower() if isinstance(classification, str) else ""
+        if normalized_classification not in GOVERNANCE_CLASSIFICATIONS:
+            raise ValueError(f"unsupported governance classification: {classification}")
+        normalized_reason = reason.strip() if isinstance(reason, str) else ""
+        if not normalized_reason:
+            raise ValueError("governance reason must be non-empty")
+        normalized: dict[str, Any] = {
+            "classification": normalized_classification,
+            "reason": normalized_reason,
+            "redaction_applied": bool(redaction_applied),
+        }
+        normalized_scope = cls._normalize_string_list(disclosure_scope)
+        if normalized_scope:
+            normalized["disclosure_scope"] = normalized_scope
+        if approval_status is not None:
+            normalized_status = approval_status.strip().lower() if isinstance(approval_status, str) else ""
+            if normalized_status not in GOVERNANCE_APPROVAL_STATUSES:
+                raise ValueError(f"unsupported governance approval status: {approval_status}")
+            approval_payload: dict[str, Any] = {"status": normalized_status}
+            if isinstance(approval_context_id, str) and approval_context_id.strip():
+                approval_payload["context_id"] = approval_context_id.strip()
+            if isinstance(approved_by, str) and approved_by.strip():
+                approval_payload["approved_by"] = approved_by.strip()
+            normalized["approval"] = approval_payload
+        return normalized
+
+    @classmethod
+    def _normalize_governance_input(cls, governance: dict[str, Any]) -> dict[str, Any]:
+        approval = governance.get("approval") if isinstance(governance.get("approval"), dict) else {}
+        return cls.build_governance_metadata(
+            classification=governance.get("classification"),
+            reason=governance.get("reason"),
+            disclosure_scope=governance.get("disclosure_scope"),
+            redaction_applied=bool(governance.get("redaction_applied", False)),
+            approval_status=approval.get("status"),
+            approval_context_id=approval.get("context_id"),
+            approved_by=approval.get("approved_by"),
+        )
+
+    @classmethod
     def extract_human_approval_request(cls, payload_text: str) -> Optional[dict[str, Any]]:
         parsed = cls.parse_interbot_payload(payload_text)
         if not parsed:
@@ -1185,6 +1256,25 @@ class MEPClient:
         if isinstance(recommended_next_action, str) and recommended_next_action.strip():
             extracted["recommended_next_action"] = recommended_next_action.strip()
         return extracted
+
+    @classmethod
+    def extract_governance_metadata(cls, payload_text: str) -> Optional[dict[str, Any]]:
+        parsed = cls.parse_interbot_payload(payload_text)
+        if not parsed:
+            return None
+        task = parsed.get("task")
+        if not isinstance(task, dict):
+            return None
+        inputs = task.get("inputs")
+        if not isinstance(inputs, dict):
+            return None
+        governance = inputs.get("governance")
+        if not isinstance(governance, dict):
+            return None
+        try:
+            return cls._normalize_governance_input(governance)
+        except ValueError:
+            return None
 
     @staticmethod
     def _default_reply_intent_type(inbound_intent_type: Optional[str]) -> str:

--- a/hub/main.py
+++ b/hub/main.py
@@ -124,6 +124,10 @@ MAX_BODY_BYTES = 200_000
 MAX_PAYLOAD_CHARS = 20_000
 RATE_LIMIT_WINDOW = 10.0
 RATE_LIMIT_MAX = 50
+INTERBOT_GOVERNANCE_CLASSIFICATIONS = {"safe", "approval_required", "forbidden"}
+INTERBOT_GOVERNANCE_APPROVAL_STATUSES = {"pending", "approved", "denied"}
+INTERBOT_REVIEW_VERDICTS = {"approve", "approve_with_conditions", "request_changes", "block"}
+INTERBOT_HUMAN_APPROVAL_INTENTS = {"human.approval.request"}
 
 def get_hub_urls(request: Request) -> tuple:
     """Get correct Hub and WebSocket URLs for clients."""
@@ -897,6 +901,224 @@ def _interbot_require_string(data: dict, field_name: str) -> str:
     return value.strip()
 
 
+def _parse_interbot_message(payload_text: str) -> Optional[dict]:
+    try:
+        parsed = json.loads(payload_text)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    if parsed.get("spec_version") != INTERBOT_SPEC_VERSION:
+        return None
+    return parsed
+
+
+def _normalize_interbot_string_list(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    normalized: list[str] = []
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            normalized.append(value.strip())
+    return normalized
+
+
+def _extract_interbot_governance(message_obj: dict) -> Optional[dict]:
+    task_obj = message_obj.get("task")
+    if not isinstance(task_obj, dict):
+        return None
+    inputs_obj = task_obj.get("inputs")
+    if not isinstance(inputs_obj, dict):
+        return None
+    governance_obj = inputs_obj.get("governance")
+    if governance_obj is None:
+        return None
+    if not isinstance(governance_obj, dict):
+        raise HTTPException(status_code=400, detail="Inter-bot payload task.inputs.governance must be an object")
+    classification = governance_obj.get("classification")
+    if not isinstance(classification, str) or classification.strip().lower() not in INTERBOT_GOVERNANCE_CLASSIFICATIONS:
+        raise HTTPException(status_code=400, detail="Inter-bot payload governance.classification invalid")
+    reason = governance_obj.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
+        raise HTTPException(status_code=400, detail="Inter-bot payload governance.reason must be non-empty")
+    normalized: dict[str, Any] = {
+        "classification": classification.strip().lower(),
+        "reason": reason.strip(),
+        "redaction_applied": bool(governance_obj.get("redaction_applied", False)),
+    }
+    disclosure_scope = _normalize_interbot_string_list(governance_obj.get("disclosure_scope"))
+    if disclosure_scope:
+        normalized["disclosure_scope"] = disclosure_scope
+    approval_obj = governance_obj.get("approval")
+    if approval_obj is not None:
+        if not isinstance(approval_obj, dict):
+            raise HTTPException(status_code=400, detail="Inter-bot payload governance.approval must be an object")
+        status = approval_obj.get("status")
+        if not isinstance(status, str) or status.strip().lower() not in INTERBOT_GOVERNANCE_APPROVAL_STATUSES:
+            raise HTTPException(status_code=400, detail="Inter-bot payload governance.approval.status invalid")
+        normalized_approval: dict[str, Any] = {"status": status.strip().lower()}
+        context_id = approval_obj.get("context_id")
+        if isinstance(context_id, str) and context_id.strip():
+            normalized_approval["context_id"] = context_id.strip()
+        approved_by = approval_obj.get("approved_by")
+        if isinstance(approved_by, str) and approved_by.strip():
+            normalized_approval["approved_by"] = approved_by.strip()
+        normalized["approval"] = normalized_approval
+    return normalized
+
+
+def _extract_human_approval_request(message_obj: dict) -> Optional[dict]:
+    task_obj = message_obj.get("task")
+    if not isinstance(task_obj, dict):
+        return None
+    inputs_obj = task_obj.get("inputs")
+    if not isinstance(inputs_obj, dict):
+        return None
+    approval_obj = inputs_obj.get("human_approval_request")
+    if not isinstance(approval_obj, dict):
+        return None
+    decision_type = approval_obj.get("decision_type")
+    summary = approval_obj.get("summary")
+    if not isinstance(decision_type, str) or not decision_type.strip():
+        return None
+    if not isinstance(summary, str) or not summary.strip():
+        return None
+    extracted: dict[str, Any] = {
+        "decision_type": decision_type.strip().lower(),
+        "summary": summary.strip(),
+        "blockers": _normalize_interbot_string_list(approval_obj.get("blockers")),
+    }
+    review_decision = approval_obj.get("review_decision")
+    if isinstance(review_decision, str) and review_decision.strip().lower() in INTERBOT_REVIEW_VERDICTS:
+        extracted["review_decision"] = review_decision.strip().lower()
+    next_action = approval_obj.get("recommended_next_action")
+    if isinstance(next_action, str) and next_action.strip():
+        extracted["recommended_next_action"] = next_action.strip()
+    return extracted
+
+
+def _extract_review_verdict(message_obj: dict) -> Optional[dict]:
+    task_obj = message_obj.get("task")
+    if not isinstance(task_obj, dict):
+        return None
+    inputs_obj = task_obj.get("inputs")
+    if not isinstance(inputs_obj, dict):
+        return None
+    verdict_obj = inputs_obj.get("review_verdict")
+    if not isinstance(verdict_obj, dict):
+        return None
+    decision = verdict_obj.get("decision")
+    rationale = verdict_obj.get("rationale")
+    if not isinstance(decision, str) or decision.strip().lower() not in INTERBOT_REVIEW_VERDICTS:
+        return None
+    if not isinstance(rationale, str) or not rationale.strip():
+        return None
+    extracted: dict[str, Any] = {
+        "decision": decision.strip().lower(),
+        "rationale": rationale.strip(),
+        "conditions": _normalize_interbot_string_list(verdict_obj.get("conditions")),
+    }
+    recommendation = verdict_obj.get("human_recommendation")
+    if isinstance(recommendation, str) and recommendation.strip():
+        extracted["human_recommendation"] = recommendation.strip()
+    return extracted
+
+
+def _log_interbot_governance_submit(task_id: str, consumer_id: str, target_node: Optional[str], payload: str) -> None:
+    message_obj = _parse_interbot_message(payload)
+    if not message_obj:
+        return
+    context_id = None
+    turn_type = None
+    conversation_obj = message_obj.get("conversation")
+    if isinstance(conversation_obj, dict):
+        context_id = conversation_obj.get("context_id")
+        turn_type = conversation_obj.get("turn_type")
+    intent_obj = message_obj.get("intent")
+    intent_type = intent_obj.get("type") if isinstance(intent_obj, dict) else None
+    governance = _extract_interbot_governance(message_obj)
+    if governance:
+        approval = governance.get("approval") if isinstance(governance.get("approval"), dict) else {}
+        log_event(
+            "interbot_governance_submit",
+            f"Inter-bot governance recorded for task {task_id[:8]}",
+            task_id=task_id,
+            consumer_id=consumer_id,
+            provider_id=target_node,
+            message_id=message_obj.get("message_id"),
+            trace_id=message_obj.get("trace_id"),
+            context_id=context_id,
+            turn_type=turn_type,
+            intent_type=intent_type,
+            governance_classification=governance.get("classification"),
+            governance_reason=governance.get("reason"),
+            governance_redaction_applied=governance.get("redaction_applied"),
+            governance_disclosure_scope=governance.get("disclosure_scope", []),
+            governance_approval_status=approval.get("status"),
+            governance_approval_context_id=approval.get("context_id"),
+            governance_approved_by=approval.get("approved_by"),
+        )
+    approval_request = _extract_human_approval_request(message_obj)
+    if approval_request:
+        log_event(
+            "human_approval_requested",
+            f"Human approval requested for task {task_id[:8]}",
+            task_id=task_id,
+            consumer_id=consumer_id,
+            provider_id=target_node,
+            message_id=message_obj.get("message_id"),
+            trace_id=message_obj.get("trace_id"),
+            context_id=context_id,
+            decision_type=approval_request.get("decision_type"),
+            review_decision=approval_request.get("review_decision"),
+            blockers=approval_request.get("blockers", []),
+        )
+
+
+def _log_interbot_governance_result(task_id: str, provider_id: str, payload_text: str) -> None:
+    message_obj = _parse_interbot_message(payload_text)
+    if not message_obj:
+        return
+    context_id = None
+    turn_type = None
+    conversation_obj = message_obj.get("conversation")
+    if isinstance(conversation_obj, dict):
+        context_id = conversation_obj.get("context_id")
+        turn_type = conversation_obj.get("turn_type")
+    intent_obj = message_obj.get("intent")
+    intent_type = intent_obj.get("type") if isinstance(intent_obj, dict) else None
+    governance = _extract_interbot_governance(message_obj)
+    if governance:
+        approval = governance.get("approval") if isinstance(governance.get("approval"), dict) else {}
+        log_event(
+            "interbot_governance_result",
+            f"Inter-bot governance result recorded for task {task_id[:8]}",
+            task_id=task_id,
+            provider_id=provider_id,
+            message_id=message_obj.get("message_id"),
+            trace_id=message_obj.get("trace_id"),
+            context_id=context_id,
+            turn_type=turn_type,
+            intent_type=intent_type,
+            governance_classification=governance.get("classification"),
+            governance_reason=governance.get("reason"),
+            governance_redaction_applied=governance.get("redaction_applied"),
+            governance_disclosure_scope=governance.get("disclosure_scope", []),
+            governance_approval_status=approval.get("status"),
+        )
+    review_verdict = _extract_review_verdict(message_obj)
+    if review_verdict:
+        log_event(
+            "review_verdict_recorded",
+            f"Review verdict recorded for task {task_id[:8]}",
+            task_id=task_id,
+            provider_id=provider_id,
+            context_id=context_id,
+            decision=review_verdict.get("decision"),
+            conditions=review_verdict.get("conditions", []),
+        )
+
+
 def _validate_interbot_payload_if_enabled(consumer_id: str, task_economics: dict, target_node: Optional[str], payload: str) -> None:
     if not INTERBOT_SPEC_VALIDATE_ENABLED or not payload:
         return
@@ -942,6 +1164,25 @@ def _validate_interbot_payload_if_enabled(consumer_id: str, task_economics: dict
         raise HTTPException(status_code=400, detail="Inter-bot payload task.instructions too long (max 4000)")
     expected_output_obj = _interbot_require_object(task_obj.get("expected_output"), "task.expected_output")
     _interbot_require_string(expected_output_obj, "result_type")
+    governance = _extract_interbot_governance(message_obj)
+    if governance:
+        classification = governance["classification"]
+        if classification == "forbidden":
+            raise HTTPException(status_code=403, detail="Inter-bot payload governance classification forbidden is not allowed")
+        approval = governance.get("approval") if isinstance(governance.get("approval"), dict) else {}
+        approval_status = approval.get("status")
+        if classification == "approval_required":
+            if intent_type in INTERBOT_HUMAN_APPROVAL_INTENTS:
+                if approval_status not in (None, "pending"):
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Inter-bot human approval requests must use governance approval status pending",
+                    )
+            elif approval_status != "approved":
+                raise HTTPException(
+                    status_code=403,
+                    detail="Inter-bot payload governance approval_required requires approved governance.approval.status",
+                )
 
     economics_obj = _interbot_require_object(message_obj.get("economics"), "economics")
     currency = economics_obj.get("currency")
@@ -2392,6 +2633,12 @@ async def submit_task(
         log_audit("ESCROW", consumer_id, -bounty, new_balance, task_id)
 
     log_event("task_submitted", f"Task {task_id[:8]} broadcasted by {consumer_id} for {bounty}", consumer_id=consumer_id, task_id=task_id, bounty=bounty)
+    try:
+        _log_interbot_governance_submit(task_id, consumer_id, target_node, payload)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log_event("interbot_governance_audit_error", f"Failed to audit governance for task {task_id[:8]}: {exc}", task_id=task_id)
 
     task_data = {
         "id": task_id,
@@ -2757,6 +3004,17 @@ async def complete_task(
         raise HTTPException(status_code=400, detail="Task result requires result_payload or result_uri")
     if len(result_payload) > MAX_PAYLOAD_CHARS:
         raise HTTPException(status_code=413, detail="Result payload too large")
+    if result_payload:
+        try:
+            _log_interbot_governance_result(result.task_id, result.provider_id, result_payload)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            log_event(
+                "interbot_governance_audit_error",
+                f"Failed to audit governance result for task {result.task_id[:8]}: {exc}",
+                task_id=result.task_id,
+            )
     
     task = db.get_task(result.task_id)
     if task and task.get("verifier_type") in ("manual_acceptance", "automated"):

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -606,6 +606,129 @@ class TestTaskLifecycle(unittest.TestCase):
 
         self.assertIn("Target requires encrypted DM payload", str(submit_resp.json().get("detail")))
 
+    def test_interbot_governance_forbidden_rejects_direct_dm(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        _, target_pub, target_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(target_pub)
+
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "message_id": "msg-forbidden",
+                "trace_id": "trace-forbidden",
+                "timestamp_ms": int(time.time() * 1000),
+                "source": {"node_id": consumer_id},
+                "target": {"node_id": target_id},
+                "conversation": {"context_id": "ctx-forbidden", "turn_type": "chat_turn"},
+                "intent": {"type": "chat.request", "priority": "normal"},
+                "task": {
+                    "instructions": "Share the raw secret.",
+                    "inputs": {
+                        "governance": {
+                            "classification": "forbidden",
+                            "reason": "raw secret disclosure is forbidden",
+                            "redaction_applied": False,
+                        }
+                    },
+                    "expected_output": {"result_type": "text"},
+                },
+                "economics": {"bounty_ns": 0, "currency": "MEP_NS", "market": "chat", "payment_direction": "none"},
+                "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+            }
+        )
+
+        submit_payload = json.dumps(
+            {
+                "consumer_id": consumer_id,
+                "payload": payload,
+                "bounty": 0.0,
+                "target_node": target_id,
+            }
+        )
+
+        headers = _auth_headers(consumer_priv, consumer_id, submit_payload)
+
+        with _interbot_validation(True):
+            submit_resp = client.post("/tasks/submit", content=submit_payload, headers=headers)
+
+        self.assertEqual(submit_resp.status_code, 403)
+        self.assertIn("governance classification forbidden", str(submit_resp.json().get("detail")))
+
+    def test_human_approval_request_with_pending_governance_is_audited(self):
+
+        consumer_priv, consumer_pub, consumer_id = _make_identity()
+
+        _, target_pub, target_id = _make_identity()
+
+        _register(consumer_pub)
+
+        _register(target_pub)
+
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "message_id": "msg-approval",
+                "trace_id": "trace-approval",
+                "timestamp_ms": int(time.time() * 1000),
+                "source": {"node_id": consumer_id},
+                "target": {"node_id": target_id},
+                "conversation": {"context_id": "ctx-approval", "turn_type": "session_close"},
+                "intent": {"type": "human.approval.request", "priority": "high"},
+                "task": {
+                    "instructions": "Human approval request: merge_decision",
+                    "inputs": {
+                        "governance": {
+                            "classification": "approval_required",
+                            "reason": "human approval required for merge_decision",
+                            "disclosure_scope": ["merge_decision"],
+                            "redaction_applied": False,
+                            "approval": {"status": "pending"},
+                        },
+                        "human_approval_request": {
+                            "decision_type": "merge_decision",
+                            "summary": "Need final merge confirmation.",
+                            "review_decision": "approve_with_conditions",
+                            "blockers": ["Confirm release window"],
+                            "recommended_next_action": "Merge after approval.",
+                        },
+                    },
+                    "expected_output": {"result_type": "text"},
+                },
+                "economics": {"bounty_ns": 0, "currency": "MEP_NS", "market": "chat", "payment_direction": "none"},
+                "delivery": {"reply_mode": "new_dm", "settlement_mode": "task_result"},
+            }
+        )
+
+        submit_payload = json.dumps(
+            {
+                "consumer_id": consumer_id,
+                "payload": payload,
+                "bounty": 0.0,
+                "target_node": target_id,
+            }
+        )
+
+        headers = _auth_headers(consumer_priv, consumer_id, submit_payload)
+        fake_ws = _FakeWebSocket()
+        main.connected_nodes[target_id] = fake_ws
+
+        try:
+            with _interbot_validation(True):
+                with mock.patch("main.log_event") as log_event_mock:
+                    submit_resp = client.post("/tasks/submit", content=submit_payload, headers=headers)
+        finally:
+            main.connected_nodes.pop(target_id, None)
+
+        self.assertEqual(submit_resp.status_code, 200, submit_resp.text)
+        self.assertEqual(submit_resp.json()["status"], "success")
+        self.assertTrue(any(call.args[0] == "interbot_governance_submit" for call in log_event_mock.call_args_list))
+        self.assertTrue(any(call.args[0] == "human_approval_requested" for call in log_event_mock.call_args_list))
+
 
 
     def test_submitted_result_timeout_refunds_manual_verification_escrow(self):

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -241,6 +241,49 @@ class TestSharedMEPClient(unittest.TestCase):
         self.assertEqual(session_safety["checkpoint_interval"], 3)
         self.assertEqual(session_safety["started_at_ms"], body["timestamp_ms"])
 
+    def test_submit_dm_can_attach_governance_metadata(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+
+            asyncio.run(
+                client.submit_dm(
+                    "Need a redacted workspace summary.",
+                    "node_reviewer",
+                    context_id="gov-ctx",
+                    governance=client.build_governance_metadata(
+                        classification="approval_required",
+                        reason="share redacted workspace facts only",
+                        disclosure_scope=["workspace_summary"],
+                        redaction_applied=True,
+                        approval_status="approved",
+                        approval_context_id="approval-ctx",
+                        approved_by="node_human",
+                    ),
+                )
+            )
+
+        submit_body = json.loads(session.post.call_args.kwargs["data"])
+        body = json.loads(submit_body["task"]["instructions"])
+        self.assertEqual(
+            body["task"]["inputs"]["governance"],
+            {
+                "classification": "approval_required",
+                "reason": "share redacted workspace facts only",
+                "disclosure_scope": ["workspace_summary"],
+                "redaction_applied": True,
+                "approval": {
+                    "status": "approved",
+                    "context_id": "approval-ctx",
+                    "approved_by": "node_human",
+                },
+            },
+        )
+
     def test_extract_interbot_instructions_prefers_structured_task_text(self):
         payload = json.dumps(
             {
@@ -372,6 +415,16 @@ class TestSharedMEPClient(unittest.TestCase):
                 "recommended_next_action": "Merge after human approval.",
             },
         )
+        self.assertEqual(
+            body["task"]["inputs"]["governance"],
+            {
+                "classification": "approval_required",
+                "reason": "human approval required for merge_decision",
+                "disclosure_scope": ["merge_decision"],
+                "redaction_applied": False,
+                "approval": {"status": "pending"},
+            },
+        )
         self.assertEqual(response["context_id"], "pr155-review")
 
     def test_extract_human_approval_request_reads_structured_payload(self):
@@ -404,6 +457,47 @@ class TestSharedMEPClient(unittest.TestCase):
                 "review_decision": "approve",
                 "blockers": ["Confirm release window"],
                 "recommended_next_action": "Merge after approval.",
+            },
+        )
+
+    def test_extract_governance_metadata_reads_structured_payload(self):
+        payload = json.dumps(
+            {
+                "spec_version": "mep.interbot.v1",
+                "task": {
+                    "instructions": "Share a redacted runtime fact summary.",
+                    "inputs": {
+                        "governance": {
+                            "classification": "approval_required",
+                            "reason": "share runtime facts after approval",
+                            "disclosure_scope": ["runtime_facts"],
+                            "redaction_applied": True,
+                            "approval": {
+                                "status": "approved",
+                                "context_id": "approval-123",
+                                "approved_by": "node_human",
+                            },
+                        }
+                    },
+                    "expected_output": {"result_type": "text"},
+                },
+            }
+        )
+
+        governance = MEPClient.extract_governance_metadata(payload)
+
+        self.assertEqual(
+            governance,
+            {
+                "classification": "approval_required",
+                "reason": "share runtime facts after approval",
+                "disclosure_scope": ["runtime_facts"],
+                "redaction_applied": True,
+                "approval": {
+                    "status": "approved",
+                    "context_id": "approval-123",
+                    "approved_by": "node_human",
+                },
             },
         )
 


### PR DESCRIPTION
## Summary
- implement the first V1 slice for #297 on interbot DM / talk+work paths
- add client-side governance metadata helpers for `safe`, `approval_required`, and `forbidden`
- add hub-side fail-closed validation and governance audit logging for interbot payloads
- cover the new behavior with client and hub API tests

## What Changed
- `clients/shared/mep_client.py`
  - add governance metadata builders/extractors
  - allow interbot and execution DMs to carry governance metadata
  - attach default `approval_required + pending` governance metadata to human approval requests
- `hub/main.py`
  - validate interbot governance metadata when interbot spec validation is enabled
  - reject `forbidden` governance payloads
  - require `approval.status=approved` for non-human-approval `approval_required` payloads
  - emit governance and human-approval audit events on submit/result paths
- tests
  - add client tests for governance metadata round-trip
  - add hub tests for forbidden fail-closed behavior and approval-request audit logging

## Validation
- `python -m pytest tests/test_shared_mep_client.py tests/test_hub_api.py tests/test_execution_bridge.py -q`

Closes #297
