### PR TITLE
Improve grounded PR review suppression and summary checks

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -2162,6 +2162,24 @@ class GitHubToMEPBridgeService:
         return str(match.group(1) or "").strip()
 
     @staticmethod
+    def _extract_summary_text(detail: str) -> str:
+        if not detail:
+            return ""
+        match = re.search(
+            r"##\s*Review Summary\s*(.+?)(?:\n\s*Observation:|\n\s*Touched paths reviewed:|\n\s*Tests reviewed:|\n\s*Risk areas checked:|\n\s*Checks performed:|\n\s*Changed identifiers verified:|$)",
+            detail,
+            re.IGNORECASE | re.DOTALL,
+        )
+        if not match:
+            return ""
+        summary = re.sub(r"\s+", " ", str(match.group(1) or "").strip()).strip()
+        if not summary:
+            return ""
+        if summary.lower().startswith("observation:"):
+            return ""
+        return summary
+
+    @staticmethod
     def _extract_review_section_text(detail: str, label: str) -> str:
         if not detail:
             return ""
@@ -2212,6 +2230,27 @@ class GitHubToMEPBridgeService:
         return any(token in lowered for token in (" has no ", " no ", " without ", " missing "))
 
     @staticmethod
+    def _is_validation_absence_claim(text: str) -> bool:
+        lowered = str(text or "").lower()
+        if not lowered:
+            return False
+        validation_patterns = (
+            r"\bdoes not validate\b",
+            r"\bdoesn't validate\b",
+            r"\bmissing validation\b",
+            r"\blacks validation\b",
+            r"\bwithout validating\b",
+            r"\bno validation\b",
+            r"\bdoes not check\b",
+            r"\bdoesn't check\b",
+            r"\bmissing guard\b",
+            r"\blacks guard\b",
+            r"\bmissing allowlist\b",
+            r"\blacks allowlist\b",
+        )
+        return any(re.search(pattern, lowered) for pattern in validation_patterns)
+
+    @staticmethod
     def _finding_conflicts_with_patch(finding_text: str, patch_text: str) -> bool:
         if not finding_text or not patch_text:
             return False
@@ -2242,6 +2281,17 @@ class GitHubToMEPBridgeService:
             return any(token in lowered_patch for token in auth_evidence_tokens)
         if GitHubToMEPBridgeService._is_auth_absence_claim(lowered_finding):
             return any(token in lowered_patch for token in auth_evidence_tokens)
+        if GitHubToMEPBridgeService._is_validation_absence_claim(lowered_finding):
+            validation_evidence_tokens = (
+                "raise valueerror",
+                "raise runtimekeypatherror",
+                "allowed_",
+                "valid_",
+                "validator",
+                " not in ",
+                "unsupported ",
+            )
+            return any(token in lowered_patch for token in validation_evidence_tokens)
         return False
 
     @staticmethod
@@ -2348,9 +2398,11 @@ class GitHubToMEPBridgeService:
             "changes": "\n".join(patches_by_path.get(path, {}).get("changes", "") for path in anchored_paths),
         }
         has_findings = "## review findings" in lowered or bool(self._extract_review_finding_entries(detail or ""))
+        summary_text = self._extract_summary_text(detail or "")
         observation_text = self._extract_observation_text(detail or "")
         risk_areas_checked = self._extract_review_section_list(detail or "", "Risk areas checked")
         checks_performed = self._extract_review_section_list(detail or "", "Checks performed")
+        verified_identifiers = self._extract_review_section_list(detail or "", "Changed identifiers verified")
         why_no_finding = self._extract_review_section_text(detail or "", "Why no finding")
         has_structured_sections = any(
             snippet in lowered
@@ -2383,9 +2435,11 @@ class GitHubToMEPBridgeService:
             "patches_by_path": patches_by_path,
             "anchored_patch_info": anchored_patch_info,
             "has_findings": has_findings,
+            "summary_text": summary_text,
             "observation_text": observation_text,
             "risk_areas_checked": risk_areas_checked,
             "checks_performed": checks_performed,
+            "verified_identifiers": verified_identifiers,
             "why_no_finding": why_no_finding,
             "has_structured_sections": has_structured_sections,
             "grounded_tokens": grounded_tokens,
@@ -2400,9 +2454,11 @@ class GitHubToMEPBridgeService:
         changed_tokens = snapshot.get("changed_tokens") or set()
         grounded_tokens = snapshot.get("grounded_tokens") or set()
         has_findings = bool(snapshot.get("has_findings"))
+        summary_text = str(snapshot.get("summary_text") or "").strip()
         observation_text = str(snapshot.get("observation_text") or "").strip()
         risk_areas_checked = snapshot.get("risk_areas_checked") or []
         checks_performed = snapshot.get("checks_performed") or []
+        verified_identifiers = snapshot.get("verified_identifiers") or []
         why_no_finding = str(snapshot.get("why_no_finding") or "").strip()
         expected_tests = snapshot.get("expected_tests") or []
         mentions_tests = bool(snapshot.get("mentions_tests"))
@@ -2420,12 +2476,15 @@ class GitHubToMEPBridgeService:
         if len(changed_tokens) >= 2:
             score += 1
             reasons.append("multiple_changed_identifiers")
+        elif verified_identifiers:
+            score += 1
+            reasons.append("verified_changed_identifiers")
         if has_findings:
             score += 2
             reasons.append("concrete_findings")
-        elif observation_text and grounded_tokens:
+        elif (summary_text or observation_text) and (changed_tokens or grounded_tokens or verified_identifiers):
             score += 1
-            reasons.append("grounded_observation")
+            reasons.append("grounded_summary_or_observation")
         if risk_areas_checked:
             score += 1
             reasons.append("risk_coverage")
@@ -2532,8 +2591,10 @@ class GitHubToMEPBridgeService:
         anchored_patch_info = snapshot.get("anchored_patch_info") or {"full": "", "changes": ""}
         has_findings = bool(snapshot.get("has_findings"))
         observation_text = str(snapshot.get("observation_text") or "")
+        summary_text = str(snapshot.get("summary_text") or "")
         risk_areas_checked = snapshot.get("risk_areas_checked") or []
         checks_performed = snapshot.get("checks_performed") or []
+        verified_identifiers = snapshot.get("verified_identifiers") or []
         has_structured_sections = bool(snapshot.get("has_structured_sections"))
         why_no_finding = str(snapshot.get("why_no_finding") or "").strip()
         grounded_tokens = snapshot.get("grounded_tokens") or set()
@@ -2554,8 +2615,14 @@ class GitHubToMEPBridgeService:
         if reviewability_bucket == "low_signal" and not has_findings and action != "approved":
             return True, "low_signal_no_finding"
         if has_structured_sections and not has_findings:
+            if summary_text and anchored_paths and review_package:
+                if self._finding_conflicts_with_patch(summary_text, anchored_patch_info["full"]) or self._finding_conflicts_with_patch(detail or "", anchored_patch_info["full"]):
+                    return True, "summary_conflicts_with_patch"
             if not observation_text and not grounded_tokens and not checks_performed and not risk_areas_checked:
                 return True, "summary_without_code_evidence"
+            summary_tokens = self._extract_identifier_tokens(summary_text)
+            if summary_tokens and not changed_tokens and not verified_identifiers:
+                return True, "summary_in_context_only"
             observation_tokens = self._extract_identifier_tokens(observation_text)
             
             # Phase 3A: Summary-only reviews must anchor to at least one changed token if they mention code
@@ -2595,6 +2662,13 @@ class GitHubToMEPBridgeService:
         elif reason in {"ungrounded_finding", "finding_in_context_only", "speculative_finding"}:
             sanitized = re.sub(r"(?im)^\s*\d+\.\s+\*\*.+(?:\n|$)", "", sanitized)
             sanitized = re.sub(r"(?im)^##\s*Review Findings\b", "## Review Summary", sanitized, count=1)
+        elif reason in {"summary_conflicts_with_patch", "summary_in_context_only"}:
+            sanitized = re.sub(
+                r"(?ims)^##\s*Review Summary\s*.*?(?=\n\s*Observation:|\n\s*Touched paths reviewed:|\n\s*Tests reviewed:|\n\s*Risk areas checked:|\n\s*Checks performed:|\n\s*Changed identifiers verified:|$)",
+                "## Review Summary\n\n",
+                sanitized,
+                count=1,
+            )
         elif reason == "summary_without_changed_behavior_evidence":
             sanitized = re.sub(r"(?im)^\s*Why no finding:\s*.+(?:\n|$)", "", sanitized)
         return cls._cleanup_review_detail(sanitized)
@@ -2608,6 +2682,8 @@ class GitHubToMEPBridgeService:
         suppression_reason: Optional[str],
     ) -> Optional[tuple[str, dict[str, Any], int, list[str]]]:
         if action == "approved":
+            return None
+        if suppression_reason in {"summary_conflicts_with_patch"}:
             return None
         sanitized = self._sanitize_review_detail_for_reason(detail, suppression_reason)
         if not sanitized or sanitized == str(detail or "").strip():

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -2917,10 +2917,7 @@ class RuntimeNode:
                 return "reviewed"
             return "approved"
         if intent_type == "code.review.request":
-            if (
-                _review_mode_for_task(task_data or {}) == "recheck_review"
-                and _approval_detail_supports_publishable_approval(detail, task_data=task_data)
-            ):
+            if _approval_detail_supports_publishable_approval(detail, task_data=task_data):
                 return "approved"
             return "reviewed"
         if intent_type == "code.review.comment":

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -2917,6 +2917,11 @@ class RuntimeNode:
                 return "reviewed"
             return "approved"
         if intent_type == "code.review.request":
+            if (
+                _review_mode_for_task(task_data or {}) == "recheck_review"
+                and _approval_detail_supports_publishable_approval(detail, task_data=task_data)
+            ):
+                return "approved"
             return "reviewed"
         if intent_type == "code.review.comment":
             return "commented"

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -804,6 +804,7 @@ def _system_prompt_for_task(
             "include 1-3 exact changed-line identifiers in `verified_identifiers` when the review context provides them, "
             "and make `summary` and `observation` explicitly about that changed behavior rather than generic quality praise. "
             "If you mention code behavior in `summary` or `observation`, tie it to the same touched path or changed identifiers. "
+            "Do not claim a helper is missing validation, checks, or guards unless the changed lines themselves show that absence rather than a nearby allowlist, raise, or verification branch. "
             "Only include a finding when it is directly supported by the provided diff, file list, PR description, or patch excerpts. "
             "Do not speculate about unseen code, do not ask for more context, and do not include chain-of-thought or any text outside the JSON object. "
             "If the change looks good, keep findings empty, use summary to state the overall conclusion, list the risk areas and checks you covered, keep observation concrete, and set approval_recommendation to approve or comment. "
@@ -861,6 +862,7 @@ def _verification_system_prompt_for_task(task_data: dict[str, Any], *, review_ma
         "If no candidate survives verification, keep `findings` empty, explain the checks you performed, and keep the summary grounded in the reviewed changed behavior. "
         "For that no-finding case, still return a grounded review: populate `touched_paths` from the real diff, populate `verified_identifiers` from changed lines when available, "
         "and make `summary` and `observation` cite the reviewed changed behavior instead of generic praise. "
+        "If `summary` or `observation` says a helper lacks validation, guard logic, or checks, that claim must survive nearby contradiction from the changed lines themselves. "
         f"{mode_hint}"
         "In approval mode, any surviving finding must force `approval_recommendation` away from `approve`."
     )

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -2621,6 +2621,59 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(len(self.github_session.posts), 0)
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "observation_in_context_only")
 
+    def test_status_callback_suppresses_summary_conflicting_with_changed_validation_logic(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "clients/shared/mep_client.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -1177,0 +1177,12 @@\n"
+                        "+def build_governance_metadata(classification: str, approval_status: Optional[str] = None) -> dict[str, Any]:\n"
+                        "+    normalized_classification = classification.strip().lower() if isinstance(classification, str) else \"\"\n"
+                        "+    if normalized_classification not in GOVERNANCE_CLASSIFICATIONS:\n"
+                        "+        raise ValueError(f\"unsupported governance classification: {classification}\")\n"
+                        "+    if approval_status is not None:\n"
+                        "+        normalized_status = approval_status.strip().lower() if isinstance(approval_status, str) else \"\"\n"
+                        "+        if normalized_status not in GOVERNANCE_APPROVAL_STATUSES:\n"
+                        "+            raise ValueError(f\"unsupported governance approval status: {approval_status}\")\n"
+                    ),
+                },
+            ],
+            pr_body="Adds governance metadata validation for classification and approval status.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR"),
+            delivery_id="delivery-summary-conflicts-with-validation-guard",
+        )
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-summary-conflicts-with-validation-guard",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "`build_governance_metadata` does not validate `classification` or `approval_status`, so unsupported values can still flow through.\n\n"
+                    "Observation: The helper still passes raw values through to the governance payload.\n\n"
+                    "Touched paths reviewed: `clients/shared/mep_client.py`\n\n"
+                    "Risk areas checked: governance metadata validation\n\n"
+                    "Checks performed: compared `build_governance_metadata` against the changed validation branch\n\n"
+                    "Changed identifiers verified: `build_governance_metadata`, `classification`, `approval_status`"
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertIn("action: retrying", self.notifier.calls[-1]["text"])
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "summary_conflicts_with_patch")
+
     def test_status_callback_allows_finding_grounded_to_changed_lines(self):
         self._set_pr_review_package(
             [

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -738,6 +738,54 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
 
         self.assertEqual(action, "approved")
 
+    def test_recheck_review_request_bridge_action_upgrades_to_approved_for_grounded_no_finding_review(self):
+        task_data = self._bridge_review_task_data(
+            intent_type="code.review.request",
+            review_mode="recheck_review",
+            changed_identifiers=["_score_review_quality", "_approval_quality_failure"],
+        )
+        detail = (
+            "## Review Summary\n\n"
+            "Verified the follow-up patch stays low-risk and the earlier concern is resolved.\n\n"
+            "Touched paths reviewed: `bridge/github_to_mep.py`\n\n"
+            "Tests reviewed: `tests/test_github_bridge.py`\n\n"
+            "Risk areas checked: approval gating, changed-line anchoring\n\n"
+            "Checks performed: traced approval suppression branches, compared changed identifiers against the diff\n\n"
+            "Changed identifiers verified: `_score_review_quality`, `_approval_quality_failure`"
+        )
+
+        action = mep_runtime.RuntimeNode._bridge_status_action(  # noqa: SLF001
+            mep_runtime._interbot_message_from_task_data(task_data),  # noqa: SLF001
+            detail=detail,
+            task_data=task_data,
+        )
+
+        self.assertEqual(action, "approved")
+
+    def test_discovery_review_request_bridge_action_stays_reviewed_even_for_grounded_no_finding_review(self):
+        task_data = self._bridge_review_task_data(
+            intent_type="code.review.request",
+            review_mode="discovery_review",
+            changed_identifiers=["_score_review_quality", "_approval_quality_failure"],
+        )
+        detail = (
+            "## Review Summary\n\n"
+            "Checked the initial review pass and found no blocker.\n\n"
+            "Touched paths reviewed: `bridge/github_to_mep.py`\n\n"
+            "Tests reviewed: `tests/test_github_bridge.py`\n\n"
+            "Risk areas checked: approval gating, changed-line anchoring\n\n"
+            "Checks performed: traced approval suppression branches, compared changed identifiers against the diff\n\n"
+            "Changed identifiers verified: `_score_review_quality`, `_approval_quality_failure`"
+        )
+
+        action = mep_runtime.RuntimeNode._bridge_status_action(  # noqa: SLF001
+            mep_runtime._interbot_message_from_task_data(task_data),  # noqa: SLF001
+            detail=detail,
+            task_data=task_data,
+        )
+
+        self.assertEqual(action, "reviewed")
+
     def test_structured_review_renders_risk_coverage_for_no_finding_reviews(self):
         rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
             (

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -540,6 +540,16 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("follow-up verification pass", prompt)
         self.assertIn("Do not invent fresh low-signal concerns", prompt)
 
+    def test_review_prompt_blocks_summary_claims_that_ignore_nearby_validation_guards(self):
+        prompt = mep_runtime._system_prompt_for_task(  # noqa: SLF001
+            self._bridge_review_task_data(),
+            generic_max_chars=300,
+            review_max_chars=1000,
+        )
+
+        self.assertIn("Do not claim a helper is missing validation, checks, or guards", prompt)
+        self.assertIn("nearby allowlist, raise, or verification branch", prompt)
+
     def test_review_lenses_include_bridge_safety_focus(self):
         lenses = mep_runtime._review_lenses_for_task(self._bridge_review_task_data())  # noqa: SLF001
 

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -762,7 +762,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
 
         self.assertEqual(action, "approved")
 
-    def test_discovery_review_request_bridge_action_stays_reviewed_even_for_grounded_no_finding_review(self):
+    def test_discovery_review_request_bridge_action_upgrades_to_approved_for_grounded_no_finding_review(self):
         task_data = self._bridge_review_task_data(
             intent_type="code.review.request",
             review_mode="discovery_review",
@@ -784,7 +784,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
             task_data=task_data,
         )
 
-        self.assertEqual(action, "reviewed")
+        self.assertEqual(action, "approved")
 
     def test_structured_review_renders_risk_coverage_for_no_finding_reviews(self):
         rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001


### PR DESCRIPTION
## Summary
- tighten no-finding review grounding around changed-line evidence
- suppress summary-level claims that contradict nearby validation or guard logic
- prevent strong contradiction suppressions from being salvaged into publishable comments

## Testing
- python -m pytest tests/test_node_runtime.py tests/test_github_bridge.py tests/test_execution_bridge.py -q