### PR TITLE
Improve review quality for hashability false positives

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -2251,6 +2251,21 @@ class GitHubToMEPBridgeService:
         return any(re.search(pattern, lowered) for pattern in validation_patterns)
 
     @staticmethod
+    def _is_hashability_membership_claim(text: str) -> bool:
+        lowered = str(text or "").lower()
+        if not lowered:
+            return False
+        has_hashability_language = any(
+            token in lowered
+            for token in ("typeerror", "unhashable", "not hashable", "hashability")
+        )
+        has_membership_language = any(
+            token in lowered
+            for token in (" membership ", " allowlist ", " not in ", " in `", " in ")
+        )
+        return has_hashability_language and has_membership_language
+
+    @staticmethod
     def _finding_conflicts_with_patch(finding_text: str, patch_text: str) -> bool:
         if not finding_text or not patch_text:
             return False
@@ -2292,6 +2307,18 @@ class GitHubToMEPBridgeService:
                 "unsupported ",
             )
             return any(token in lowered_patch for token in validation_evidence_tokens)
+        if GitHubToMEPBridgeService._is_hashability_membership_claim(lowered_finding):
+            allowlist_membership_tokens = (
+                " not in ",
+                " in interbot_governance_classifications",
+                " in allowed_",
+                " in valid_",
+                "classification",
+                "allowlist",
+                "unsupported ",
+            )
+            if any(token in lowered_patch for token in allowlist_membership_tokens):
+                return True
         return False
 
     @staticmethod

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -805,6 +805,8 @@ def _system_prompt_for_task(
             "and make `summary` and `observation` explicitly about that changed behavior rather than generic quality praise. "
             "If you mention code behavior in `summary` or `observation`, tie it to the same touched path or changed identifiers. "
             "Do not claim a helper is missing validation, checks, or guards unless the changed lines themselves show that absence rather than a nearby allowlist, raise, or verification branch. "
+            "Do not publish a runtime-exception finding unless the changed lines expose the exact operator, method call, or data-shape transition that would fail under Python semantics. "
+            "Do not infer `TypeError`, `unhashable`, or similar hashability failures from ordinary `in`/`not in` membership checks that are only validating an optional value against an allowlist or classification set. "
             "Only include a finding when it is directly supported by the provided diff, file list, PR description, or patch excerpts. "
             "Do not speculate about unseen code, do not ask for more context, and do not include chain-of-thought or any text outside the JSON object. "
             "If the change looks good, keep findings empty, use summary to state the overall conclusion, list the risk areas and checks you covered, keep observation concrete, and set approval_recommendation to approve or comment. "
@@ -863,6 +865,8 @@ def _verification_system_prompt_for_task(task_data: dict[str, Any], *, review_ma
         "For that no-finding case, still return a grounded review: populate `touched_paths` from the real diff, populate `verified_identifiers` from changed lines when available, "
         "and make `summary` and `observation` cite the reviewed changed behavior instead of generic praise. "
         "If `summary` or `observation` says a helper lacks validation, guard logic, or checks, that claim must survive nearby contradiction from the changed lines themselves. "
+        "If a candidate predicts a Python runtime exception, verify the exact failing operator or method call from the changed lines before promoting it. "
+        "Do not promote `TypeError` or `unhashable` claims that are based only on ordinary allowlist membership checks for optional values. "
         f"{mode_hint}"
         "In approval mode, any surviving finding must force `approval_recommendation` away from `approve`."
     )

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -2776,6 +2776,51 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(len(self.github_session.posts), 0)
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "speculative_finding")
 
+    def test_status_callback_suppresses_hashability_claim_from_allowlist_membership(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "hub/main.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -1048,0 +1048,6 @@\n"
+                        '+classification = governance.get("classification")\n'
+                        "+if classification not in INTERBOT_GOVERNANCE_CLASSIFICATIONS:\n"
+                        '+    raise HTTPException(status_code=400, detail="Inter-bot governance classification invalid")\n'
+                    ),
+                },
+            ],
+            pr_body="Adds governance validation for inter-bot payload classification.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=124),
+            delivery_id="delivery-hashability-finding",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-hashability-finding",
+                "detail": (
+                    "## Review Findings\n\n"
+                    "1. **`classification` can raise a `TypeError` during allowlist membership checks.** (`hub/main.py`): "
+                    "If `governance.get(\"classification\")` returns `None`, the `classification not in "
+                    "INTERBOT_GOVERNANCE_CLASSIFICATIONS` guard will treat it as unhashable and fail before the intended HTTPException."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "ungrounded_finding")
+
     def test_status_callback_posts_issue_comment_for_analysis_completion(self):
         response = self._post_webhook(
             _issue_comment_payload("@Hub-Sentinel analyze this PR", delivery_number=227),

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -550,6 +550,17 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("Do not claim a helper is missing validation, checks, or guards", prompt)
         self.assertIn("nearby allowlist, raise, or verification branch", prompt)
 
+    def test_review_prompt_blocks_hashability_claims_from_plain_allowlist_membership(self):
+        prompt = mep_runtime._system_prompt_for_task(  # noqa: SLF001
+            self._bridge_review_task_data(),
+            generic_max_chars=300,
+            review_max_chars=1000,
+        )
+
+        self.assertIn("Do not publish a runtime-exception finding", prompt)
+        self.assertIn("Do not infer `TypeError`, `unhashable`", prompt)
+        self.assertIn("allowlist or classification set", prompt)
+
     def test_review_lenses_include_bridge_safety_focus(self):
         lenses = mep_runtime._review_lenses_for_task(self._bridge_review_task_data())  # noqa: SLF001
 


### PR DESCRIPTION
## Summary
- tighten reviewer prompt against invented Python hashability exceptions
- suppress ungrounded TypeError/unhashable findings from plain allowlist membership checks
- add focused regressions for prompt guidance and bridge writeback suppression

## Testing
- python -m pytest tests/test_node_runtime.py tests/test_github_bridge.py tests/test_execution_bridge.py -q