### PR TITLE
bridge: harden review score weight coverage

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -2510,7 +2510,8 @@ class GitHubToMEPBridgeService:
         lowered = str(snapshot.get("lowered") or "")
 
         if anchored_paths:
-            raw_score += min(len(anchored_paths), 2)
+            path_anchor_units = min(len(anchored_paths), 2) / 2
+            raw_score += path_anchor_units * _QUALITY_SCORE_WEIGHTS["path_anchor"]
             reasons.append("touched_path_anchor")
         if len(anchored_paths) >= 2:
             reasons.append("multi_path_anchor")
@@ -2518,7 +2519,8 @@ class GitHubToMEPBridgeService:
         if not changed_evidence_count and verified_identifiers:
             changed_evidence_count = min(len(verified_identifiers), 2)
         if changed_evidence_count:
-            raw_score += min(changed_evidence_count, 2)
+            changed_code_units = min(changed_evidence_count, 2) / 2
+            raw_score += changed_code_units * _QUALITY_SCORE_WEIGHTS["changed_code_evidence"]
             reasons.append("changed_code_evidence")
         if len(changed_tokens) >= 2 or len(verified_identifiers) >= 2:
             reasons.append("multiple_changed_identifiers")

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -998,6 +998,50 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertGreaterEqual(score, 6)
         self.assertIn("explicit_low_risk_claim", reasons)
 
+    def test_score_review_quality_clamps_max_score_to_ten(self):
+        score, reasons = self.service._score_review_quality(  # noqa: SLF001
+            {
+                "anchored_paths": {
+                    "bridge/github_to_mep.py",
+                    "tests/test_github_bridge.py",
+                    "node/mep_runtime.py",
+                },
+                "changed_tokens": {
+                    "_score_review_quality",
+                    "PHASE8_STABILITY_TARGETS",
+                    "_approval_quality_failure",
+                },
+                "grounded_tokens": {
+                    "_score_review_quality",
+                    "PHASE8_STABILITY_TARGETS",
+                    "_approval_quality_failure",
+                },
+                "has_findings": True,
+                "summary_text": "Verified the scoring path and found a concrete regression risk.",
+                "observation_text": "Changed-line evidence supports the same finding.",
+                "risk_areas_checked": ["approval gate", "phase8 stability"],
+                "checks_performed": ["reviewed changed diff", "checked related tests"],
+                "verified_identifiers": [
+                    "_score_review_quality",
+                    "PHASE8_STABILITY_TARGETS",
+                    "_approval_quality_failure",
+                ],
+                "expected_tests": ["tests/test_github_bridge.py"],
+                "mentions_tests": True,
+                "lowered": "verified the scoring path. low risk. tests reviewed.",
+            },
+            action="approved",
+        )
+
+        self.assertEqual(score, 10)
+        self.assertIn("explicit_low_risk_claim", reasons)
+
+    def test_score_review_quality_empty_snapshot_returns_zero(self):
+        score, reasons = self.service._score_review_quality({}, action="reviewed")  # noqa: SLF001
+
+        self.assertEqual(score, 0)
+        self.assertEqual(reasons, [])
+
     def test_review_trials_endpoint_returns_latest_trial_results(self):
         self._set_pr_review_package(
             [


### PR DESCRIPTION
## Summary
- wire path anchor and changed-code evidence through the centralized weight table
- add explicit upper-bound and empty-snapshot score tests
- keep the normalized 0-10 behavior while tightening score invariants

## Testing
- python -m pytest tests/test_github_bridge.py -q -k " score_review_quality or phase8_stability or approval_quality_bar\