### PR TITLE
runtime: finish V1 no-finding review quality

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -798,6 +798,7 @@ def _system_prompt_for_task(
             "Use `risk_areas_checked` for 1-4 concrete risk themes you examined in the changed code. "
             "Use `checks_performed` for 1-4 specific verification steps you actually performed against the diff, tests, or workspace excerpts. "
             "When findings are empty, keep `summary` verdict-style and `observation` concrete; do not add filler sections or generic praise. "
+            "For no-finding reviews, never use generic approval language like `looks good`, `well-structured`, `clean patch`, or `LGTM`. "
             "Use `verified_identifiers` for exact function/variable/class names copied from changed lines in the supplied diff or workspace excerpts. "
             "Prefer real touched files and tests from the supplied GitHub inputs for `touched_paths` and `tests_reviewed`. "
             "For no-finding reviews, always anchor the output to the actual diff: include at least one touched path in `touched_paths`, "
@@ -1265,11 +1266,35 @@ _WEAK_REVIEW_PATTERNS = [
 ]
 
 
+_GENERIC_NO_FINDING_PATTERNS = [
+    r"\blooks good\b",
+    r"\blooks correct\b",
+    r"\bwell-structured\b",
+    r"\bwell structured\b",
+    r"\bwell-scoped\b",
+    r"\bwell scoped\b",
+    r"\bwell-contained\b",
+    r"\bwell contained\b",
+    r"\bclean change\b",
+    r"\bclean patch\b",
+    r"\blgtm\b",
+    r"\bno issues found\b",
+    r"\bno problems found\b",
+]
+
+
 def _is_weak_review_text(text: str) -> bool:
     lowered = text.strip().lower()
     if not lowered:
         return True
     return any(re.search(pattern, lowered) for pattern in _WEAK_REVIEW_PATTERNS)
+
+
+def _is_generic_no_finding_text(text: str) -> bool:
+    lowered = text.strip().lower()
+    if not lowered:
+        return False
+    return any(re.search(pattern, lowered) for pattern in _GENERIC_NO_FINDING_PATTERNS)
 
 
 def _default_review_risk_areas(task_data: Optional[dict[str, Any]]) -> list[str]:
@@ -1971,7 +1996,11 @@ def _render_structured_review_with_task_data(
                 findings.append(f"**{issue}**: {rationale or 'Check this logic.'}")
     if findings and allowed_identifiers and not verified_identifiers:
         findings = []
-    if not approval_mode and not findings:
+    if not findings:
+        if _is_generic_no_finding_text(summary):
+            summary = ""
+        if _is_generic_no_finding_text(observation):
+            observation = ""
         if not verified_identifiers:
             verified_identifiers = allowed_identifiers[:3]
         if not risk_areas_checked:
@@ -1990,6 +2019,8 @@ def _render_structured_review_with_task_data(
             )
         if not observation and legacy_no_finding:
             observation = legacy_no_finding
+        if _is_generic_no_finding_text(observation):
+            observation = ""
         if not observation and (touched_paths or verified_identifiers):
             observation = _default_review_observation(
                 touched_paths=touched_paths,

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -1267,8 +1267,8 @@ _WEAK_REVIEW_PATTERNS = [
 
 
 _GENERIC_NO_FINDING_PATTERNS = [
-    r"\blooks good\b",
-    r"\blooks correct\b",
+    r"\blooks[- ]good\b",
+    r"\blooks[- ]correct\b",
     r"\bwell-structured\b",
     r"\bwell structured\b",
     r"\bwell-scoped\b",

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -910,6 +910,31 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertNotIn("LGTM", rendered)
         self.assertNotIn("looks good", rendered)
 
+    def test_structured_review_rewrites_hyphenated_generic_no_finding_text(self):
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            (
+                '{"summary":"Looks-Good overall.",'
+                '"observation":"The change is well-structured.",'
+                '"findings":[],"approval_recommendation":"comment"}'
+            ),
+            max_chars=1400,
+            task_data=self._bridge_review_task_data(
+                changed_identifiers=["verify_signature", "_evict_expired_nonces"],
+                touched_paths=["hub/auth.py", "hub/db.py"],
+                touched_tests=["tests/test_hub_api.py"],
+            ),
+        )
+
+        self.assertIn(
+            "Reviewed the changed behavior around `verify_signature`, `_evict_expired_nonces` and did not find a concrete issue supported by the diff.",
+            rendered,
+        )
+        self.assertIn(
+            "Observation: `verify_signature`, `_evict_expired_nonces` stay scoped to `hub/auth.py`, and the changed test context in `tests/test_hub_api.py` supports the reviewed low-risk path.",
+            rendered,
+        )
+        self.assertNotIn("Looks-Good overall.", rendered)
+
     def test_structured_review_synthesizes_grounded_summary_from_non_json_reply(self):
         rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
             "The replay-protection and dependency-pin changes look low-risk after review.",

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -526,6 +526,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("mention the changed tests", prompt)
         self.assertIn("state the scope is low-risk", prompt)
         self.assertIn("checks are pending or failing", prompt)
+        self.assertIn("never use generic approval language", prompt)
         self.assertIn("Diff restatement without risk coverage is not a sufficient review", prompt)
 
     def test_recheck_review_prompt_mentions_follow_up_verification_mode(self):
@@ -849,7 +850,7 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
                 '"why_no_finding":"No issues found after review.",'
                 '"findings":[],"approval_recommendation":"comment"}'
             ),
-            max_chars=1000,
+            max_chars=1400,
             task_data=self._bridge_review_task_data(
                 changed_identifiers=["verify_signature", "_evict_expired_nonces"],
                 touched_paths=["hub/auth.py", "hub/db.py"],
@@ -858,12 +859,56 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         )
 
         self.assertIn("## Review Summary", rendered)
+        self.assertIn(
+            "Reviewed the changed behavior around `verify_signature`, `_evict_expired_nonces` and did not find a concrete issue supported by the diff.",
+            rendered,
+        )
+        self.assertIn(
+            "Observation: `verify_signature`, `_evict_expired_nonces` stay scoped to `hub/auth.py`, and the changed test context in `tests/test_hub_api.py` supports the reviewed low-risk path.",
+            rendered,
+        )
         self.assertIn("Touched paths reviewed: `hub/auth.py`, `hub/db.py`", rendered)
         self.assertIn("Tests reviewed: `tests/test_hub_api.py`", rendered)
         self.assertIn("Changed identifiers verified: `verify_signature`, `_evict_expired_nonces`", rendered)
-        self.assertIn("The patch looks good overall.", rendered)
-        self.assertIn("Observation: The change is well-structured.", rendered)
+        self.assertNotIn("The patch looks good overall.", rendered)
+        self.assertNotIn("Observation: The change is well-structured.", rendered)
         self.assertNotIn("Why no finding:", rendered)
+
+    def test_structured_approval_review_rewrites_generic_no_finding_text_to_grounded_anchors(self):
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            (
+                '{"summary":"LGTM, the patch looks good.",'
+                '"observation":"The change is well-structured.",'
+                '"touched_paths":["bridge/github_to_mep.py"],'
+                '"tests_reviewed":["tests/test_github_bridge.py"],'
+                '"verified_identifiers":["_score_review_quality","_approval_quality_failure"],'
+                '"findings":[],"approval_recommendation":"approve"}'
+            ),
+            max_chars=1400,
+            task_data=self._bridge_review_task_data(
+                intent_type="code.review.approve",
+                changed_identifiers=["_score_review_quality", "_approval_quality_failure"],
+            ),
+        )
+
+        self.assertIn("## Review Summary", rendered)
+        self.assertIn(
+            "Reviewed the changed behavior around `_score_review_quality`, `_approval_quality_failure` and did not find a concrete issue supported by the diff.",
+            rendered,
+        )
+        self.assertIn(
+            "Observation: `_score_review_quality`, `_approval_quality_failure` stay scoped to `bridge/github_to_mep.py`, and the changed test context in `tests/test_github_bridge.py` supports the reviewed low-risk path.",
+            rendered,
+        )
+        self.assertIn("Risk areas checked:", rendered)
+        self.assertIn("Checks performed:", rendered)
+        self.assertIn("Tests reviewed: `tests/test_github_bridge.py`", rendered)
+        self.assertIn(
+            "Changed identifiers verified: `_score_review_quality`, `_approval_quality_failure`",
+            rendered,
+        )
+        self.assertNotIn("LGTM", rendered)
+        self.assertNotIn("looks good", rendered)
 
     def test_structured_review_synthesizes_grounded_summary_from_non_json_reply(self):
         rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001


### PR DESCRIPTION
## Summary
- tighten the no-finding review prompt so generic praise is not allowed
- rewrite generic no-finding outputs into grounded reviewer notes
- add regression coverage for comment and approve no-finding paths

## Validation
- python -m pytest tests/test_node_runtime.py -q
- python -m pytest tests/test_github_bridge.py -q

@Hub-Sentinel review this PR