### PR TITLE
bridge: discount contradicted review findings

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -100,6 +100,11 @@ _QUALITY_SCORE_WEIGHTS = {
     "explicit_checks": 1.0,
     "test_awareness": 1.0,
     "approval_low_risk": 1.0,
+    # Heuristic patch-grounding adjustment for concrete findings. This is not a
+    # semantic proof: it only discounts or rewards contradiction classes and
+    # changed-line evidence that the bridge can verify from the diff itself.
+    "finding_contradicted": -2.0,
+    "finding_verified": 1.0,
 }
 _LOW_RISK_CLAIM_RE = re.compile(
     r"\b(?:"
@@ -2338,6 +2343,20 @@ class GitHubToMEPBridgeService:
             )
             if any(token in lowered_patch for token in allowlist_membership_tokens):
                 return True
+        normalization_absence_patterns = (
+            r"\bcase[- ]sensitive\b",
+            r"\bdoes not normalize case\b",
+            r"\bwithout normalizing case\b",
+            r"\bmissing case normalization\b",
+            r"\bcase[- ]insensitive variants? (?:are|is) not covered\b",
+        )
+        normalization_evidence_tokens = (
+            ".lower(",
+            ".casefold(",
+            "re.ignorecase",
+        )
+        if any(re.search(pattern, lowered_finding) for pattern in normalization_absence_patterns):
+            return any(token in lowered_patch for token in normalization_evidence_tokens)
         return False
 
     @staticmethod
@@ -2361,6 +2380,84 @@ class GitHubToMEPBridgeService:
                     "changes": changes_only,
                 }
         return patches
+
+    @classmethod
+    def _classify_finding_correctness_against_patch(
+        cls,
+        finding_text: str,
+        matched_paths: set[str],
+        patches_by_path: dict[str, dict[str, str]],
+    ) -> str:
+        patch_info = {
+            "full": "\n".join(patches_by_path.get(path, {}).get("full", "") for path in matched_paths),
+            "changes": "\n".join(patches_by_path.get(path, {}).get("changes", "") for path in matched_paths),
+        }
+        if not patch_info["full"]:
+            return "unverifiable"
+
+        # Heuristic only: this catches structured contradiction classes already
+        # modeled by _finding_conflicts_with_patch plus changed-line grounding.
+        if cls._finding_conflicts_with_patch(finding_text, patch_info["full"]):
+            return "contradicted"
+
+        identifier_tokens = cls._extract_identifier_tokens(finding_text)
+        if identifier_tokens and not any(token in patch_info["full"] for token in identifier_tokens):
+            return "unsupported"
+
+        grounded_tokens = cls._grounded_code_tokens(finding_text, patch_info)
+        changed_tokens = {token for token in grounded_tokens if token in patch_info["changes"]}
+
+        if identifier_tokens and not changed_tokens:
+            return "unsupported"
+        if cls._is_speculative_finding(finding_text) and len(grounded_tokens) < 2:
+            return "unsupported"
+        if changed_tokens:
+            return "verified"
+        if grounded_tokens or cls._is_auth_absence_claim(finding_text):
+            return "unsupported"
+        return "unverifiable"
+
+    @classmethod
+    def _classify_review_finding_correctness(
+        cls,
+        detail: str,
+        review_package: dict[str, Any],
+        expected_paths: list[str],
+    ) -> str:
+        findings = cls._extract_review_finding_entries(detail)
+        if not findings or not review_package or not expected_paths:
+            return "unverifiable"
+        patches_by_path = cls._patch_text_by_path(review_package)
+        saw_verified = False
+        saw_unsupported = False
+        saw_unverifiable = False
+        for file_hint, finding_text in findings:
+            matched_paths = cls._match_path_reference(file_hint, expected_paths) if file_hint else set()
+            if not matched_paths:
+                matched_paths = cls._grounded_review_paths(finding_text, expected_paths)
+            if not matched_paths:
+                saw_unsupported = True
+                continue
+            correctness = cls._classify_finding_correctness_against_patch(
+                finding_text,
+                matched_paths,
+                patches_by_path,
+            )
+            if correctness == "contradicted":
+                return "contradicted"
+            if correctness == "verified":
+                saw_verified = True
+            elif correctness == "unsupported":
+                saw_unsupported = True
+            else:
+                saw_unverifiable = True
+        if saw_unsupported:
+            return "unsupported"
+        if saw_verified:
+            return "verified"
+        if saw_unverifiable:
+            return "unverifiable"
+        return "unverifiable"
 
     @staticmethod
     def _summarize_pr_checks(check_runs_payload: Any) -> dict[str, Any]:
@@ -2465,6 +2562,11 @@ class GitHubToMEPBridgeService:
         )
         grounded_tokens = self._grounded_code_tokens(detail or "", anchored_patch_info)
         changed_tokens = {token for token in grounded_tokens if token in anchored_patch_info["changes"]}
+        finding_correctness = self._classify_review_finding_correctness(
+            detail or "",
+            review_package,
+            expected_paths,
+        )
         mentions_tests = bool(anchored_tests)
         if not mentions_tests and expected_tests:
             mentions_tests = bool(re.search(r"\btest(?:s|ed|ing)?\b", lowered))
@@ -2490,6 +2592,7 @@ class GitHubToMEPBridgeService:
             "has_structured_sections": has_structured_sections,
             "grounded_tokens": grounded_tokens,
             "changed_tokens": changed_tokens,
+            "finding_correctness": finding_correctness,
             "mentions_tests": mentions_tests,
         }
 
@@ -2507,6 +2610,7 @@ class GitHubToMEPBridgeService:
         verified_identifiers = snapshot.get("verified_identifiers") or []
         expected_tests = snapshot.get("expected_tests") or []
         mentions_tests = bool(snapshot.get("mentions_tests"))
+        finding_correctness = str(snapshot.get("finding_correctness") or "").strip().lower()
         lowered = str(snapshot.get("lowered") or "")
 
         if anchored_paths:
@@ -2529,6 +2633,12 @@ class GitHubToMEPBridgeService:
         if has_findings:
             raw_score += _QUALITY_SCORE_WEIGHTS["review_substance"]
             reasons.append("concrete_findings")
+            if finding_correctness == "contradicted":
+                raw_score += _QUALITY_SCORE_WEIGHTS["finding_contradicted"]
+                reasons.append("finding_contradicted_by_patch")
+            elif finding_correctness == "verified":
+                raw_score += _QUALITY_SCORE_WEIGHTS["finding_verified"]
+                reasons.append("finding_verified_against_patch")
         elif (summary_text or observation_text) and (changed_tokens or grounded_tokens or verified_identifiers):
             raw_score += _QUALITY_SCORE_WEIGHTS["review_substance"] / 2
             reasons.append("grounded_summary_or_observation")
@@ -2547,7 +2657,7 @@ class GitHubToMEPBridgeService:
         if action == "approved" and _LOW_RISK_CLAIM_RE.search(lowered):
             raw_score += _QUALITY_SCORE_WEIGHTS["approval_low_risk"]
             reasons.append("explicit_low_risk_claim")
-        score = int(round(min(raw_score, 10.0)))
+        score = int(round(max(0.0, min(raw_score, 10.0))))
         return score, reasons
 
     def _approval_quality_failure(self, snapshot: dict[str, Any], score: int) -> Optional[str]:

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -22,6 +22,7 @@ from bridge.github_to_mep import (  # noqa: E402
     DefaultMEPSubmissionClient,
     GitHubToMEPBridgeService,
     NormalizedGitHubEvent,
+    PHASE8_STABILITY_TARGETS,
     create_app,
 )
 
@@ -1017,6 +1018,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
                     "_approval_quality_failure",
                 },
                 "has_findings": True,
+                "finding_correctness": "verified",
                 "summary_text": "Verified the scoring path and found a concrete regression risk.",
                 "observation_text": "Changed-line evidence supports the same finding.",
                 "risk_areas_checked": ["approval gate", "phase8 stability"],
@@ -1035,12 +1037,111 @@ class TestGitHubToMEPBridge(unittest.TestCase):
 
         self.assertEqual(score, 10)
         self.assertIn("explicit_low_risk_claim", reasons)
+        self.assertIn("finding_verified_against_patch", reasons)
 
     def test_score_review_quality_empty_snapshot_returns_zero(self):
         score, reasons = self.service._score_review_quality({}, action="reviewed")  # noqa: SLF001
 
         self.assertEqual(score, 0)
         self.assertEqual(reasons, [])
+
+    def test_score_review_quality_discounts_contradicted_finding(self):
+        score, reasons = self.service._score_review_quality(  # noqa: SLF001
+            {
+                "anchored_paths": {"bridge/github_to_mep.py"},
+                "changed_tokens": {"_score_review_quality"},
+                "grounded_tokens": {"_score_review_quality"},
+                "has_findings": True,
+                "finding_correctness": "contradicted",
+                "summary_text": "The review cites a concrete defect.",
+                "observation_text": "The claim is tied to the touched path and changed code.",
+                "risk_areas_checked": ["quality rubric"],
+                "checks_performed": ["reviewed changed diff"],
+                "verified_identifiers": ["_score_review_quality"],
+                "expected_tests": [],
+                "mentions_tests": True,
+                "lowered": "reviewed the changed diff and tests.",
+            },
+            action="reviewed",
+        )
+
+        self.assertLess(score, PHASE8_STABILITY_TARGETS["min_avg_quality_score"])
+        self.assertIn("finding_contradicted_by_patch", reasons)
+
+    def test_score_review_quality_clamps_contradicted_only_review_to_zero(self):
+        score, reasons = self.service._score_review_quality(  # noqa: SLF001
+            {
+                "has_findings": True,
+                "finding_correctness": "contradicted",
+            },
+            action="reviewed",
+        )
+
+        self.assertEqual(score, 0)
+        self.assertIn("finding_contradicted_by_patch", reasons)
+
+    def test_build_review_snapshot_marks_contradicted_findings(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -1290,0 +1294,4 @@\n"
+                        "+def _is_generic_no_finding_text(text: str) -> bool:\n"
+                        '+    normalized = _clean_review_text(text).lower()\n'
+                        '+    return any(re.search(pattern, normalized) for pattern in _GENERIC_NO_FINDING_PATTERNS)\n'
+                    ),
+                }
+            ],
+            pr_body="Normalize generic no-finding matching before regex evaluation.",
+        )
+
+        snapshot = self.service._build_review_snapshot(  # noqa: SLF001
+            {
+                "entity_type": "pr",
+                "repo_full_name": "WUAIBING/MEP",
+                "issue_number": 304,
+            },
+            (
+                "## Review Findings\n\n"
+                "1. **Regex pattern is case-sensitive and misses `Looks Good`.** (`node/mep_runtime.py`): "
+                "The matcher does not normalize case before testing `looks good` variants."
+            ),
+        )
+
+        self.assertEqual(snapshot["finding_correctness"], "contradicted")
+
+    def test_build_review_snapshot_marks_context_only_findings_unsupported(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "hub/auth.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -88,0 +88,4 @@\n"
+                        "+def verify_signature(payload: str, signature: str) -> bool:\n"
+                        "+    nonce = _evict_expired_nonces()\n"
+                    ),
+                }
+            ],
+            pr_body="Touches the signature verification path.",
+        )
+
+        snapshot = self.service._build_review_snapshot(  # noqa: SLF001
+            {
+                "entity_type": "pr",
+                "repo_full_name": "WUAIBING/MEP",
+                "issue_number": 304,
+            },
+            (
+                "## Review Findings\n\n"
+                "1. **`load_cached_public_keys` skips tenant validation.** (`hub/auth.py`): "
+                "The change leaves `load_cached_public_keys` without a changed-line validation guard."
+            ),
+        )
+
+        self.assertEqual(snapshot["finding_correctness"], "unsupported")
 
     def test_review_trials_endpoint_returns_latest_trial_results(self):
         self._set_pr_review_package(


### PR DESCRIPTION
## Summary
- add a patch-grounded correctness classifier for review findings
- discount findings contradicted by the diff and reward findings verified against changed lines
- keep unsupported or unverifiable findings neutral instead of treating them as proved wrong
- extend contradiction heuristics for case-normalization claims like the PR #304 .lower() false positive

## Validation
- python -m pytest tests/test_github_bridge.py -q

@Hub-Sentinel review this PR