### PR TITLE
fix(hub): help pending nodes understand 403 on WS connect

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -687,8 +687,17 @@ def get_pub_pem(node_id: str) -> Optional[str]:
     else:
         cursor.execute("SELECT pub_pem FROM ledger WHERE node_id = ?", (node_id,))
     row = cursor.fetchone()
+    if row:
+        _release_conn(conn)
+        return row[0]
+    # Check pending_registrations for nodes awaiting admin approval
+    if _is_postgres():
+        cursor.execute("SELECT pub_pem FROM pending_registrations WHERE node_id = %s", (node_id,))
+    else:
+        cursor.execute("SELECT pub_pem FROM pending_registrations WHERE node_id = ?", (node_id,))
+    pending_row = cursor.fetchone()
     _release_conn(conn)
-    return row[0] if row else None
+    return pending_row[0] if pending_row else None
 
 def get_balance(node_id: str) -> Optional[float]:
     conn = _get_conn()

--- a/hub/main.py
+++ b/hub/main.py
@@ -1749,7 +1749,7 @@ async def verify_request(
 
     pub_pem = db.get_pub_pem(x_mep_nodeid)
     if not pub_pem:
-        raise HTTPException(status_code=401, detail="Unknown Node ID. Please register first.")
+        raise HTTPException(status_code=401, detail="Unknown Node ID. If you registered recently, your registration may still be pending admin approval. Check /admin/pending-registrations or ask the hub operator.")
 
     if not auth.verify_signature(pub_pem, payload_str, x_mep_timestamp, x_mep_signature):
         raise HTTPException(status_code=401, detail="Invalid cryptographic signature.")
@@ -3246,7 +3246,7 @@ async def diagnostic(
 
         pub_pem = db.get_pub_pem(requesting_node)
         if not pub_pem:
-            raise HTTPException(status_code=401, detail="Unknown Node ID. Please register first.")
+            raise HTTPException(status_code=401, detail="Unknown Node ID. If you registered recently, your registration may still be pending admin approval. Check /admin/pending-registrations or ask the hub operator.")
         if not auth.verify_signature(pub_pem, requesting_node, ts, sig):
             raise HTTPException(status_code=401, detail="Invalid cryptographic signature.")
 


### PR DESCRIPTION
Two fixes for pending node registration UX:

1. get_pub_pem() now checks pending_registrations table (was: ledger only)
2. Better 401 error tells operator their registration may be pending approval

@Hub-Sentinel