### PR TITLE
review: harden checks correctness output

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -2220,6 +2220,28 @@ class GitHubToMEPBridgeService:
         return values
 
     @classmethod
+    def _list_entries_with_unsupported_identifiers(
+        cls,
+        values: list[str],
+        patch_info: dict[str, str],
+        *,
+        ignored_tokens: Optional[set[str]] = None,
+    ) -> list[str]:
+        if not values:
+            return []
+        full_patch = str(patch_info.get("full") or "")
+        unsupported: list[str] = []
+        ignored = {token.lower() for token in (ignored_tokens or set()) if token}
+        for item in values:
+            tokens = {token for token in cls._extract_identifier_tokens(item) if token not in ignored}
+            if not tokens:
+                continue
+            hallucinated = {token for token in tokens if token not in full_patch}
+            if hallucinated:
+                unsupported.append(item)
+        return unsupported
+
+    @classmethod
     def _grounded_code_tokens(cls, text: str, patch_info: dict[str, str]) -> set[str]:
         if not text or not patch_info:
             return set()
@@ -2696,6 +2718,11 @@ class GitHubToMEPBridgeService:
         observation_tokens = {token for token in observation_tokens if token not in path_identifier_tokens}
         summary_changed_tokens = {token for token in summary_changed_tokens if token not in path_identifier_tokens}
         observation_changed_tokens = {token for token in observation_changed_tokens if token not in path_identifier_tokens}
+        unsupported_check_entries = self._list_entries_with_unsupported_identifiers(
+            checks_performed,
+            anchored_patch_info,
+            ignored_tokens=path_identifier_tokens,
+        )
         reviewability = snapshot.get("reviewability") or {}
         reviewability_bucket = str(reviewability.get("bucket") or "standard").strip().lower()
         if has_findings and not anchored_paths:
@@ -2711,6 +2738,8 @@ class GitHubToMEPBridgeService:
                 return True, "ungrounded_finding"
         if verified_identifiers and unsupported_verified_identifiers:
             return True, "verified_identifiers_in_context_only"
+        if unsupported_check_entries:
+            return True, "checks_in_context_only"
         if reviewability_bucket == "low_signal" and not has_findings and action != "approved":
             return True, "low_signal_no_finding"
         if has_structured_sections and not has_findings:
@@ -2771,6 +2800,8 @@ class GitHubToMEPBridgeService:
             sanitized = re.sub(r"(?im)^##\s*Review Findings\b", "## Review Summary", sanitized, count=1)
         elif reason == "verified_identifiers_in_context_only":
             sanitized = re.sub(r"(?im)^\s*Changed identifiers verified:\s*.+(?:\n|$)", "", sanitized)
+        elif reason == "checks_in_context_only":
+            sanitized = re.sub(r"(?im)^\s*Checks performed:\s*.+(?:\n|$)", "", sanitized)
         elif reason in {"summary_conflicts_with_patch", "summary_in_context_only"}:
             sanitized = re.sub(
                 r"(?ims)^##\s*Review Summary\s*.*?(?=\n\s*Observation:|\n\s*Touched paths reviewed:|\n\s*Tests reviewed:|\n\s*Risk areas checked:|\n\s*Checks performed:|\n\s*Changed identifiers verified:|$)",

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -668,6 +668,19 @@ def _clean_review_list(values: Any, *, max_items: int, max_chars: int) -> list[s
     return cleaned
 
 
+def _clip_without_partial_token(text: str, *, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    clipped = text[:max_chars].rstrip()
+    if not clipped:
+        return ""
+    if max_chars < len(text) and text[max_chars].isalnum() and clipped[-1].isalnum():
+        word_break = max(clipped.rfind(" "), clipped.rfind(", "), clipped.rfind("; "), clipped.rfind(": "))
+        if word_break >= max(20, max_chars // 2):
+            clipped = clipped[:word_break].rstrip(" ,;:")
+    return clipped
+
+
 def _filter_review_list_to_allowed(values: list[str], allowed: list[str]) -> list[str]:
     if not values:
         return []
@@ -958,7 +971,7 @@ def _clean_review_text(value: Any, *, max_chars: int) -> str:
         return ""
     text = re.sub(r"\s+", " ", text).strip()
     if len(text) > max_chars:
-        clipped = text[:max_chars].rstrip()
+        clipped = _clip_without_partial_token(text, max_chars=max_chars)
         sentence_break = max(clipped.rfind(". "), clipped.rfind("! "), clipped.rfind("? "))
         if sentence_break >= max(40, max_chars // 2):
             clipped = clipped[: sentence_break + 1].rstrip()
@@ -974,7 +987,7 @@ def _clean_review_label(value: Any, *, max_chars: int) -> str:
         return ""
     text = re.sub(r"\s+", " ", text).strip()
     if len(text) > max_chars:
-        text = text[:max_chars].rstrip()
+        text = _clip_without_partial_token(text, max_chars=max_chars)
     return text.rstrip(".,;: ")
 
 
@@ -1473,7 +1486,7 @@ def _finalize_model_reply(text: str, *, max_chars: int) -> str:
     cleaned = cleaned.replace("\r\n", "\n")
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
     if len(cleaned) > max_chars:
-        clipped = cleaned[:max_chars].rstrip()
+        clipped = _clip_without_partial_token(cleaned, max_chars=max_chars)
         breakpoints = [
             clipped.rfind("\n\n"),
             clipped.rfind("\n- "),
@@ -2024,13 +2037,12 @@ def _render_structured_review_with_task_data(
             verified_identifiers = allowed_identifiers[:3]
         if not risk_areas_checked:
             risk_areas_checked = _default_review_risk_areas(task_data)
-        if not checks_performed:
-            checks_performed = _default_review_checks(
-                touched_paths=touched_paths,
-                tests_reviewed=tests_reviewed,
-                verified_identifiers=verified_identifiers,
-                task_data=task_data,
-            )
+        checks_performed = _default_review_checks(
+            touched_paths=touched_paths,
+            tests_reviewed=tests_reviewed,
+            verified_identifiers=verified_identifiers,
+            task_data=task_data,
+        )
         if not summary:
             summary = _default_review_summary(
                 touched_paths=touched_paths,
@@ -2050,6 +2062,15 @@ def _render_structured_review_with_task_data(
                 touched_paths=touched_paths,
                 verified_identifiers=verified_identifiers,
             )
+    else:
+        synthesized_checks = _default_review_checks(
+            touched_paths=touched_paths,
+            tests_reviewed=tests_reviewed,
+            verified_identifiers=verified_identifiers,
+            task_data=task_data,
+        )
+        if synthesized_checks:
+            checks_performed = synthesized_checks
     sections: list[str] = []
     if findings:
         sections.append("## Review Findings")

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -2735,6 +2735,70 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertIn("action: retrying", self.notifier.calls[-1]["text"])
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "summary_without_risk_coverage")
 
+    def test_status_callback_salvages_checks_with_unsupported_identifier_by_stripping_checks_section(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "additions": 10,
+                    "deletions": 1,
+                    "changes": 11,
+                    "patch": (
+                        "@@ -945,0 +945,10 @@\n"
+                        "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                        "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                    ),
+                },
+                {
+                    "filename": "tests/test_node_runtime.py",
+                    "status": "modified",
+                    "additions": 8,
+                    "deletions": 0,
+                    "changes": 8,
+                    "patch": (
+                        "@@ -494,0 +494,8 @@\n"
+                        "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
+                        "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
+                    ),
+                },
+            ],
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=244),
+            delivery_id="delivery-checks-in-context-only",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-checks-in-context-only",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability in `node/mep_runtime.py` and corresponding tests in `tests/test_node_runtime.py`.\n\n"
+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, so the recovery metrics stay visible.\n\n"
+                    "Risk areas checked: metrics correctness, test coverage\n\n"
+                    "Checks performed: verified `_record_pending_task_poll_failure` writes `last_poll_status`, confirmed `imagined_guard` keeps the retry filter stable\n\n"
+                    "Why no finding: The changed metrics write is narrowly scoped and the changed test covers the intended recovery path."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 1)
+        review_payload = self.github_session.posts[0]["json"]
+        self.assertNotIn("Checks performed:", review_payload["body"])
+        self.assertNotIn("imagined_guard", review_payload["body"])
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], None)
+
     def test_status_callback_suppresses_finding_grounded_only_to_context_lines(self):
         self._set_pr_review_package(
             [

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -813,12 +813,54 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
                 '"findings":[],"approval_recommendation":"comment"}'
             ),
             max_chars=1000,
-            task_data=self._bridge_review_task_data(),
+            task_data=self._bridge_review_task_data(
+                changed_identifiers=["_build_review_trial_result", "list_review_trials"]
+            ),
         )
 
         self.assertIn("Risk areas checked: trial persistence, endpoint decoding", rendered)
-        self.assertIn("Checks performed: verified suppression and publish paths mention `review_result_json`, checked `/bridge/review-trials` returns stored review metadata", rendered)
+        self.assertIn("Checks performed: reviewed the changed diff for `bridge/github_to_mep.py`, verified changed identifiers `_build_review_trial_result`, `list_review_trials` against the supplied review context, checked relevant changed tests `tests/test_github_bridge.py`", rendered)
         self.assertNotIn("Why no finding:", rendered)
+
+    def test_structured_review_replaces_model_checks_with_grounded_defaults_for_no_finding_reviews(self):
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            (
+                '{"summary":"Checked the review trial ledger flow end to end.",'
+                '"observation":"`_build_review_trial_result` and `list_review_trials` stay aligned with the stored JSON payload.",'
+                '"touched_paths":["bridge/github_to_mep.py"],'
+                '"tests_reviewed":["tests/test_github_bridge.py"],'
+                '"risk_areas_checked":["trial persistence","endpoint decoding"],'
+                '"checks_performed":["Confirmed that `imagined_guard` keeps the publish path safe for retries"],'
+                '"verified_identifiers":["_build_review_trial_result","list_review_trials"],'
+                '"findings":[],"approval_recommendation":"comment"}'
+            ),
+            max_chars=1000,
+            task_data=self._bridge_review_task_data(
+                changed_identifiers=["_build_review_trial_result", "list_review_trials"]
+            ),
+        )
+
+        self.assertNotIn("imagined_guard", rendered)
+        self.assertIn("reviewed the changed diff for `bridge/github_to_mep.py`", rendered)
+        self.assertIn("verified changed identifiers `_build_review_trial_result`, `list_review_trials` against the supplied review context", rendered)
+
+    def test_clean_review_label_drops_partial_trailing_word_when_clipped(self):
+        cleaned = mep_runtime._clean_review_label(  # noqa: SLF001
+            "Confirmed that _filter_review_list_to_allowed uses exact matching and avoids trailing filteri",
+            max_chars=88,
+        )
+
+        self.assertNotIn("filteri", cleaned)
+        self.assertTrue(cleaned.endswith("trailing"))
+
+    def test_finalize_model_reply_drops_partial_trailing_word_after_clip(self):
+        rendered = mep_runtime._finalize_model_reply(  # noqa: SLF001
+            "## Review Summary\n\nChecks performed: confirmed the publish path stays grounded and avoids trailing filteri",
+            max_chars=96,
+        )
+
+        self.assertNotIn("filteri", rendered)
+        self.assertNotIn("filter.", rendered)
 
     def test_structured_review_fills_no_finding_defaults_from_task_data(self):
         rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001


### PR DESCRIPTION
## Summary
- harden bridge publishability checks for Checks performed entries that cite unsupported identifiers
- replace no-finding and approval check summaries with deterministic grounded defaults from task context
- drop partial trailing word clips that degrade published review quality

## Validation
- python -m pytest tests/test_github_bridge.py tests/test_node_runtime.py