### PR TITLE
review: harden code snippet grounding

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -2208,13 +2208,89 @@ class GitHubToMEPBridgeService:
         return str(match.group(1) or "").strip()
 
     @classmethod
+    def _split_review_section_items(cls, text: str) -> list[str]:
+        if not text:
+            return []
+        parts: list[str] = []
+        current: list[str] = []
+        in_backticks = False
+        for char in str(text):
+            if char == "`":
+                in_backticks = not in_backticks
+                current.append(char)
+                continue
+            if char == "," and not in_backticks:
+                part = "".join(current).strip()
+                if part:
+                    parts.append(part)
+                current = []
+                continue
+            current.append(char)
+        trailing = "".join(current).strip()
+        if trailing:
+            parts.append(trailing)
+        return parts
+
+    @staticmethod
+    def _extract_backticked_snippets(text: str) -> list[str]:
+        if not text:
+            return []
+        snippets: list[str] = []
+        seen: set[str] = set()
+        for snippet in re.findall(r"`([^`\n]+)`", str(text)):
+            cleaned = re.sub(r"\s+", " ", str(snippet or "").strip()).strip()
+            if not cleaned:
+                continue
+            lowered = cleaned.lower()
+            if lowered in seen:
+                continue
+            snippets.append(cleaned)
+            seen.add(lowered)
+        return snippets
+
+    @staticmethod
+    def _has_unbalanced_backticks(text: str) -> bool:
+        return bool(text) and str(text).count("`") % 2 == 1
+
+    @classmethod
+    def _list_entries_with_unsupported_code_snippets(
+        cls,
+        values: list[str],
+        patch_info: dict[str, str],
+        *,
+        allowed_snippets: Optional[set[str]] = None,
+    ) -> list[str]:
+        if not values:
+            return []
+        full_patch = str(patch_info.get("full") or "").lower()
+        allowed = {snippet.lower() for snippet in (allowed_snippets or set()) if snippet}
+        unsupported: list[str] = []
+        for item in values:
+            if cls._has_unbalanced_backticks(item):
+                unsupported.append(item)
+                continue
+            snippets = cls._extract_backticked_snippets(item)
+            bad_snippets = [
+                snippet
+                for snippet in snippets
+                if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", snippet)
+                and snippet.lower() not in allowed
+                and snippet.lower() not in full_patch
+            ]
+            if bad_snippets:
+                unsupported.append(item)
+        return unsupported
+
+    @classmethod
     def _extract_review_section_list(cls, detail: str, label: str) -> list[str]:
         text = cls._extract_review_section_text(detail, label)
         if not text:
             return []
         values: list[str] = []
-        for part in text.split(","):
-            cleaned = re.sub(r"\s+", " ", str(part or "").strip(" `")).strip()
+        for part in cls._split_review_section_items(text):
+            cleaned = re.sub(r"\s+", " ", str(part or "").strip()).strip()
+            if cleaned.startswith("`") and cleaned.endswith("`") and cleaned.count("`") == 2:
+                cleaned = cleaned[1:-1].strip()
             if cleaned and cleaned not in values:
                 values.append(cleaned)
         return values
@@ -2660,6 +2736,17 @@ class GitHubToMEPBridgeService:
             if identifier_tokens and not any(token in patch_info["full"] for token in identifier_tokens):
                 if not any(token in full_review_patch_info["full"] for token in identifier_tokens):
                     return "ungrounded_finding"
+            allowed_snippets = set(expected_paths)
+            snippets_for_tests = review_package.get("metadata", {}).get("github", {}).get("touched_tests")
+            if isinstance(snippets_for_tests, list):
+                allowed_snippets.update(str(item).strip() for item in snippets_for_tests if item)
+            unsupported_code_snippets = cls._list_entries_with_unsupported_code_snippets(
+                [finding_text],
+                patch_info,
+                allowed_snippets=allowed_snippets,
+            )
+            if unsupported_code_snippets:
+                return "finding_in_context_only"
             
             grounded_tokens = cls._grounded_code_tokens(finding_text, patch_info)
             changed_tokens = cls._changed_code_tokens(finding_text, patch_info)
@@ -2714,6 +2801,7 @@ class GitHubToMEPBridgeService:
         path_identifier_tokens: set[str] = set()
         for path_like in list(expected_paths) + list(snapshot.get("expected_tests") or []):
             path_identifier_tokens.update(self._extract_identifier_tokens(path_like))
+        allowed_snippets = {str(path_like).strip() for path_like in list(expected_paths) + list(snapshot.get("expected_tests") or []) if path_like}
         summary_tokens = {token for token in summary_tokens if token not in path_identifier_tokens}
         observation_tokens = {token for token in observation_tokens if token not in path_identifier_tokens}
         summary_changed_tokens = {token for token in summary_changed_tokens if token not in path_identifier_tokens}
@@ -2722,6 +2810,15 @@ class GitHubToMEPBridgeService:
             checks_performed,
             anchored_patch_info,
             ignored_tokens=path_identifier_tokens,
+        )
+        unsupported_check_entries.extend(
+            entry
+            for entry in self._list_entries_with_unsupported_code_snippets(
+                checks_performed,
+                anchored_patch_info,
+                allowed_snippets=allowed_snippets,
+            )
+            if entry not in unsupported_check_entries
         )
         reviewability = snapshot.get("reviewability") or {}
         reviewability_bucket = str(reviewability.get("bucket") or "standard").strip().lower()
@@ -2754,6 +2851,12 @@ class GitHubToMEPBridgeService:
                 }
                 if hallucinated_summary_tokens:
                     return True, "summary_in_context_only"
+                if self._list_entries_with_unsupported_code_snippets(
+                    [summary_text],
+                    anchored_patch_info,
+                    allowed_snippets=allowed_snippets,
+                ):
+                    return True, "summary_in_context_only"
                 if not summary_changed_tokens and not changed_tokens and not verified_identifiers:
                     return True, "summary_in_context_only"
             if observation_tokens:
@@ -2761,6 +2864,12 @@ class GitHubToMEPBridgeService:
                     token for token in (observation_tokens - observation_changed_tokens) if token not in anchored_patch_full
                 }
                 if hallucinated_observation_tokens:
+                    return True, "observation_in_context_only"
+                if self._list_entries_with_unsupported_code_snippets(
+                    [observation_text],
+                    anchored_patch_info,
+                    allowed_snippets=allowed_snippets,
+                ):
                     return True, "observation_in_context_only"
                 if not observation_changed_tokens and not changed_tokens:
                     return True, "observation_in_context_only"

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -681,6 +681,55 @@ def _clip_without_partial_token(text: str, *, max_chars: int) -> str:
     return clipped
 
 
+def _extract_backticked_review_snippets(text: Any) -> list[str]:
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return []
+    snippets: list[str] = []
+    seen: set[str] = set()
+    for snippet in re.findall(r"`([^`\n]+)`", cleaned):
+        normalized = re.sub(r"\s+", " ", str(snippet or "").strip()).strip()
+        if not normalized:
+            continue
+        lowered = normalized.lower()
+        if lowered in seen:
+            continue
+        snippets.append(normalized)
+        seen.add(lowered)
+    return snippets
+
+
+def _has_unbalanced_backticks(text: Any) -> bool:
+    cleaned = str(text or "")
+    return bool(cleaned) and cleaned.count("`") % 2 == 1
+
+
+def _review_text_uses_only_allowed_snippets(
+    text: str,
+    *,
+    allowed_identifiers: list[str],
+    allowed_paths: list[str],
+    allowed_tests: list[str],
+) -> bool:
+    if _has_unbalanced_backticks(text):
+        return False
+    allowed = {
+        item.lower()
+        for item in list(allowed_identifiers) + list(allowed_paths) + list(allowed_tests)
+        if item
+    }
+    for snippet in _extract_backticked_review_snippets(text):
+        lowered = snippet.lower()
+        if lowered in allowed:
+            continue
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", snippet):
+            if lowered in {item.lower() for item in allowed_identifiers if item}:
+                continue
+            return False
+        return False
+    return True
+
+
 def _filter_review_list_to_allowed(values: list[str], allowed: list[str]) -> list[str]:
     if not values:
         return []
@@ -1997,10 +2046,36 @@ def _render_structured_review_with_task_data(
     checks_performed = _clean_review_list(parsed.get("checks_performed"), max_items=4, max_chars=120)
     verified_identifiers = _clean_review_list(parsed.get("verified_identifiers"), max_items=4, max_chars=80)
     verified_identifiers = _filter_review_list_to_allowed(verified_identifiers, allowed_identifiers)
-    if summary and not _review_text_uses_only_allowed_identifiers(summary, allowed_identifiers):
+    if summary and (
+        not _review_text_uses_only_allowed_identifiers(summary, allowed_identifiers)
+        or not _review_text_uses_only_allowed_snippets(
+            summary,
+            allowed_identifiers=allowed_identifiers,
+            allowed_paths=allowed_paths,
+            allowed_tests=allowed_tests,
+        )
+    ):
         summary = ""
-    if observation and not _review_text_uses_only_allowed_identifiers(observation, allowed_identifiers):
+    if observation and (
+        not _review_text_uses_only_allowed_identifiers(observation, allowed_identifiers)
+        or not _review_text_uses_only_allowed_snippets(
+            observation,
+            allowed_identifiers=allowed_identifiers,
+            allowed_paths=allowed_paths,
+            allowed_tests=allowed_tests,
+        )
+    ):
         observation = ""
+    checks_performed = [
+        entry
+        for entry in checks_performed
+        if _review_text_uses_only_allowed_snippets(
+            entry,
+            allowed_identifiers=allowed_identifiers,
+            allowed_paths=allowed_paths,
+            allowed_tests=allowed_tests,
+        )
+    ]
     legacy_no_finding = _clean_review_text(parsed.get("why_no_finding"), max_chars=400)
     if _is_weak_review_text(legacy_no_finding):
         legacy_no_finding = ""
@@ -2019,6 +2094,13 @@ def _render_structured_review_with_task_data(
             if _is_weak_review_text(combined):
                 continue
             if not _review_text_uses_only_allowed_identifiers(combined, allowed_identifiers):
+                continue
+            if not _review_text_uses_only_allowed_snippets(
+                combined,
+                allowed_identifiers=allowed_identifiers,
+                allowed_paths=allowed_paths,
+                allowed_tests=allowed_tests,
+            ):
                 continue
             file_name = _clean_review_label(item.get("file"), max_chars=80)
             if file_name and allowed_path_keys:

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -2733,7 +2733,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(status_response.status_code, 200, status_response.text)
         self.assertEqual(len(self.github_session.posts), 0)
         self.assertIn("action: retrying", self.notifier.calls[-1]["text"])
-        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "summary_without_risk_coverage")
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "observation_in_context_only")
 
     def test_status_callback_salvages_checks_with_unsupported_identifier_by_stripping_checks_section(self):
         self._set_pr_review_package(
@@ -2799,6 +2799,76 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertNotIn("imagined_guard", review_payload["body"])
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], None)
 
+    def test_extract_review_section_list_keeps_commas_inside_backticked_code_snippets(self):
+        values = self.service._extract_review_section_list(
+            "Checks performed: verified `_list_entries_with_unsupported_identifiers` uses `patch_info.get('changed_identifiers', [])`, confirmed `_cleanup_review_detail` strips stale sections",
+            "Checks performed",
+        )
+
+        self.assertEqual(
+            values,
+            [
+                "verified `_list_entries_with_unsupported_identifiers` uses `patch_info.get('changed_identifiers', [])`",
+                "confirmed `_cleanup_review_detail` strips stale sections",
+            ],
+        )
+
+    def test_status_callback_salvages_checks_with_unsupported_code_snippet_by_stripping_checks_section(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "bridge/github_to_mep.py",
+                    "status": "modified",
+                    "additions": 12,
+                    "deletions": 0,
+                    "changes": 12,
+                    "patch": (
+                        "@@ -2221,0 +2221,12 @@\n"
+                        "+def _list_entries_with_unsupported_identifiers(values, patch_info):\n"
+                        "+    full_patch = str(patch_info.get(\"full\") or \"\")\n"
+                        "+    return []\n"
+                        "+\n"
+                        "+def _cleanup_review_detail(detail: str) -> str:\n"
+                        "+    return str(detail or \"\").strip()\n"
+                    ),
+                },
+            ],
+            pr_body="Hardens bridge review sanitization around unsupported identifiers.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=245),
+            delivery_id="delivery-checks-unsupported-code-snippet",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-checks-unsupported-code-snippet",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The bridge now narrows unsupported identifier handling in `bridge/github_to_mep.py`.\n\n"
+                    "Observation: `_cleanup_review_detail` still trims surrounding whitespace before publishing the body.\n\n"
+                    "Risk areas checked: bridge review sanitization\n\n"
+                    "Checks performed: verified `_list_entries_with_unsupported_identifiers` uses `patch_info.get('changed_identifiers', [])`, confirmed `_cleanup_review_detail` strips stale sections\n\n"
+                    "Why no finding: The changed bridge helpers stay scoped to sanitization and review gating."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 1)
+        review_payload = self.github_session.posts[0]["json"]
+        self.assertNotIn("Checks performed:", review_payload["body"])
+        self.assertNotIn("patch_info.get('changed_identifiers', [])", review_payload["body"])
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], None)
+
     def test_status_callback_suppresses_finding_grounded_only_to_context_lines(self):
         self._set_pr_review_package(
             [
@@ -2837,6 +2907,55 @@ class TestGitHubToMEPBridge(unittest.TestCase):
             headers={"Authorization": f"Bearer {token}"},
         )
         self.assertEqual(status_response.status_code, 200)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "finding_in_context_only")
+
+    def test_status_callback_suppresses_finding_with_unsupported_code_snippet_claim(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "node/mep_runtime.py",
+                    "status": "modified",
+                    "patch": (
+                        "@@ -671,0 +671,12 @@\n"
+                        "+def _clip_without_partial_token(text: str, *, max_chars: int) -> str:\n"
+                        "+    clipped = text[:max_chars].rstrip()\n"
+                        "+    if not clipped:\n"
+                        "+        return \"\"\n"
+                        "+    if max_chars < len(text) and text[max_chars].isalnum() and clipped[-1].isalnum():\n"
+                        "+        word_break = max(clipped.rfind(\" \"), clipped.rfind(\", \"), clipped.rfind(\"; \"), clipped.rfind(\": \"))\n"
+                        "+        if word_break >= max(20, max_chars // 2):\n"
+                        "+            clipped = clipped[:word_break].rstrip(\" ,;:\")\n"
+                        "+    return clipped\n"
+                    ),
+                },
+            ],
+            pr_body="Hardens truncation cleanup for structured review output.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=246),
+            delivery_id="delivery-finding-unsupported-code-snippet",
+        )
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-finding-unsupported-code-snippet",
+                "detail": (
+                    "## Review Findings\n\n"
+                    "1. **`_clip_without_partial_token` returns `text[:max_chars]` when `text.rfind(' ', 0, max_chars)` fails.** (`node/mep_runtime.py`): "
+                    "That fallback leaves the trailing token fragment in place instead of trimming to the last safe boundary."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
         self.assertEqual(len(self.github_session.posts), 0)
         self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "finding_in_context_only")
 

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -987,6 +987,46 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertNotIn("imagined_guard", rendered)
         self.assertNotIn("Mixed identifier claim", rendered)
 
+    def test_structured_review_drops_findings_with_unsupported_code_snippets(self):
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            (
+                '{"summary":"Checked the runtime diff.","observation":"The truncation helper changed in a narrow way.",'
+                '"touched_paths":["bridge/github_to_mep.py"],'
+                '"tests_reviewed":["tests/test_github_bridge.py"],'
+                '"verified_identifiers":["_record_pending_task_poll_failure","last_poll_status"],'
+                '"findings":[{"file":"bridge/github_to_mep.py","issue":"False fallback claim in `_record_pending_task_poll_failure`",'
+                '"rationale":"The branch now returns `patch_info.get(\'changed_identifiers\', [])`, which leaves stale identifiers behind."}],'
+                '"approval_recommendation":"comment"}'
+            ),
+            max_chars=1200,
+            task_data=self._bridge_review_task_data(),
+        )
+
+        self.assertIn("## Review Summary", rendered)
+        self.assertNotIn("## Review Findings", rendered)
+        self.assertNotIn("patch_info.get('changed_identifiers', [])", rendered)
+        self.assertNotIn("False fallback claim", rendered)
+
+    def test_structured_review_drops_malformed_checks_section_entries(self):
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            (
+                '{"summary":"Checked the bridge diff.","observation":"The changed path stays narrow.",'
+                '"touched_paths":["bridge/github_to_mep.py"],'
+                '"tests_reviewed":["tests/test_github_bridge.py"],'
+                '"verified_identifiers":["_record_pending_task_poll_failure","last_poll_status"],'
+                '"checks_performed":["verified `_record_pending_task_poll_failure` updates `last_poll_status safely ha"],'
+                '"findings":[{"file":"bridge/github_to_mep.py","issue":"Guard remains scoped to `_record_pending_task_poll_failure`",'
+                '"rationale":"The diff still keeps the metrics update tied to the same helper."}],'
+                '"approval_recommendation":"comment"}'
+            ),
+            max_chars=1200,
+            task_data=self._bridge_review_task_data(),
+        )
+
+        self.assertIn("## Review Findings", rendered)
+        self.assertNotIn("Checks performed:", rendered)
+        self.assertNotIn("safely ha", rendered)
+
     def test_structured_review_drops_findings_for_untouched_files(self):
         rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
             (


### PR DESCRIPTION
## Summary
- keep review section parsing stable when backticked code snippets contain commas
- suppress findings and checks that cite code-like snippets not actually present in the touched diff
- drop malformed backticked checks entries earlier in the runtime renderer

## Validation
- python -m pytest tests/test_github_bridge.py tests/test_node_runtime.py