### PR TITLE
fix: route execution DMs through bridge in mep_runtime, not just CodexProvider

### DIFF
--- a/OPERATOR_CHECKLIST.md
+++ b/OPERATOR_CHECKLIST.md
@@ -110,6 +110,60 @@ codex> mepdmreplysafe task_review_request 3 "I approve with conditions." --turn-
   - verify node clocks (timestamp skew window)
   - verify signature input rules (HTTP body vs WS node_id/timestamp)
 
+## Execution Bridge (Talk + Execute)
+
+Use this section to enable a node to receive and execute code-editing DMs.
+
+### Required Environment Variables
+
+| Variable | Purpose | Required |
+|---|---|---|
+| `MEP_RUNTIME_EDIT_PATH` | Workspace root for file edits | Yes |
+| `MEP_EXECUTION_BRIDGE_COMMAND` | Path to bridge binary that executes edit_operations | No (falls back to adapter) |
+
+Without `MEP_RUNTIME_EDIT_PATH`, the bridge returns `no_runtime_edit_path_configured`
+and execution DMs fall through to the LLM adapter (which will generate plausible
+but fabricated output instead of real shell results).
+
+With `MEP_RUNTIME_EDIT_PATH` set but no `MEP_EXECUTION_BRIDGE_COMMAND`, the
+runtime's built-in bridge executes `operation.action` types (`insert`, `replace`,
+`delete`) directly against the workspace. Shell commands (`action: execute`)
+require the bridge binary.
+
+### Testing the Bridge
+
+```bash
+# 1. Set the path and restart
+export MEP_RUNTIME_EDIT_PATH=/opt/stockbot
+python -m node.mep_runtime --adapter deepseek run
+
+# 2. From another node, send a test execution DM
+python -c "
+from clients.shared.mep_client import MEPClient
+c = MEPClient('my_key.pem')
+c.submit_execution_dm(
+    'Test: check git status',
+    target_node='<node_id>',
+    required_capabilities=['code_edit'],
+    max_runtime_seconds=30,
+)
+"
+
+# 3. Verify the result payload contains real shell output,
+#    not LLM-generated text. Real output includes actual git SHAs,
+#    real file paths, and real test counts.
+```
+
+### Common Bridge Failure Modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `no_runtime_edit_path_configured` | `MEP_RUNTIME_EDIT_PATH` not set | Set env var and restart |
+| `execution_bridge_timeout` | Bridge binary timed out | Increase `MEP_EXECUTION_BRIDGE_TIMEOUT_SECONDS` |
+| AI-generated fake output (made-up commit SHAs, wrong test counts) | Bridge not configured; adapter fallback active | Verify `MEP_RUNTIME_EDIT_PATH` is set and restart |
+| `missing_edit_operations` | DM sent without `edit_operations` in payload | Use `submit_execution_dm()` with `task_inputs={"edit_operations": [...]}` |
+| `unsupported_action: X` | Bridge doesn't recognize the action type | Use only `insert`, `replace`, `delete`, `execute` |
+
 ## Release Gate
 - Do not mark deployment complete unless:
   - `/health` passes

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -3710,13 +3710,11 @@ class RuntimeNode:
         # ── Execution bridge gate: route code-editing tasks to the real bridge,
         # not the LLM adapter. LLMs hallucinate shell output; bridges execute.
         # Falls through to adapter when bridge functions aren't importable (None).
-        is_execution = False
         if (
             interbot_message is not None
             and is_execution_request is not None
             and is_execution_request(interbot_message)
         ):
-            is_execution = True
             bridge_request = build_execution_bridge_request(
                 interbot_message,
                 consumer_id=str(task_data.get("consumer_id") or ""),

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -37,6 +37,21 @@ except ImportError:  # pragma: no cover - direct file execution from node/ may n
     MEPClient = None  # type: ignore[assignment]
 
 try:
+    from clients.shared.execution_bridge import (
+        build_execution_bridge_request,
+        build_execution_unavailable_result,
+        execute_bridge_command,
+        is_execution_request,
+        render_execution_result,
+    )
+except ImportError:  # pragma: no cover - supports direct file execution
+    build_execution_bridge_request = None  # type: ignore[assignment]
+    build_execution_unavailable_result = None  # type: ignore[assignment]
+    execute_bridge_command = None  # type: ignore[assignment]
+    is_execution_request = None  # type: ignore[assignment]
+    render_execution_result = None  # type: ignore[assignment]
+
+try:
     from clients.shared import identity_paths
 except ImportError:  # pragma: no cover - direct file execution from node/ may not see repo root
     identity_paths = None  # type: ignore[assignment]
@@ -3691,6 +3706,35 @@ class RuntimeNode:
                 print(f"[mep repo_audit] refusing normalized task={task_id[:8]} reason={detail}")
                 self.complete(task_id, detail)
                 return
+
+        # ── Execution bridge gate: route code-editing tasks to the real bridge,
+        # not the LLM adapter. LLMs hallucinate shell output; bridges execute.
+        # Falls through to adapter when bridge functions aren't importable (None).
+        is_execution = False
+        if (
+            interbot_message is not None
+            and is_execution_request is not None
+            and is_execution_request(interbot_message)
+        ):
+            is_execution = True
+            bridge_request = build_execution_bridge_request(
+                interbot_message,
+                consumer_id=str(task_data.get("consumer_id") or ""),
+                task_id=task_id,
+                prompt=instructions,
+            )
+            try:
+                bridge_result = asyncio.run(
+                    execute_bridge_command(bridge_request, timeout_seconds=600)
+                )
+            except Exception as exc:  # noqa: BLE001
+                bridge_result = build_execution_unavailable_result(
+                    f"bridge_raised: {exc}"
+                )
+            rendered = render_execution_result(bridge_result)
+            self.complete(task_id, rendered)
+            print(f"[mep run] execution bridge task={task_id[:8]} result={rendered}")
+            return
 
         result = self.adapter.generate_reply(instructions, adapter_task_data)
 


### PR DESCRIPTION
## Problem

PR #293 added execution bridge routing but only to `CodexProvider`. Nodes running the default `mep_runtime.py` (`python -m node.mep_runtime run`) have no bridge gate in `process_task()` — every DM, including execution DMs with `edit_operations`, falls through to `adapter.generate_reply()`.

The LLM adapter generates **plausible-looking but fabricated output**: fake commit SHAs, wrong test counts, made-up file paths, example URLs (`github.com/example/stockbot`). The sender receives what looks like a successful execution result but no code was actually changed.

**Real-world reproduction:** Two nodes on `mep-hub.silentcopilot.ai` spent multiple turn cycles sending execution DMs with `edit_operations` payloads. The receiving node accepted the format but returned AI-generated text claiming "tests passed, pushed commit abc123" — all fabricated. The root cause was that `mep_runtime.py` never checked `is_execution_request()` and always routed through the LLM.

## Fix

- **`node/mep_runtime.py`**: Added execution bridge gate in `process_task()`, inserted **before** `adapter.generate_reply()`. When `is_execution_request()` returns true and the bridge functions are importable, the task is routed to `execute_bridge_command()` instead of the adapter. Falls through to adapter when bridge imports fail (None-safe).

- **`OPERATOR_CHECKLIST.md`**: New "Execution Bridge (Talk + Execute)" section documenting:
  - Required env vars (`MEP_RUNTIME_EDIT_PATH`, `MEP_EXECUTION_BRIDGE_COMMAND`)
  - Testing procedure
  - Common failure modes table (5 entries from real interop experience)

## Test plan

- [ ] Existing tests pass: `python -m pytest tests/test_execution_bridge.py -v`
- [ ] Manual: start runtime with `MEP_RUNTIME_EDIT_PATH=/tmp/test`, send execution DM with `edit_operations`, verify result contains real shell output not LLM-generated text
- [ ] Manual: start runtime WITHOUT `MEP_RUNTIME_EDIT_PATH`, send execution DM, verify it returns `no_runtime_edit_path_configured` (fails closed)