### PR TITLE
fix: accept mep.execution-bridge.v1 in parse_interbot_payload

### DIFF
--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -1014,7 +1014,7 @@ class MEPClient:
             return None
         if not isinstance(parsed, dict):
             return None
-        if parsed.get("spec_version") != "mep.interbot.v1":
+        if parsed.get("spec_version") not in ("mep.interbot.v1", "mep.execution-bridge.v1"):
             return None
         return parsed
 


### PR DESCRIPTION
One-line fix: parse_interbot_payload only accepted mep.interbot.v1. PR #314 execution DMs use mep.execution-bridge.v1 and were silently rejected.