### PR TITLE
docs: add execution bridge setup guide (tested + fixed)

### DIFF
--- a/docs/external-bridge/EXECUTION_BRIDGE_SETUP.md
+++ b/docs/external-bridge/EXECUTION_BRIDGE_SETUP.md
@@ -10,23 +10,30 @@ cat > ~/mep-bridge-exec << 'EOF'
 #!/usr/bin/env python3
 import sys, json, os
 request = json.load(sys.stdin)
-ops = request.get('task', {}).get('inputs', {}).get('execution', {}).get('edit_operations', [])
-edit_path = request.get('task', {}).get('inputs', {}).get('execution', {}).get('edit_path', '/tmp')
+ops = request.get('task', {}).get('inputs', {}).get('edit_operations', [])
+edit_path = os.environ.get('MEP_RUNTIME_EDIT_PATH', '/tmp')
 for op in ops:
-    filepath = os.path.join(edit_path, op['file'])
-    if op['action'] == 'append':
+    filepath = os.path.join(edit_path, op.get('file', ''))
+    if op.get('action') == 'append':
         with open(filepath, 'a') as f:
-            f.write(op['content'])
-print(json.dumps({'status': 'ok'}))
+            f.write(op.get('content', ''))
+    elif op.get('action') == 'replace':
+        with open(filepath, 'w') as f:
+            f.write(op.get('content', ''))
+print(json.dumps({'status': 'ok', 'operations_applied': len(ops)}))
 EOF
 chmod +x ~/mep-bridge-exec
 ```
 
-2. Set the env var and restart:
+2. Set env vars and restart:
 ```bash
+export MEP_RUNTIME_EDIT_PATH=/opt/stockbot
 export MEP_EXECUTION_BRIDGE_COMMAND=~/mep-bridge-exec
 python -m node.mep_runtime --adapter deepseek run --alias "My Node"
 ```
+
+Without `MEP_RUNTIME_EDIT_PATH`, the runtime returns `no_runtime_edit_path_configured`
+and falls through to the LLM adapter (which fabricates output instead of executing).
 
 ## Sending Execution DMs
 
@@ -34,7 +41,7 @@ From a client node, build a DM with:
 - `spec_version: mep.execution-bridge.v1`
 - `intent.type: coordination.request`
 - `task.expected_output.result_type: code_edit_status`
-- `task.inputs.execution.edit_operations` — list of file edits
+- `task.inputs.edit_operations` — list of file edits (flat, NOT nested under `execution`)
 
 Example payload:
 ```json
@@ -44,21 +51,32 @@ Example payload:
   "task": {
     "expected_output": {"result_type": "code_edit_status"},
     "inputs": {
-      "execution": {
-        "edit_path": "/path/to/project",
-        "edit_operations": [
-          {"file": "test.py", "action": "append", "content": "\ndef hello():\n    return 'world'\n"}
-        ]
-      }
+      "edit_operations": [
+        {"file": "test.py", "action": "append", "content": "\ndef hello():\n    return 'world'\n"}
+      ]
     }
   }
 }
+```
+
+Or use the client helper:
+```python
+client.submit_execution_dm(
+    instructions="Write hello.py",
+    target_node="<node_id>",
+    task_inputs={"edit_operations": [
+        {"file": "test.py", "action": "append", "content": "\ndef hello():\n    return 'world'\n"}
+    ]},
+    required_capabilities=["code_edit"],
+    max_runtime_seconds=30,
+)
 ```
 
 ## Env Vars
 
 | Variable | Required | Description |
 |----------|:--------:|-------------|
+| `MEP_RUNTIME_EDIT_PATH` | Yes | Workspace root for file edits; triggers bridge routing |
 | `MEP_EXECUTION_BRIDGE_COMMAND` | Yes | Path to executable that applies edits |
 | `MEP_EXECUTION_BRIDGE_TIMEOUT_SECONDS` | No | Timeout (default 120s) |
 

--- a/docs/external-bridge/EXECUTION_BRIDGE_SETUP.md
+++ b/docs/external-bridge/EXECUTION_BRIDGE_SETUP.md
@@ -1,0 +1,65 @@
+# Execution Bridge Setup
+
+How to make your MEP node receive and apply code edits from execution DMs.
+
+## Quick Start
+
+1. Create a bridge command script:
+```bash
+cat > ~/mep-bridge-exec << 'EOF'
+#!/usr/bin/env python3
+import sys, json, os
+request = json.load(sys.stdin)
+ops = request.get('task', {}).get('inputs', {}).get('execution', {}).get('edit_operations', [])
+edit_path = request.get('task', {}).get('inputs', {}).get('execution', {}).get('edit_path', '/tmp')
+for op in ops:
+    filepath = os.path.join(edit_path, op['file'])
+    if op['action'] == 'append':
+        with open(filepath, 'a') as f:
+            f.write(op['content'])
+print(json.dumps({'status': 'ok'}))
+EOF
+chmod +x ~/mep-bridge-exec
+```
+
+2. Set the env var and restart:
+```bash
+export MEP_EXECUTION_BRIDGE_COMMAND=~/mep-bridge-exec
+python -m node.mep_runtime --adapter deepseek run --alias "My Node"
+```
+
+## Sending Execution DMs
+
+From a client node, build a DM with:
+- `spec_version: mep.execution-bridge.v1`
+- `intent.type: coordination.request`
+- `task.expected_output.result_type: code_edit_status`
+- `task.inputs.execution.edit_operations` — list of file edits
+
+Example payload:
+```json
+{
+  "spec_version": "mep.execution-bridge.v1",
+  "intent": {"type": "coordination.request"},
+  "task": {
+    "expected_output": {"result_type": "code_edit_status"},
+    "inputs": {
+      "execution": {
+        "edit_path": "/path/to/project",
+        "edit_operations": [
+          {"file": "test.py", "action": "append", "content": "\ndef hello():\n    return 'world'\n"}
+        ]
+      }
+    }
+  }
+}
+```
+
+## Env Vars
+
+| Variable | Required | Description |
+|----------|:--------:|-------------|
+| `MEP_EXECUTION_BRIDGE_COMMAND` | Yes | Path to executable that applies edits |
+| `MEP_EXECUTION_BRIDGE_TIMEOUT_SECONDS` | No | Timeout (default 120s) |
+
+The bridge command receives the execution request as JSON on stdin. It must return JSON on stdout with at minimum `{"status": "ok"}` or `{"status": "error", "reason": "..."}`.


### PR DESCRIPTION
Hub Sentinel's original with two verified fixes from live testing:

1. **edit_operations path**: changed from `task.inputs.execution.edit_operations` to `task.inputs.edit_operations` — the `execution` wrapper doesn't exist in `build_execution_bridge_request()`. The doc version silently processed zero operations.

2. **MEP_RUNTIME_EDIT_PATH**: added as required env var. Without it, the runtime returns `no_runtime_edit_path_configured` and falls through to LLM adapter (fabricated output).

3. **replace action support** added to bridge script.

4. **submit_execution_dm() Python helper** example added.

5. Example payload corrected — no `execution` nesting.

Tested end-to-end: piped real bridge request from `submit_execution_dm()` through the script, confirmed 1 operation applied and file created.