### PR TITLE
bridge: rerun downgraded approvals after green CI

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1359,12 +1359,12 @@ class GitHubToMEPBridgeService:
             latest_github_inputs = self._execution_github_inputs(latest_execution)
             if not latest_review_result:
                 return None
-            if str(latest_review_result.get("resolved_action") or "").strip() != "reviewed":
-                return None
-            if str(latest_review_result.get("attempted_action") or "").strip() != "approved":
-                return None
             downgrade_reason = str(latest_review_result.get("downgrade_reason") or "").strip()
-            if downgrade_reason not in {"approval_checks_pending", "approval_checks_not_green"}:
+            if not self._is_ci_downgraded_approval_execution(
+                latest_execution,
+                latest_review_result=latest_review_result,
+                downgrade_reason=downgrade_reason,
+            ):
                 return None
             if str(latest_github_inputs.get("followup_reason") or "").strip() == "ci_green_webhook":
                 return None
@@ -1442,6 +1442,23 @@ class GitHubToMEPBridgeService:
                 coalesced_actions=[action],
             )
         return None
+
+    @staticmethod
+    def _is_ci_downgraded_approval_execution(
+        execution: dict[str, Any],
+        *,
+        latest_review_result: Optional[dict[str, Any]] = None,
+        downgrade_reason: Optional[str] = None,
+    ) -> bool:
+        review_result = latest_review_result or {}
+        resolved_action = str(review_result.get("resolved_action") or execution.get("action") or "").strip()
+        attempted_action = str(review_result.get("attempted_action") or "").strip()
+        normalized_reason = str(downgrade_reason or review_result.get("downgrade_reason") or "").strip()
+        return (
+            resolved_action == "reviewed"
+            and attempted_action == "approved"
+            and normalized_reason in {"approval_checks_pending", "approval_checks_not_green"}
+        )
 
     def _get_targets_for_event(
         self, event: NormalizedGitHubEvent

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -28,7 +28,13 @@ except ImportError:  # pragma: no cover - direct file execution may not see repo
     _shared_review_patterns = None
 
 
-SUPPORTED_GITHUB_EVENTS = {"issue_comment", "pull_request", "pull_request_review_comment"}
+SUPPORTED_GITHUB_EVENTS = {
+    "issue_comment",
+    "pull_request",
+    "pull_request_review_comment",
+    "check_run",
+    "check_suite",
+}
 DEFAULT_TRIGGER_VERBS = {
     "review": "code.review.request",
     "rereview": "code.review.request",
@@ -722,6 +728,29 @@ class BridgeStore:
         record["review_feedback"] = self._decode_json_dict(record.get("review_feedback_json"))
         return record
 
+    def get_latest_execution_for_pr(self, repo_full_name: str, issue_number: int) -> Optional[dict[str, Any]]:
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT *
+            FROM bridge_executions
+            WHERE repo_full_name = ? AND issue_number = ? AND entity_type = 'pr'
+            ORDER BY updated_at DESC
+            LIMIT 1
+            """,
+            (repo_full_name, issue_number),
+        )
+        row = cursor.fetchone()
+        conn.close()
+        if row is None:
+            return None
+        record = dict(row)
+        record["github_inputs"] = self._decode_json_dict(record.get("github_inputs_json"))
+        record["review_result"] = self._decode_json_dict(record.get("review_result_json"))
+        record["review_feedback"] = self._decode_json_dict(record.get("review_feedback_json"))
+        return record
+
     def list_recent_review_trials(self, *, limit: int = 20) -> list[dict[str, Any]]:
         safe_limit = max(1, min(int(limit), 200))
         conn = self._connect()
@@ -1174,6 +1203,13 @@ class GitHubToMEPBridgeService:
             return None
         if self.config.allowed_repos and repo_full_name not in self.config.allowed_repos:
             return None
+        if github_event in {"check_run", "check_suite"}:
+            return self._normalize_ci_followup_event(
+                delivery_id=delivery_id,
+                github_event=github_event,
+                payload=payload,
+                repo_full_name=repo_full_name,
+            )
 
         action = str(payload.get("action") or "").strip() or "unknown"
         entity_type = "pr"
@@ -1285,10 +1321,143 @@ class GitHubToMEPBridgeService:
             coalesced_actions=[action],
         )
 
+    def _normalize_ci_followup_event(
+        self,
+        *,
+        delivery_id: str,
+        github_event: str,
+        payload: dict[str, Any],
+        repo_full_name: str,
+    ) -> Optional[NormalizedGitHubEvent]:
+        action = str(payload.get("action") or "").strip() or "unknown"
+        check_key = "check_run" if github_event == "check_run" else "check_suite"
+        check_payload = payload.get(check_key)
+        if not isinstance(check_payload, dict):
+            return None
+        status = str(check_payload.get("status") or "").strip().lower()
+        if action != "completed" or status != "completed":
+            return None
+        conclusion = str(check_payload.get("conclusion") or "").strip().lower()
+        if conclusion not in {"success", "neutral", "skipped"}:
+            return None
+        pr_refs = check_payload.get("pull_requests")
+        if not isinstance(pr_refs, list) or not pr_refs:
+            return None
+        sender = payload.get("sender") if isinstance(payload.get("sender"), dict) else {}
+        actor_login = str(sender.get("login") or "github-actions[bot]")
+
+        for pr_ref in pr_refs:
+            if not isinstance(pr_ref, dict):
+                continue
+            number = pr_ref.get("number")
+            if not isinstance(number, int) or number <= 0:
+                continue
+            latest_execution = self.store.get_latest_execution_for_pr(repo_full_name, number)
+            if latest_execution is None:
+                continue
+            latest_review_result = latest_execution.get("review_result") or {}
+            latest_github_inputs = self._execution_github_inputs(latest_execution)
+            if not latest_review_result:
+                return None
+            if str(latest_review_result.get("resolved_action") or "").strip() != "reviewed":
+                return None
+            if str(latest_review_result.get("attempted_action") or "").strip() != "approved":
+                return None
+            downgrade_reason = str(latest_review_result.get("downgrade_reason") or "").strip()
+            if downgrade_reason not in {"approval_checks_pending", "approval_checks_not_green"}:
+                return None
+            if str(latest_github_inputs.get("followup_reason") or "").strip() == "ci_green_webhook":
+                return None
+
+            review_package = self._fetch_pr_review_package(repo_full_name, number)
+            ci_checks = review_package.get("ci_checks") or {}
+            if not ci_checks.get("has_checks") or not ci_checks.get("all_green"):
+                return None
+
+            url = str(
+                latest_github_inputs.get("url")
+                or pr_ref.get("html_url")
+                or f"https://github.com/{repo_full_name}/pull/{number}"
+            ).strip()
+            imperative_verb = str(latest_execution.get("imperative_verb") or "approve").strip() or "approve"
+            review_mode = str(latest_github_inputs.get("review_mode") or self._review_mode_for_verb(imperative_verb)).strip()
+            intent_type = str(latest_execution.get("intent_type") or DEFAULT_TRIGGER_VERBS["approve"]).strip()
+            review_context = str(review_package.get("instructions_context") or "")
+            title = str(latest_github_inputs.get("title") or f"PR #{number}").strip() or f"PR #{number}"
+            trigger_text = (
+                "Automatic follow-up: GitHub CI turned green after an earlier approval attempt was downgraded. "
+                "Re-evaluate the latest diff and checks, and only approve if the evidence is still grounded."
+            )
+            followup_github_inputs = {
+                **latest_github_inputs,
+                "delivery_id": delivery_id,
+                "source_event": github_event,
+                "source_action": action,
+                "trigger_verb": imperative_verb,
+                "review_mode": review_mode,
+                "followup_reason": "ci_green_webhook",
+                "followup_of_bridge_id": str(latest_execution.get("bridge_id") or ""),
+                "followup_target_alias": str(latest_execution.get("target_alias") or "").strip(),
+                "followup_target_node_id": str(latest_execution.get("target_node_id") or "").strip(),
+            }
+            compact_review_package = self._compact_review_package_for_task_inputs(review_package)
+            for key, value in compact_review_package.items():
+                if key != "instructions_context":
+                    followup_github_inputs[key] = value
+            instructions = self._build_instructions(
+                repo_full_name=repo_full_name,
+                entity_type="pr",
+                number=number,
+                title=title,
+                url=url,
+                actor_login=actor_login,
+                action=action,
+                imperative_verb=imperative_verb,
+                review_mode=review_mode,
+                trigger_text=trigger_text,
+                review_context=review_context,
+            )
+            context_id = str(latest_execution.get("context_id") or "").strip()
+            if not context_id:
+                owner, repo_name = repo_full_name.split("/", 1)
+                context_id = f"github-{owner}-{repo_name}-pr-{number}"
+            return NormalizedGitHubEvent(
+                delivery_id=delivery_id,
+                source_event=github_event,
+                source_action=action,
+                repo_full_name=repo_full_name,
+                entity_type="pr",
+                number=number,
+                title=title,
+                url=url,
+                actor_login=actor_login,
+                author_association="",
+                context_id=context_id,
+                imperative_verb=imperative_verb,
+                intent_type=intent_type,
+                instructions=instructions,
+                raw_trigger_text="",
+                github_inputs=followup_github_inputs,
+                coalesced_delivery_ids=[delivery_id],
+                coalesced_actions=[action],
+            )
+        return None
+
     def _get_targets_for_event(
         self, event: NormalizedGitHubEvent
     ) -> list[TriggerMatch]:
         """Re-extract multi-target triggers from a normalized event's trigger text."""
+        explicit_alias = str(event.github_inputs.get("followup_target_alias") or "").strip()
+        explicit_node_id = str(event.github_inputs.get("followup_target_node_id") or "").strip()
+        if explicit_alias and explicit_node_id:
+            return [
+                TriggerMatch(
+                    alias=explicit_alias,
+                    verb=event.imperative_verb,
+                    intent_type=event.intent_type,
+                    node_id=explicit_node_id,
+                )
+            ]
         return self._extract_triggers(event.raw_trigger_text)
 
     @staticmethod

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1092,6 +1092,88 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(duplicate_response.json()["reason"], "non_actionable")
         self.assertEqual(len(self.submission.calls), 2)
 
+    def test_green_ci_webhook_ignores_latest_execution_without_ci_downgraded_approval_guard(self):
+        event = NormalizedGitHubEvent(
+            delivery_id="delivery-seeded",
+            source_event="issue_comment",
+            source_action="created",
+            repo_full_name="WUAIBING/MEP",
+            entity_type="pr",
+            number=322,
+            title="PR 322",
+            url="https://github.com/WUAIBING/MEP/pull/322",
+            actor_login="moltbot",
+            author_association="COLLABORATOR",
+            context_id="github-WUAIBING-MEP-pr-322",
+            imperative_verb="approve",
+            intent_type="code.review.approve",
+            instructions="seeded execution for guard coverage",
+            raw_trigger_text="@Hub-Sentinel approve this PR",
+            github_inputs={
+                "url": "https://github.com/WUAIBING/MEP/pull/322",
+                "review_mode": "discovery_review",
+            },
+        )
+        self.store.create_execution(
+            event,
+            "br-seeded-322",
+            "node_target",
+            target_alias="Hub Sentinel",
+            instructions=event.instructions,
+        )
+        self.store.update_execution(
+            "br-seeded-322",
+            status="completed",
+            action="reviewed",
+            review_result={
+                "attempted_action": "approved",
+                "resolved_action": "reviewed",
+                "published": True,
+                "suppressed": False,
+                "retry_queued": False,
+                "retry_count": 0,
+            },
+        )
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "bridge/github_to_mep.py",
+                    "status": "modified",
+                    "additions": 3,
+                    "deletions": 0,
+                    "changes": 3,
+                    "patch": "@@ -1,0 +1,3 @@\n+def green_ci_followup_guard():\n+    return True\n",
+                }
+            ],
+            pr_body="Seeded CI-green follow-up guard coverage.",
+            checks_payload={
+                "total_count": 2,
+                "check_runs": [
+                    {
+                        "name": "test (ubuntu-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                    {
+                        "name": "test (windows-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                ],
+            },
+            fetch_cycles=2,
+        )
+
+        response = self._post_webhook(
+            _check_run_payload(pr_number=322),
+            delivery_id="delivery-ci-followup-guard",
+            event_name="check_run",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()["status"], "ignored")
+        self.assertEqual(response.json()["reason"], "non_actionable")
+        self.assertEqual(len(self.submission.calls), 0)
+
     def test_status_callback_allows_approve_with_grounded_code_and_test_awareness(self):
         self._set_pr_review_package(
             [

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -165,6 +165,54 @@ def _issue_comment_payload(
     }
 
 
+def _check_run_payload(
+    *,
+    pr_number: int,
+    action: str = "completed",
+    status: str = "completed",
+    conclusion: Optional[str] = "success",
+) -> dict:
+    return {
+        "action": action,
+        "repository": {"full_name": "WUAIBING/MEP"},
+        "check_run": {
+            "status": status,
+            "conclusion": conclusion,
+            "pull_requests": [
+                {
+                    "number": pr_number,
+                    "html_url": f"https://github.com/WUAIBING/MEP/pull/{pr_number}",
+                }
+            ],
+        },
+        "sender": {"login": "github-actions[bot]", "type": "Bot"},
+    }
+
+
+def _check_suite_payload(
+    *,
+    pr_number: int,
+    action: str = "completed",
+    status: str = "completed",
+    conclusion: Optional[str] = "success",
+) -> dict:
+    return {
+        "action": action,
+        "repository": {"full_name": "WUAIBING/MEP"},
+        "check_suite": {
+            "status": status,
+            "conclusion": conclusion,
+            "pull_requests": [
+                {
+                    "number": pr_number,
+                    "html_url": f"https://github.com/WUAIBING/MEP/pull/{pr_number}",
+                }
+            ],
+        },
+        "sender": {"login": "github-actions[bot]", "type": "Bot"},
+    }
+
+
 class TestGitHubToMEPBridge(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = tempfile.mkdtemp(prefix="mep_bridge_")
@@ -920,6 +968,129 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(execution["action"], "reviewed")
         self.assertEqual(execution["task_id"], "task-approve-checks-fail")
         self.assertEqual(execution["retry_count"], 0)
+
+    def test_green_ci_webhook_retriggers_downgraded_approval_once(self):
+        changed_files = [
+            {
+                "filename": "node/mep_runtime.py",
+                "status": "modified",
+                "additions": 6,
+                "deletions": 1,
+                "changes": 7,
+                "patch": (
+                    "@@ -945,0 +945,6 @@\n"
+                    "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
+                    "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
+                ),
+            },
+            {
+                "filename": "tests/test_node_runtime.py",
+                "status": "modified",
+                "additions": 8,
+                "deletions": 0,
+                "changes": 8,
+                "patch": (
+                    "@@ -494,0 +494,8 @@\n"
+                    "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
+                    "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
+                ),
+            },
+        ]
+        self._set_pr_review_package(
+            changed_files,
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+            checks_payload={
+                "total_count": 1,
+                "check_runs": [
+                    {
+                        "name": "test (windows-latest, 3.10)",
+                        "status": "in_progress",
+                        "conclusion": None,
+                    }
+                ],
+            },
+            fetch_cycles=4,
+        )
+        initial_response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel approve this PR", delivery_number=320),
+            delivery_id="delivery-ci-followup-initial",
+        )
+        self.assertEqual(initial_response.status_code, 200)
+        bridge_id = initial_response.json()["bridge_id"]
+        self._flush_context(initial_response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-ci-followup-initial",
+                "action": "approved",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The PR adds pending-task recovery observability in `node/mep_runtime.py` and keeps the verification path narrow.\n\n"
+                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, and the changed test keeps the recovery behavior covered. No risky changes.\n\n"
+                    "Touched paths reviewed: `node/mep_runtime.py`, `tests/test_node_runtime.py`\n\n"
+                    "Tests reviewed: `tests/test_node_runtime.py`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.submission.calls), 1)
+        self.assertEqual(len(self.github_session.posts), 1)
+        self.assertEqual(self.github_session.posts[0]["json"]["event"], "COMMENT")
+
+        self._set_pr_review_package(
+            changed_files,
+            pr_body="Adds pending-task recovery observability and focused runtime tests.",
+            checks_payload={
+                "total_count": 2,
+                "check_runs": [
+                    {
+                        "name": "test (ubuntu-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                    {
+                        "name": "test (windows-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                ],
+            },
+            fetch_cycles=4,
+        )
+        green_response = self._post_webhook(
+            _check_run_payload(pr_number=320),
+            delivery_id="delivery-ci-followup-green",
+            event_name="check_run",
+        )
+        self.assertEqual(green_response.status_code, 200, green_response.text)
+        self.assertEqual(green_response.json()["status"], "buffered")
+        self._flush_context(green_response.json()["context_id"])
+
+        self.assertEqual(len(self.submission.calls), 2)
+        followup_call = self.submission.calls[-1]
+        self.assertEqual(followup_call["intent_type"], "code.review.approve")
+        self.assertEqual(followup_call["target_node_id"], "node_target")
+        followup_inputs = followup_call["envelope"]["task"]["inputs"]["github"]
+        self.assertEqual(followup_inputs["followup_reason"], "ci_green_webhook")
+        self.assertEqual(followup_inputs["followup_of_bridge_id"], bridge_id)
+        self.assertEqual(followup_inputs["source_event"], "check_run")
+        self.assertEqual(followup_inputs["ci_checks"]["state"], "green")
+
+        duplicate_response = self._post_webhook(
+            _check_suite_payload(pr_number=320),
+            delivery_id="delivery-ci-followup-duplicate",
+            event_name="check_suite",
+        )
+        self.assertEqual(duplicate_response.status_code, 200, duplicate_response.text)
+        self.assertEqual(duplicate_response.json()["status"], "ignored")
+        self.assertEqual(duplicate_response.json()["reason"], "non_actionable")
+        self.assertEqual(len(self.submission.calls), 2)
 
     def test_status_callback_allows_approve_with_grounded_code_and_test_awareness(self):
         self._set_pr_review_package(


### PR DESCRIPTION
## Summary
- add check_run/check_suite handling so the bridge can re-dispatch an approval task after CI turns green
- only trigger follow-up when the latest PR execution was downgraded from approve due to non-green CI
- preserve target routing and add a one-shot regression test for the green follow-up path

## Verification
- python -m pytest tests/test_github_bridge.py