### PR TITLE
fix: bootstrap green-CI bridge reviews

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1352,9 +1352,78 @@ class GitHubToMEPBridgeService:
             number = pr_ref.get("number")
             if not isinstance(number, int) or number <= 0:
                 continue
+            review_package = self._fetch_pr_review_package(repo_full_name, number)
+            ci_checks = review_package.get("ci_checks") or {}
+            if not ci_checks.get("has_checks") or not ci_checks.get("all_green"):
+                return None
             latest_execution = self.store.get_latest_execution_for_pr(repo_full_name, number)
             if latest_execution is None:
-                continue
+                bootstrap_target_node_id = self.config.target_node_id.strip()
+                bootstrap_target_alias = self.config.target_alias.strip() or "Hub Sentinel"
+                if not bootstrap_target_node_id:
+                    continue
+                url = str(pr_ref.get("html_url") or f"https://github.com/{repo_full_name}/pull/{number}").strip()
+                review_mode = self._review_mode_for_verb("review")
+                review_context = str(review_package.get("instructions_context") or "")
+                title = str(review_package.get("title") or f"PR #{number}").strip() or f"PR #{number}"
+                trigger_text = (
+                    "Automatic bootstrap: GitHub CI is green and no prior bridge execution exists. "
+                    "Review the latest diff and checks, and only publish grounded findings or a grounded no-finding review."
+                )
+                bootstrap_github_inputs = {
+                    "repo_full_name": repo_full_name,
+                    "entity_type": "pr",
+                    "number": number,
+                    "url": url,
+                    "actor_login": actor_login,
+                    "author_association": "",
+                    "delivery_id": delivery_id,
+                    "source_event": github_event,
+                    "source_action": action,
+                    "trigger_verb": "review",
+                    "review_mode": review_mode,
+                    "followup_reason": "ci_green_bootstrap",
+                    "followup_target_alias": bootstrap_target_alias,
+                    "followup_target_node_id": bootstrap_target_node_id,
+                }
+                compact_review_package = self._compact_review_package_for_task_inputs(review_package)
+                for key, value in compact_review_package.items():
+                    if key != "instructions_context":
+                        bootstrap_github_inputs[key] = value
+                instructions = self._build_instructions(
+                    repo_full_name=repo_full_name,
+                    entity_type="pr",
+                    number=number,
+                    title=title,
+                    url=url,
+                    actor_login=actor_login,
+                    action=action,
+                    imperative_verb="review",
+                    review_mode=review_mode,
+                    trigger_text=trigger_text,
+                    review_context=review_context,
+                )
+                owner, repo_name = repo_full_name.split("/", 1)
+                return NormalizedGitHubEvent(
+                    delivery_id=delivery_id,
+                    source_event=github_event,
+                    source_action=action,
+                    repo_full_name=repo_full_name,
+                    entity_type="pr",
+                    number=number,
+                    title=title,
+                    url=url,
+                    actor_login=actor_login,
+                    author_association="",
+                    context_id=f"github-{owner}-{repo_name}-pr-{number}",
+                    imperative_verb="review",
+                    intent_type=DEFAULT_TRIGGER_VERBS["review"],
+                    instructions=instructions,
+                    raw_trigger_text="",
+                    github_inputs=bootstrap_github_inputs,
+                    coalesced_delivery_ids=[delivery_id],
+                    coalesced_actions=[action],
+                )
             latest_review_result = latest_execution.get("review_result") or {}
             latest_github_inputs = self._execution_github_inputs(latest_execution)
             if not latest_review_result:
@@ -1367,11 +1436,6 @@ class GitHubToMEPBridgeService:
             ):
                 return None
             if str(latest_github_inputs.get("followup_reason") or "").strip() == "ci_green_webhook":
-                return None
-
-            review_package = self._fetch_pr_review_package(repo_full_name, number)
-            ci_checks = review_package.get("ci_checks") or {}
-            if not ci_checks.get("has_checks") or not ci_checks.get("all_green"):
                 return None
 
             url = str(

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1174,6 +1174,80 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(response.json()["reason"], "non_actionable")
         self.assertEqual(len(self.submission.calls), 0)
 
+    def test_green_ci_webhook_bootstraps_review_when_no_prior_execution_exists(self):
+        changed_files = [
+            {
+                "filename": "bridge/github_to_mep.py",
+                "status": "modified",
+                "additions": 8,
+                "deletions": 0,
+                "changes": 8,
+                "patch": (
+                    "@@ -1324,0 +1324,8 @@\n"
+                    "+def bootstrap_green_ci_review(self):\n"
+                    "+    return 'queued'\n"
+                ),
+            },
+            {
+                "filename": "tests/test_github_bridge.py",
+                "status": "modified",
+                "additions": 8,
+                "deletions": 0,
+                "changes": 8,
+                "patch": (
+                    "@@ -1095,0 +1095,8 @@\n"
+                    "+def test_green_ci_webhook_bootstraps_review_when_no_prior_execution_exists(self):\n"
+                    "+    assert response.json()['status'] == 'buffered'\n"
+                ),
+            },
+        ]
+        self._set_pr_review_package(
+            changed_files,
+            pr_body="Adds CI-green bootstrap coverage for the GitHub bridge review loop.",
+            checks_payload={
+                "total_count": 2,
+                "check_runs": [
+                    {
+                        "name": "test (ubuntu-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                    {
+                        "name": "test (windows-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                ],
+            },
+            fetch_cycles=2,
+        )
+
+        response = self._post_webhook(
+            _check_suite_payload(pr_number=323),
+            delivery_id="delivery-ci-bootstrap-review",
+            event_name="check_suite",
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()["status"], "buffered")
+        self._flush_context(response.json()["context_id"])
+
+        self.assertEqual(len(self.submission.calls), 1)
+        call = self.submission.calls[0]
+        self.assertEqual(call["target_node_id"], "node_target")
+        self.assertEqual(call["intent_type"], "code.review.request")
+
+        github_inputs = call["envelope"]["task"]["inputs"]["github"]
+        instructions = call["envelope"]["task"]["instructions"]
+        self.assertEqual(github_inputs["followup_reason"], "ci_green_bootstrap")
+        self.assertEqual(github_inputs["followup_target_alias"], "Hub Sentinel")
+        self.assertEqual(github_inputs["followup_target_node_id"], "node_target")
+        self.assertEqual(github_inputs["trigger_verb"], "review")
+        self.assertEqual(github_inputs["review_mode"], "discovery_review")
+        self.assertEqual(github_inputs["source_event"], "check_suite")
+        self.assertEqual(github_inputs["ci_checks"]["state"], "green")
+        self.assertIn("Automatic bootstrap: GitHub CI is green", instructions)
+        self.assertEqual(len(self.github_session.posts), 0)
+
     def test_status_callback_allows_approve_with_grounded_code_and_test_awareness(self):
         self._set_pr_review_package(
             [


### PR DESCRIPTION
Bootstrap a default review task when GitHub CI turns green and no prior bridge execution exists. Preserves the existing resume-only path for downgraded approval follow-ups.\n\nTesting:\n- python -m pytest tests/test_github_bridge.py -q -k 'green_ci_webhook or ci_followup or bootstrap_review'\n- python -m pytest tests/test_github_bridge.py -q