### PR TITLE
chore: clarify patch grounding comment

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -600,6 +600,8 @@ def _review_patch_visible_identifier_tokens(task_data: Optional[dict[str, Any]])
 
 def _review_has_patch_grounding_context(task_data: Optional[dict[str, Any]]) -> bool:
     github_inputs = _review_github_inputs(task_data or {})
+    # Only enforce changed-line identifier grounding when the task carries
+    # authoritative diff excerpts or hunk context from the bridge.
     changed_files = github_inputs.get("changed_files")
     if isinstance(changed_files, list) and any(isinstance(item, dict) for item in changed_files):
         return True


### PR DESCRIPTION
## Summary
- add a clarifying comment beside the patch-grounding helper

## Verification
- python -m pytest tests/test_node_runtime.py -q -k " test_structured_review_omits_context_only_verified_identifiers_for_comment_only_change\