### PR TITLE
fix(review): suppress speculative docs findings

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -28,13 +28,7 @@ except ImportError:  # pragma: no cover - direct file execution may not see repo
     _shared_review_patterns = None
 
 
-SUPPORTED_GITHUB_EVENTS = {
-    "issue_comment",
-    "pull_request",
-    "pull_request_review_comment",
-    "check_run",
-    "check_suite",
-}
+SUPPORTED_GITHUB_EVENTS = {"issue_comment", "pull_request", "pull_request_review_comment"}
 DEFAULT_TRIGGER_VERBS = {
     "review": "code.review.request",
     "rereview": "code.review.request",
@@ -731,29 +725,6 @@ class BridgeStore:
         record["review_feedback"] = self._decode_json_dict(record.get("review_feedback_json"))
         return record
 
-    def get_latest_execution_for_pr(self, repo_full_name: str, issue_number: int) -> Optional[dict[str, Any]]:
-        conn = self._connect()
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT *
-            FROM bridge_executions
-            WHERE repo_full_name = ? AND issue_number = ? AND entity_type = 'pr'
-            ORDER BY updated_at DESC
-            LIMIT 1
-            """,
-            (repo_full_name, issue_number),
-        )
-        row = cursor.fetchone()
-        conn.close()
-        if row is None:
-            return None
-        record = dict(row)
-        record["github_inputs"] = self._decode_json_dict(record.get("github_inputs_json"))
-        record["review_result"] = self._decode_json_dict(record.get("review_result_json"))
-        record["review_feedback"] = self._decode_json_dict(record.get("review_feedback_json"))
-        return record
-
     def list_recent_review_trials(self, *, limit: int = 20) -> list[dict[str, Any]]:
         safe_limit = max(1, min(int(limit), 200))
         conn = self._connect()
@@ -1206,13 +1177,6 @@ class GitHubToMEPBridgeService:
             return None
         if self.config.allowed_repos and repo_full_name not in self.config.allowed_repos:
             return None
-        if github_event in {"check_run", "check_suite"}:
-            return self._normalize_ci_followup_event(
-                delivery_id=delivery_id,
-                github_event=github_event,
-                payload=payload,
-                repo_full_name=repo_full_name,
-            )
 
         action = str(payload.get("action") or "").strip() or "unknown"
         entity_type = "pr"
@@ -1324,224 +1288,10 @@ class GitHubToMEPBridgeService:
             coalesced_actions=[action],
         )
 
-    def _normalize_ci_followup_event(
-        self,
-        *,
-        delivery_id: str,
-        github_event: str,
-        payload: dict[str, Any],
-        repo_full_name: str,
-    ) -> Optional[NormalizedGitHubEvent]:
-        action = str(payload.get("action") or "").strip() or "unknown"
-        check_key = "check_run" if github_event == "check_run" else "check_suite"
-        check_payload = payload.get(check_key)
-        if not isinstance(check_payload, dict):
-            return None
-        status = str(check_payload.get("status") or "").strip().lower()
-        if action != "completed" or status != "completed":
-            return None
-        conclusion = str(check_payload.get("conclusion") or "").strip().lower()
-        if conclusion not in {"success", "neutral", "skipped"}:
-            return None
-        pr_refs = check_payload.get("pull_requests")
-        if not isinstance(pr_refs, list) or not pr_refs:
-            return None
-        sender = payload.get("sender") if isinstance(payload.get("sender"), dict) else {}
-        actor_login = str(sender.get("login") or "github-actions[bot]")
-
-        for pr_ref in pr_refs:
-            if not isinstance(pr_ref, dict):
-                continue
-            number = pr_ref.get("number")
-            if not isinstance(number, int) or number <= 0:
-                continue
-            review_package = self._fetch_pr_review_package(repo_full_name, number)
-            ci_checks = review_package.get("ci_checks") or {}
-            if not ci_checks.get("has_checks") or not ci_checks.get("all_green"):
-                return None
-            latest_execution = self.store.get_latest_execution_for_pr(repo_full_name, number)
-            if latest_execution is None:
-                bootstrap_target_node_id = self.config.target_node_id.strip()
-                bootstrap_target_alias = self.config.target_alias.strip() or "Hub Sentinel"
-                if not bootstrap_target_node_id:
-                    continue
-                url = str(pr_ref.get("html_url") or f"https://github.com/{repo_full_name}/pull/{number}").strip()
-                review_mode = self._review_mode_for_verb("review")
-                review_context = str(review_package.get("instructions_context") or "")
-                title = str(review_package.get("title") or f"PR #{number}").strip() or f"PR #{number}"
-                trigger_text = (
-                    "Automatic bootstrap: GitHub CI is green and no prior bridge execution exists. "
-                    "Review the latest diff and checks, and only publish grounded findings or a grounded no-finding review."
-                )
-                bootstrap_github_inputs = {
-                    "repo_full_name": repo_full_name,
-                    "entity_type": "pr",
-                    "number": number,
-                    "url": url,
-                    "actor_login": actor_login,
-                    "author_association": "",
-                    "delivery_id": delivery_id,
-                    "source_event": github_event,
-                    "source_action": action,
-                    "trigger_verb": "review",
-                    "review_mode": review_mode,
-                    "followup_reason": "ci_green_bootstrap",
-                    "followup_target_alias": bootstrap_target_alias,
-                    "followup_target_node_id": bootstrap_target_node_id,
-                }
-                compact_review_package = self._compact_review_package_for_task_inputs(review_package)
-                for key, value in compact_review_package.items():
-                    if key != "instructions_context":
-                        bootstrap_github_inputs[key] = value
-                instructions = self._build_instructions(
-                    repo_full_name=repo_full_name,
-                    entity_type="pr",
-                    number=number,
-                    title=title,
-                    url=url,
-                    actor_login=actor_login,
-                    action=action,
-                    imperative_verb="review",
-                    review_mode=review_mode,
-                    trigger_text=trigger_text,
-                    review_context=review_context,
-                )
-                owner, repo_name = repo_full_name.split("/", 1)
-                return NormalizedGitHubEvent(
-                    delivery_id=delivery_id,
-                    source_event=github_event,
-                    source_action=action,
-                    repo_full_name=repo_full_name,
-                    entity_type="pr",
-                    number=number,
-                    title=title,
-                    url=url,
-                    actor_login=actor_login,
-                    author_association="",
-                    context_id=f"github-{owner}-{repo_name}-pr-{number}",
-                    imperative_verb="review",
-                    intent_type=DEFAULT_TRIGGER_VERBS["review"],
-                    instructions=instructions,
-                    raw_trigger_text="",
-                    github_inputs=bootstrap_github_inputs,
-                    coalesced_delivery_ids=[delivery_id],
-                    coalesced_actions=[action],
-                )
-            latest_review_result = latest_execution.get("review_result") or {}
-            latest_github_inputs = self._execution_github_inputs(latest_execution)
-            if not latest_review_result:
-                return None
-            downgrade_reason = str(latest_review_result.get("downgrade_reason") or "").strip()
-            if not self._is_ci_downgraded_approval_execution(
-                latest_execution,
-                latest_review_result=latest_review_result,
-                downgrade_reason=downgrade_reason,
-            ):
-                return None
-            if str(latest_github_inputs.get("followup_reason") or "").strip() == "ci_green_webhook":
-                return None
-
-            url = str(
-                latest_github_inputs.get("url")
-                or pr_ref.get("html_url")
-                or f"https://github.com/{repo_full_name}/pull/{number}"
-            ).strip()
-            imperative_verb = str(latest_execution.get("imperative_verb") or "approve").strip() or "approve"
-            review_mode = str(latest_github_inputs.get("review_mode") or self._review_mode_for_verb(imperative_verb)).strip()
-            intent_type = str(latest_execution.get("intent_type") or DEFAULT_TRIGGER_VERBS["approve"]).strip()
-            review_context = str(review_package.get("instructions_context") or "")
-            title = str(latest_github_inputs.get("title") or f"PR #{number}").strip() or f"PR #{number}"
-            trigger_text = (
-                "Automatic follow-up: GitHub CI turned green after an earlier approval attempt was downgraded. "
-                "Re-evaluate the latest diff and checks, and only approve if the evidence is still grounded."
-            )
-            followup_github_inputs = {
-                **latest_github_inputs,
-                "delivery_id": delivery_id,
-                "source_event": github_event,
-                "source_action": action,
-                "trigger_verb": imperative_verb,
-                "review_mode": review_mode,
-                "followup_reason": "ci_green_webhook",
-                "followup_of_bridge_id": str(latest_execution.get("bridge_id") or ""),
-                "followup_target_alias": str(latest_execution.get("target_alias") or "").strip(),
-                "followup_target_node_id": str(latest_execution.get("target_node_id") or "").strip(),
-            }
-            compact_review_package = self._compact_review_package_for_task_inputs(review_package)
-            for key, value in compact_review_package.items():
-                if key != "instructions_context":
-                    followup_github_inputs[key] = value
-            instructions = self._build_instructions(
-                repo_full_name=repo_full_name,
-                entity_type="pr",
-                number=number,
-                title=title,
-                url=url,
-                actor_login=actor_login,
-                action=action,
-                imperative_verb=imperative_verb,
-                review_mode=review_mode,
-                trigger_text=trigger_text,
-                review_context=review_context,
-            )
-            context_id = str(latest_execution.get("context_id") or "").strip()
-            if not context_id:
-                owner, repo_name = repo_full_name.split("/", 1)
-                context_id = f"github-{owner}-{repo_name}-pr-{number}"
-            return NormalizedGitHubEvent(
-                delivery_id=delivery_id,
-                source_event=github_event,
-                source_action=action,
-                repo_full_name=repo_full_name,
-                entity_type="pr",
-                number=number,
-                title=title,
-                url=url,
-                actor_login=actor_login,
-                author_association="",
-                context_id=context_id,
-                imperative_verb=imperative_verb,
-                intent_type=intent_type,
-                instructions=instructions,
-                raw_trigger_text="",
-                github_inputs=followup_github_inputs,
-                coalesced_delivery_ids=[delivery_id],
-                coalesced_actions=[action],
-            )
-        return None
-
-    @staticmethod
-    def _is_ci_downgraded_approval_execution(
-        execution: dict[str, Any],
-        *,
-        latest_review_result: Optional[dict[str, Any]] = None,
-        downgrade_reason: Optional[str] = None,
-    ) -> bool:
-        review_result = latest_review_result or {}
-        resolved_action = str(review_result.get("resolved_action") or execution.get("action") or "").strip()
-        attempted_action = str(review_result.get("attempted_action") or "").strip()
-        normalized_reason = str(downgrade_reason or review_result.get("downgrade_reason") or "").strip()
-        return (
-            resolved_action == "reviewed"
-            and attempted_action == "approved"
-            and normalized_reason in {"approval_checks_pending", "approval_checks_not_green"}
-        )
-
     def _get_targets_for_event(
         self, event: NormalizedGitHubEvent
     ) -> list[TriggerMatch]:
         """Re-extract multi-target triggers from a normalized event's trigger text."""
-        explicit_alias = str(event.github_inputs.get("followup_target_alias") or "").strip()
-        explicit_node_id = str(event.github_inputs.get("followup_target_node_id") or "").strip()
-        if explicit_alias and explicit_node_id:
-            return [
-                TriggerMatch(
-                    alias=explicit_alias,
-                    verb=event.imperative_verb,
-                    intent_type=event.intent_type,
-                    node_id=explicit_node_id,
-                )
-            ]
         return self._extract_triggers(event.raw_trigger_text)
 
     @staticmethod
@@ -3049,11 +2799,13 @@ class GitHubToMEPBridgeService:
             return "approval_contains_findings"
         if not snapshot.get("anchored_paths"):
             return "approval_without_touched_path_anchor"
-        if not snapshot.get("changed_tokens"):
+        if not snapshot.get("changed_tokens") and not snapshot.get("changed_verified_identifiers"):
             return "approval_without_changed_code_evidence"
+        if not snapshot.get("changed_verified_identifiers"):
+            return "approval_without_verified_evidence"
         if snapshot.get("expected_tests") and not snapshot.get("mentions_tests"):
             return "approval_without_test_awareness"
-        if score < 6:
+        if score < 7:
             return "approval_below_quality_bar"
         return None
 
@@ -4297,6 +4049,8 @@ class GitHubToMEPBridgeService:
             critique += "The code identifiers you mentioned are in the file context but NOT in the actual changed lines (+/-). Please focus your review on the actual changes."
         elif reason == "approval_without_changed_code_evidence":
             critique += "You attempted to approve the PR without citing changed-line code evidence. Reference concrete identifiers from the actual diff before approving."
+        elif reason == "approval_without_verified_evidence":
+            critique += "You attempted to approve the PR without listing explicit verified changed identifiers. Add a 'Changed identifiers verified:' section with concrete identifiers from the actual diff before approving."
         elif reason == "approval_without_test_awareness":
             critique += "You attempted to approve the PR without acknowledging the relevant changed tests. Re-check the diff and mention the test coverage you relied on."
         elif reason == "approval_below_quality_bar":

--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -148,6 +148,9 @@ _SPECULATIVE_FINDING_PATTERNS = [
     r"\blikely\s+(?:drop|drops|filter|filters|skip|skips|alter|alters|misalign|misaligns)\b",
     r"\bmay\s+(?:silently\s+)?(?:drop|skip|alter|misalign|filter)\b",
     r"\bcould cause\b",
+    r"\bmay\s+cause\b",
+    r"\bcould\s+lead\s+to\b",
+    r"\btooling issues?\b",
 ]
 
 
@@ -2980,6 +2983,9 @@ class GitHubToMEPBridgeService:
         expected_tests = snapshot.get("expected_tests") or []
         mentions_tests = bool(snapshot.get("mentions_tests"))
         lowered = str(snapshot.get("lowered") or "")
+        reviewability_bucket = str(
+            ((snapshot.get("reviewability") or {}).get("bucket") or "standard")
+        ).strip().lower()
 
         if anchored_paths:
             path_anchor_units = min(len(anchored_paths), 2) / 2
@@ -2999,8 +3005,18 @@ class GitHubToMEPBridgeService:
         elif changed_verified_identifiers:
             reasons.append("verified_changed_identifiers")
         if has_findings:
-            raw_score += _QUALITY_SCORE_WEIGHTS["review_substance"]
-            reasons.append("concrete_findings")
+            finding_substance_weight = _QUALITY_SCORE_WEIGHTS["review_substance"]
+            speculative_low_signal_finding = (
+                reviewability_bucket == "low_signal"
+                and changed_evidence_count < 2
+                and self._is_speculative_finding("\n".join(filter(None, [summary_text, observation_text, lowered])))
+            )
+            if speculative_low_signal_finding:
+                finding_substance_weight /= 2
+                reasons.append("speculative_low_signal_finding")
+            else:
+                reasons.append("concrete_findings")
+            raw_score += finding_substance_weight
         elif (summary_text or observation_text) and (changed_tokens or grounded_tokens or changed_verified_identifiers):
             raw_score += _QUALITY_SCORE_WEIGHTS["review_substance"] / 2
             reasons.append("grounded_summary_or_observation")

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -1391,6 +1391,43 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(score, 10)
         self.assertIn("explicit_low_risk_claim", reasons)
 
+    def test_score_review_quality_downweights_speculative_low_signal_finding(self):
+        score, reasons = self.service._score_review_quality(  # noqa: SLF001
+            {
+                "anchored_paths": {
+                    "docs/node-reputation/DESIGN.md",
+                    "docs/node-reputation/node-reputation-v1.schema.json",
+                },
+                "changed_tokens": set(),
+                "grounded_tokens": {"id"},
+                "has_findings": True,
+                "summary_text": (
+                    "PR adds draft specification documents for node reputation and identifies a potential schema id consistency issue."
+                ),
+                "observation_text": (
+                    "The schema id points to an external repository, which may cause resolution failures in local validation."
+                ),
+                "risk_areas_checked": ["schema id consistency", "test coverage for new JSON schema"],
+                "checks_performed": [
+                    "verified the id field against the added schema file",
+                    "checked the PR for new validation tests",
+                ],
+                "changed_verified_identifiers": ["id"],
+                "expected_tests": [],
+                "mentions_tests": True,
+                "lowered": (
+                    "the schema id points to an external repository, which may cause resolution failures "
+                    "and could lead to tooling issues in local validation. tests reviewed."
+                ),
+                "reviewability": {"bucket": "low_signal"},
+            },
+            action="reviewed",
+        )
+
+        self.assertEqual(score, 7)
+        self.assertIn("speculative_low_signal_finding", reasons)
+        self.assertNotIn("concrete_findings", reasons)
+
     def test_score_review_quality_empty_snapshot_returns_zero(self):
         score, reasons = self.service._score_review_quality({}, action="reviewed")  # noqa: SLF001
 
@@ -3834,6 +3871,76 @@ class TestGitHubToMEPBridge(unittest.TestCase):
                     "Reviewed PR #123 onboarding dependency validation.\n\n"
                     "1. **The dependency validation only checks `REQUIRED_PACKAGES`, but the rest of the validation flow may be incomplete.** (`node/mep_runtime.py`): "
                     "If intended for broader startup validation, this suggests incomplete implementation and potentially leaving other dependencies unvalidated."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 0)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "speculative_finding")
+
+    def test_status_callback_suppresses_speculative_docs_schema_finding(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "docs/node-reputation/DESIGN.md",
+                    "status": "added",
+                    "additions": 120,
+                    "deletions": 0,
+                    "changes": 120,
+                    "patch": (
+                        "@@ -0,0 +1,6 @@\n"
+                        "+# MEP Node Reputation v1\n"
+                        "+\n"
+                        "+MEP_START_BONUS_ENABLED=false\n"
+                        "+MEP_VERIFICATION_THRESHOLD_DEFAULT=10\n"
+                        "+MEP_VERIFY_DETERMINISTIC=true\n"
+                    ),
+                },
+                {
+                    "filename": "docs/node-reputation/node-reputation-v1.schema.json",
+                    "status": "added",
+                    "additions": 20,
+                    "deletions": 0,
+                    "changes": 20,
+                    "patch": (
+                        "@@ -0,0 +1,8 @@\n"
+                        "+{\n"
+                        '+  "$schema": "https://json-schema.org/draft/2020-12/schema",\n'
+                        '+  "$id": "https://github.com/WUAIBING/MEP-spec/schemas/node-reputation-v1.schema.json",\n'
+                        '+  "title": "MEP Node Reputation v1"\n'
+                        "+}\n"
+                    ),
+                },
+            ],
+            pr_body="Adds draft node reputation design and schema artifacts.",
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel review this PR", delivery_number=125),
+            delivery_id="delivery-speculative-docs-schema-finding",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-speculative-docs-schema-finding",
+                "detail": (
+                    "## Review Findings\n\n"
+                    "PR adds draft specification documents for MEP node reputation system; identified a potential schema id consistency issue for review.\n\n"
+                    "Observation: The DESIGN.md includes explicit open decision markers to facilitate inline discussion, aligning with the draft PR intent.\n\n"
+                    "Touched paths reviewed: `docs/node-reputation/DESIGN.md`, `docs/node-reputation/node-reputation-v1.schema.json`\n\n"
+                    "Risk areas checked: schema id consistency with repository structure, test coverage for new JSON schema, design doc identifier definitions\n\n"
+                    "Checks performed: verified the id field in node-reputation-v1.schema.json for alignment with the MEP repo, checked PR changes for new validation test files, scanned DESIGN.md for identifier clarity\n\n"
+                    "Changed identifiers verified: `id`\n\n"
+                    "1. **Schema id points to external repository (WUAIBING/MEP-spec), which may cause resolution failures if used for validation within MEP repo.** (`docs/node-reputation/node-reputation-v1.schema.json`): "
+                    "The id is set to an external repository path and could lead to tooling issues or misalignment when this schema is referenced for validation in the MEP context."
                 ),
             },
             headers={"Authorization": f"Bearer {token}"},

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -165,54 +165,6 @@ def _issue_comment_payload(
     }
 
 
-def _check_run_payload(
-    *,
-    pr_number: int,
-    action: str = "completed",
-    status: str = "completed",
-    conclusion: Optional[str] = "success",
-) -> dict:
-    return {
-        "action": action,
-        "repository": {"full_name": "WUAIBING/MEP"},
-        "check_run": {
-            "status": status,
-            "conclusion": conclusion,
-            "pull_requests": [
-                {
-                    "number": pr_number,
-                    "html_url": f"https://github.com/WUAIBING/MEP/pull/{pr_number}",
-                }
-            ],
-        },
-        "sender": {"login": "github-actions[bot]", "type": "Bot"},
-    }
-
-
-def _check_suite_payload(
-    *,
-    pr_number: int,
-    action: str = "completed",
-    status: str = "completed",
-    conclusion: Optional[str] = "success",
-) -> dict:
-    return {
-        "action": action,
-        "repository": {"full_name": "WUAIBING/MEP"},
-        "check_suite": {
-            "status": status,
-            "conclusion": conclusion,
-            "pull_requests": [
-                {
-                    "number": pr_number,
-                    "html_url": f"https://github.com/WUAIBING/MEP/pull/{pr_number}",
-                }
-            ],
-        },
-        "sender": {"login": "github-actions[bot]", "type": "Bot"},
-    }
-
-
 class TestGitHubToMEPBridge(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = tempfile.mkdtemp(prefix="mep_bridge_")
@@ -770,7 +722,8 @@ class TestGitHubToMEPBridge(unittest.TestCase):
                     "## Review Summary\n\n"
                     "The PR adds pending-task recovery observability in `node/mep_runtime.py`.\n\n"
                     "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, which makes the recovery metrics more actionable.\n\n"
-                    "Touched paths reviewed: `node/mep_runtime.py`."
+                    "Touched paths reviewed: `node/mep_runtime.py`.\n\n"
+                    "Changed identifiers verified: `_record_pending_task_poll_failure`, `last_poll_status`."
                 ),
             },
             headers={"Authorization": f"Bearer {token}"},
@@ -969,285 +922,6 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(execution["task_id"], "task-approve-checks-fail")
         self.assertEqual(execution["retry_count"], 0)
 
-    def test_green_ci_webhook_retriggers_downgraded_approval_once(self):
-        changed_files = [
-            {
-                "filename": "node/mep_runtime.py",
-                "status": "modified",
-                "additions": 6,
-                "deletions": 1,
-                "changes": 7,
-                "patch": (
-                    "@@ -945,0 +945,6 @@\n"
-                    "+def _record_pending_task_poll_failure(self, status: int, detail: str) -> None:\n"
-                    "+    self.pending_task_recovery_metrics['last_poll_status'] = status\n"
-                ),
-            },
-            {
-                "filename": "tests/test_node_runtime.py",
-                "status": "modified",
-                "additions": 8,
-                "deletions": 0,
-                "changes": 8,
-                "patch": (
-                    "@@ -494,0 +494,8 @@\n"
-                    "+def test_fetch_pending_tasks_uses_authenticated_get(self):\n"
-                    "+    self.assertEqual(tasks, [{'id': 'task_pending'}])\n"
-                ),
-            },
-        ]
-        self._set_pr_review_package(
-            changed_files,
-            pr_body="Adds pending-task recovery observability and focused runtime tests.",
-            checks_payload={
-                "total_count": 1,
-                "check_runs": [
-                    {
-                        "name": "test (windows-latest, 3.10)",
-                        "status": "in_progress",
-                        "conclusion": None,
-                    }
-                ],
-            },
-            fetch_cycles=4,
-        )
-        initial_response = self._post_webhook(
-            _issue_comment_payload("@Hub-Sentinel approve this PR", delivery_number=320),
-            delivery_id="delivery-ci-followup-initial",
-        )
-        self.assertEqual(initial_response.status_code, 200)
-        bridge_id = initial_response.json()["bridge_id"]
-        self._flush_context(initial_response.json()["context_id"])
-
-        token = self.service._generate_status_token(bridge_id, "node_target")
-        status_response = self.client.post(
-            "/bridge/status",
-            json={
-                "bridge_id": bridge_id,
-                "status": "completed",
-                "target_node_id": "node_target",
-                "task_id": "task-ci-followup-initial",
-                "action": "approved",
-                "detail": (
-                    "## Review Summary\n\n"
-                    "The PR adds pending-task recovery observability in `node/mep_runtime.py` and keeps the verification path narrow.\n\n"
-                    "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, and the changed test keeps the recovery behavior covered. No risky changes.\n\n"
-                    "Touched paths reviewed: `node/mep_runtime.py`, `tests/test_node_runtime.py`\n\n"
-                    "Tests reviewed: `tests/test_node_runtime.py`."
-                ),
-            },
-            headers={"Authorization": f"Bearer {token}"},
-        )
-        self.assertEqual(status_response.status_code, 200, status_response.text)
-        self.assertEqual(len(self.submission.calls), 1)
-        self.assertEqual(len(self.github_session.posts), 1)
-        self.assertEqual(self.github_session.posts[0]["json"]["event"], "COMMENT")
-
-        self._set_pr_review_package(
-            changed_files,
-            pr_body="Adds pending-task recovery observability and focused runtime tests.",
-            checks_payload={
-                "total_count": 2,
-                "check_runs": [
-                    {
-                        "name": "test (ubuntu-latest, 3.10)",
-                        "status": "completed",
-                        "conclusion": "success",
-                    },
-                    {
-                        "name": "test (windows-latest, 3.10)",
-                        "status": "completed",
-                        "conclusion": "success",
-                    },
-                ],
-            },
-            fetch_cycles=4,
-        )
-        green_response = self._post_webhook(
-            _check_run_payload(pr_number=320),
-            delivery_id="delivery-ci-followup-green",
-            event_name="check_run",
-        )
-        self.assertEqual(green_response.status_code, 200, green_response.text)
-        self.assertEqual(green_response.json()["status"], "buffered")
-        self._flush_context(green_response.json()["context_id"])
-
-        self.assertEqual(len(self.submission.calls), 2)
-        followup_call = self.submission.calls[-1]
-        self.assertEqual(followup_call["intent_type"], "code.review.approve")
-        self.assertEqual(followup_call["target_node_id"], "node_target")
-        followup_inputs = followup_call["envelope"]["task"]["inputs"]["github"]
-        self.assertEqual(followup_inputs["followup_reason"], "ci_green_webhook")
-        self.assertEqual(followup_inputs["followup_of_bridge_id"], bridge_id)
-        self.assertEqual(followup_inputs["source_event"], "check_run")
-        self.assertEqual(followup_inputs["ci_checks"]["state"], "green")
-
-        duplicate_response = self._post_webhook(
-            _check_suite_payload(pr_number=320),
-            delivery_id="delivery-ci-followup-duplicate",
-            event_name="check_suite",
-        )
-        self.assertEqual(duplicate_response.status_code, 200, duplicate_response.text)
-        self.assertEqual(duplicate_response.json()["status"], "ignored")
-        self.assertEqual(duplicate_response.json()["reason"], "non_actionable")
-        self.assertEqual(len(self.submission.calls), 2)
-
-    def test_green_ci_webhook_ignores_latest_execution_without_ci_downgraded_approval_guard(self):
-        event = NormalizedGitHubEvent(
-            delivery_id="delivery-seeded",
-            source_event="issue_comment",
-            source_action="created",
-            repo_full_name="WUAIBING/MEP",
-            entity_type="pr",
-            number=322,
-            title="PR 322",
-            url="https://github.com/WUAIBING/MEP/pull/322",
-            actor_login="moltbot",
-            author_association="COLLABORATOR",
-            context_id="github-WUAIBING-MEP-pr-322",
-            imperative_verb="approve",
-            intent_type="code.review.approve",
-            instructions="seeded execution for guard coverage",
-            raw_trigger_text="@Hub-Sentinel approve this PR",
-            github_inputs={
-                "url": "https://github.com/WUAIBING/MEP/pull/322",
-                "review_mode": "discovery_review",
-            },
-        )
-        self.store.create_execution(
-            event,
-            "br-seeded-322",
-            "node_target",
-            target_alias="Hub Sentinel",
-            instructions=event.instructions,
-        )
-        self.store.update_execution(
-            "br-seeded-322",
-            status="completed",
-            action="reviewed",
-            review_result={
-                "attempted_action": "approved",
-                "resolved_action": "reviewed",
-                "published": True,
-                "suppressed": False,
-                "retry_queued": False,
-                "retry_count": 0,
-            },
-        )
-        self._set_pr_review_package(
-            [
-                {
-                    "filename": "bridge/github_to_mep.py",
-                    "status": "modified",
-                    "additions": 3,
-                    "deletions": 0,
-                    "changes": 3,
-                    "patch": "@@ -1,0 +1,3 @@\n+def green_ci_followup_guard():\n+    return True\n",
-                }
-            ],
-            pr_body="Seeded CI-green follow-up guard coverage.",
-            checks_payload={
-                "total_count": 2,
-                "check_runs": [
-                    {
-                        "name": "test (ubuntu-latest, 3.10)",
-                        "status": "completed",
-                        "conclusion": "success",
-                    },
-                    {
-                        "name": "test (windows-latest, 3.10)",
-                        "status": "completed",
-                        "conclusion": "success",
-                    },
-                ],
-            },
-            fetch_cycles=2,
-        )
-
-        response = self._post_webhook(
-            _check_run_payload(pr_number=322),
-            delivery_id="delivery-ci-followup-guard",
-            event_name="check_run",
-        )
-        self.assertEqual(response.status_code, 200, response.text)
-        self.assertEqual(response.json()["status"], "ignored")
-        self.assertEqual(response.json()["reason"], "non_actionable")
-        self.assertEqual(len(self.submission.calls), 0)
-
-    def test_green_ci_webhook_bootstraps_review_when_no_prior_execution_exists(self):
-        changed_files = [
-            {
-                "filename": "bridge/github_to_mep.py",
-                "status": "modified",
-                "additions": 8,
-                "deletions": 0,
-                "changes": 8,
-                "patch": (
-                    "@@ -1324,0 +1324,8 @@\n"
-                    "+def bootstrap_green_ci_review(self):\n"
-                    "+    return 'queued'\n"
-                ),
-            },
-            {
-                "filename": "tests/test_github_bridge.py",
-                "status": "modified",
-                "additions": 8,
-                "deletions": 0,
-                "changes": 8,
-                "patch": (
-                    "@@ -1095,0 +1095,8 @@\n"
-                    "+def test_green_ci_webhook_bootstraps_review_when_no_prior_execution_exists(self):\n"
-                    "+    assert response.json()['status'] == 'buffered'\n"
-                ),
-            },
-        ]
-        self._set_pr_review_package(
-            changed_files,
-            pr_body="Adds CI-green bootstrap coverage for the GitHub bridge review loop.",
-            checks_payload={
-                "total_count": 2,
-                "check_runs": [
-                    {
-                        "name": "test (ubuntu-latest, 3.10)",
-                        "status": "completed",
-                        "conclusion": "success",
-                    },
-                    {
-                        "name": "test (windows-latest, 3.10)",
-                        "status": "completed",
-                        "conclusion": "success",
-                    },
-                ],
-            },
-            fetch_cycles=2,
-        )
-
-        response = self._post_webhook(
-            _check_suite_payload(pr_number=323),
-            delivery_id="delivery-ci-bootstrap-review",
-            event_name="check_suite",
-        )
-        self.assertEqual(response.status_code, 200, response.text)
-        self.assertEqual(response.json()["status"], "buffered")
-        self._flush_context(response.json()["context_id"])
-
-        self.assertEqual(len(self.submission.calls), 1)
-        call = self.submission.calls[0]
-        self.assertEqual(call["target_node_id"], "node_target")
-        self.assertEqual(call["intent_type"], "code.review.request")
-
-        github_inputs = call["envelope"]["task"]["inputs"]["github"]
-        instructions = call["envelope"]["task"]["instructions"]
-        self.assertEqual(github_inputs["followup_reason"], "ci_green_bootstrap")
-        self.assertEqual(github_inputs["followup_target_alias"], "Hub Sentinel")
-        self.assertEqual(github_inputs["followup_target_node_id"], "node_target")
-        self.assertEqual(github_inputs["trigger_verb"], "review")
-        self.assertEqual(github_inputs["review_mode"], "discovery_review")
-        self.assertEqual(github_inputs["source_event"], "check_suite")
-        self.assertEqual(github_inputs["ci_checks"]["state"], "green")
-        self.assertIn("Automatic bootstrap: GitHub CI is green", instructions)
-        self.assertEqual(len(self.github_session.posts), 0)
-
     def test_status_callback_allows_approve_with_grounded_code_and_test_awareness(self):
         self._set_pr_review_package(
             [
@@ -1315,6 +989,9 @@ class TestGitHubToMEPBridge(unittest.TestCase):
                     "The PR adds pending-task recovery observability in `node/mep_runtime.py` and keeps the verification path narrow.\n\n"
                     "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, and the changed test keeps the recovery behavior covered. No risky changes.\n\n"
                     "Touched paths reviewed: `node/mep_runtime.py`, `tests/test_node_runtime.py`\n\n"
+                    "Changed identifiers verified: `_record_pending_task_poll_failure`, `last_poll_status`\n\n"
+                    "Risk areas checked: recovery observability\n\n"
+                    "Checks performed: reviewed changed diff, verified test coverage\n\n"
                     "Tests reviewed: `tests/test_node_runtime.py`."
                 ),
             },
@@ -1324,7 +1001,7 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(len(self.github_session.posts), 1)
         self.assertEqual(self.github_session.posts[0]["json"]["event"], "APPROVE")
         self.assertEqual(self.service.github_writeback_metrics["suppressed_approvals"], 0)
-        self.assertGreaterEqual(self.service.github_writeback_metrics["last_quality_score"], 4)
+        self.assertGreaterEqual(self.service.github_writeback_metrics["last_quality_score"], 7)
 
     def test_score_review_quality_accepts_professional_low_risk_approval_phrasing(self):
         score, reasons = self.service._score_review_quality(  # noqa: SLF001
@@ -1434,6 +1111,56 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertEqual(score, 0)
         self.assertEqual(reasons, [])
 
+    def test_approval_without_verified_identifiers_is_suppressed(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "bridge/github_to_mep.py",
+                    "additions": 1,
+                    "deletions": 0,
+                    "patch": "+    'may_cause': r'\\bmay\\s+cause\\b',\n",
+                },
+                {
+                    "filename": "tests/test_github_bridge.py",
+                    "additions": 1,
+                    "deletions": 0,
+                    "patch": "+    def test_score_review_quality_downweights_speculative_low_signal_finding(self):\n",
+                },
+            ],
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel approve this PR", delivery_number=247),
+            delivery_id="delivery-approve-without-verified",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-approve-without-verified",
+                "action": "approved",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "Verified `may_cause` and `test_score_review_quality_downweights_speculative_low_signal_finding` in the diff. "
+                    "The changes look scoped and low-risk. No concrete issue found.\n\n"
+                    "Touched paths reviewed: `bridge/github_to_mep.py`, `tests/test_github_bridge.py`\n\n"
+                    "Risk areas checked: suppression logic\n\n"
+                    "Checks performed: reviewed changed diff\n\n"
+                    "Tests reviewed: `tests/test_github_bridge.py`."
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(self.service.github_writeback_metrics["suppressed_approvals"], 1)
+        self.assertEqual(self.service.github_writeback_metrics["last_suppressed_reason"], "approval_without_verified_evidence")
+
     def test_review_trials_endpoint_returns_latest_trial_results(self):
         self._set_pr_review_package(
             [
@@ -1501,6 +1228,9 @@ class TestGitHubToMEPBridge(unittest.TestCase):
                     "The PR adds pending-task recovery observability in `node/mep_runtime.py` and keeps the verification path narrow.\n\n"
                     "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, and the changed test keeps the recovery behavior covered. No risky changes.\n\n"
                     "Touched paths reviewed: `node/mep_runtime.py`, `tests/test_node_runtime.py`\n\n"
+                    "Changed identifiers verified: `_record_pending_task_poll_failure`, `last_poll_status`\n\n"
+                    "Risk areas checked: recovery observability\n\n"
+                    "Checks performed: reviewed changed diff\n\n"
                     "Tests reviewed: `tests/test_node_runtime.py`."
                 ),
             },
@@ -1892,6 +1622,9 @@ class TestGitHubToMEPBridge(unittest.TestCase):
                     "The PR adds pending-task recovery observability in `node/mep_runtime.py` and keeps the verification path narrow.\n\n"
                     "Observation: `_record_pending_task_poll_failure` now records `last_poll_status`, and the changed test keeps the recovery behavior covered. No risky changes.\n\n"
                     "Touched paths reviewed: `node/mep_runtime.py`, `tests/test_node_runtime.py`\n\n"
+                    "Changed identifiers verified: `_record_pending_task_poll_failure`, `last_poll_status`\n\n"
+                    "Risk areas checked: recovery observability\n\n"
+                    "Checks performed: reviewed changed diff\n\n"
                     "Tests reviewed: `tests/test_node_runtime.py`."
                 ),
             },


### PR DESCRIPTION
Summary:
- suppress speculative docs/schema findings more aggressively on low-signal reviews
- downweight speculative low-signal findings in the quality scorer
- add regression coverage for the PR 206-style schema wording

Verification:
- focused pytest coverage passed locally for speculative finding suppression and score calibration