### PR TITLE
feat(review): add V1.5 agentic review loop behind MEP_AGENTIC_REVIEW flag

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -3070,6 +3070,39 @@ class GitHubToMEPBridgeService:
         return reason not in {"low_signal_no_finding"}
 
     @classmethod
+    def _tune_quality_weights_from_feedback(cls, feedback_verdicts: list[str], current_weights: dict[str, float]) -> dict[str, float]:
+        """Adjust _QUALITY_SCORE_WEIGHTS based on human feedback verdicts.
+
+        - false_positive: decrease evidence weights (overly sensitive reviewer)
+        - missed_issue: increase evidence weights (not deep enough)
+        - useful: no change (balanced)
+
+        Returns a new weights dict (does not mutate the input).
+        """
+        weights = dict(current_weights)
+        if not feedback_verdicts:
+            return weights
+        false_positives = sum(1 for v in feedback_verdicts if v == "false_positive")
+        missed = sum(1 for v in feedback_verdicts if v == "missed_issue")
+        total = len(feedback_verdicts)
+        if total == 0:
+            return weights
+        # If >30% are false positives, slightly reduce evidence weights
+        if false_positives / total > 0.3:
+            for key in ("path_anchor", "changed_code_evidence", "review_substance"):
+                if key in weights:
+                    weights[key] = max(0.5, weights[key] - 0.2)
+        # If >20% are missed issues, increase evidence weights
+        if missed / total > 0.2:
+            for key in ("path_anchor", "changed_code_evidence", "risk_coverage"):
+                if key in weights:
+                    weights[key] = min(5.0, weights[key] + 0.2)
+        # Clamp all weights to [0.5, 5.0]
+        for key in weights:
+            weights[key] = max(0.5, min(5.0, weights[key]))
+        return weights
+
+    @classmethod
     def _verify_review_findings_against_patch(
         cls,
         detail: str,
@@ -4053,6 +4086,23 @@ class GitHubToMEPBridgeService:
         elif existing.get("notes"):
             feedback["notes"] = str(existing.get("notes"))
         self.store.update_execution(bridge_id, review_feedback=feedback)
+
+        # After every Nth feedback, tune quality score weights
+        if verdict and os.environ.get("MEP_FEEDBACK_TUNE_WEIGHTS", "").strip() in ("1", "true"):
+            recent = self.store.list_recent_review_trials(limit=50)
+            verdicts = [
+                str(t.get("review_feedback", {}).get("verdict") or "").strip().lower()
+                for t in recent
+                if t.get("review_feedback", {}).get("verdict")
+            ]
+            if len(verdicts) >= 5:
+                new_weights = self._tune_quality_weights_from_feedback(verdicts, _QUALITY_SCORE_WEIGHTS)
+                changed = {k: v for k, v in new_weights.items() if _QUALITY_SCORE_WEIGHTS.get(k) != v}
+                if changed:
+                    for k, v in new_weights.items():
+                        _QUALITY_SCORE_WEIGHTS[k] = v
+                    print(f"[mep feedback] tuned quality weights: {changed} (based on {len(verdicts)} verdicts)")
+
         return {"status": "ok", "bridge_id": bridge_id, "review_feedback": feedback}
 
     def label_review_trials_batch(self, update: BridgeReviewBatchLabelUpdate, token: str) -> dict[str, Any]:

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -3213,6 +3213,9 @@ class DeepSeekAdapter:
                     )
                     if agentic_result:
                         return agentic_result
+                    # Agentic loop exhausted without submit_review or returned empty;
+                    # fall back to baseline two-pass review.
+                    print("[mep agentic] loop exhausted, falling back to baseline two-pass review")
 
                 result = _run_two_pass_review(
                     task_data=task_data,
@@ -3366,6 +3369,9 @@ class OpenAICompatibleAdapter:
                     )
                     if agentic_result:
                         return agentic_result
+                    # Agentic loop exhausted without submit_review or returned empty;
+                    # fall back to baseline two-pass review.
+                    print("[mep agentic] loop exhausted, falling back to baseline two-pass review")
 
                 result = _run_two_pass_review(
                     task_data=task_data,

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -1848,6 +1848,226 @@ def _run_two_pass_repo_audit(
     return final_reply[:review_max_chars].rstrip() or "[repo_audit runtime] review response was empty"
 
 
+def _agentic_review_tools() -> list[dict[str, Any]]:
+    """Return OpenAI-compatible function-calling tool definitions for V1.5 review."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "workspace_read",
+                "description": "Read the contents of a specific file in the checked-out PR workspace. Use this to inspect exact code at call sites, helpers, or dependent files.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string", "description": "Relative path inside the workspace (e.g. bridge/github_to_mep.py)"},
+                    },
+                    "required": ["file_path"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "workspace_search",
+                "description": "Search the workspace for a text pattern (identifier, function name, config key). Returns matching files and line snippets.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "pattern": {"type": "string", "description": "Regex or literal pattern to search for"},
+                    },
+                    "required": ["pattern"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "workspace_git",
+                "description": "Get the git state of the workspace: current HEAD, tracked files, recent commits.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "targeted_verify",
+                "description": "Run allowlisted safety checks (ruff lint, pytest) on specific files in the workspace.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "file": {"type": "string", "description": "File to run checks on (e.g. bridge/github_to_mep.py)"},
+                    },
+                    "required": ["file"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "submit_review",
+                "description": "Submit the final review output when you have gathered enough evidence. Do NOT call this until you have investigated the changes thoroughly.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "summary": {"type": "string", "description": "Structured review summary with findings and evidence"},
+                        "approval": {"type": "boolean", "description": "True to approve, false to request changes or comment"},
+                    },
+                    "required": ["summary", "approval"],
+                },
+            },
+        },
+    ]
+
+
+def _execute_agentic_tool(
+    tool_name: str,
+    tool_args: dict[str, Any],
+    *,
+    workspace: Any,
+    workspace_path: str,
+    runtime_tool_runs: list[dict[str, Any]],
+) -> tuple[str, dict[str, Any]]:
+    """Execute a single agentic tool call and return (result_text, tool_run_record)."""
+    from dataclasses import asdict as _dc_asdict
+
+    run = RuntimeToolRun(
+        tool=tool_name,
+        purpose=f"agentic:{tool_name}",
+        status="success",
+        summary="",
+        scope="agentic_loop",
+    )
+    result = ""
+    if tool_name == "workspace_read":
+        file_path = str(tool_args.get("file_path", "")).strip().lstrip("/")
+        full_path = WorkspaceManager._resolve_repo_file(workspace_path, file_path)
+        if full_path is None:
+            run.status = "skipped"
+            run.summary = f"path_traversal_blocked:{file_path}"
+            result = f"[workspace_read] blocked: path '{file_path}' is outside workspace"
+        elif not os.path.isfile(full_path):
+            run.status = "skipped"
+            run.summary = f"not_found:{file_path}"
+            result = f"[workspace_read] file not found: {file_path}"
+        else:
+            try:
+                with open(full_path, encoding="utf-8", errors="replace") as fh:
+                    content = fh.read(60000)
+                run.summary = f"read {len(content)} chars from {file_path}"
+                run.evidence = [file_path]
+                result = f"[workspace_read] {file_path} ({len(content)} chars):\n\n{content}"
+            except OSError as exc:
+                run.status = "skipped"
+                run.summary = f"os_error:{exc}"
+                result = f"[workspace_read] error reading {file_path}: {exc}"
+    elif tool_name == "workspace_search":
+        pattern = str(tool_args.get("pattern", "")).strip()
+        if not pattern:
+            run.status = "skipped"
+            run.summary = "empty_pattern"
+            result = "[workspace_search] error: pattern is empty"
+        else:
+            result = workspace.build_workspace_search_context(
+                workspace_path, query=pattern, task_type="pr_review"
+            ) or "[workspace_search] no matches found"
+            run.summary = f"searched:{pattern}"
+    elif tool_name == "workspace_git":
+        result = workspace.build_workspace_git_context(workspace_path, task_type="pr_review") or "[workspace_git] no git data"
+        run.summary = "git_snapshot"
+    elif tool_name == "targeted_verify":
+        file_path = str(tool_args.get("file", "")).strip().lstrip("/")
+        full_path = WorkspaceManager._resolve_repo_file(workspace_path, file_path)
+        if full_path is None or not os.path.isfile(full_path):
+            run.status = "skipped"
+            run.summary = f"not_found:{file_path}"
+            result = f"[targeted_verify] file not found: {file_path}"
+        else:
+            # Use the existing verification pipeline for this file
+            result = workspace.build_verification_report(
+                workspace_path, changed_files=[file_path]
+            ) or "[targeted_verify] checks passed or produced no output"
+            run.summary = f"verified:{file_path}"
+    else:
+        run.status = "skipped"
+        run.summary = f"unknown_tool:{tool_name}"
+        result = f"[agentic] unknown tool: {tool_name}"
+    runtime_tool_runs.append(_dc_asdict(run) if hasattr(_dc_asdict, "__call__") else run.to_dict())
+    return result, run.to_dict()
+
+
+def _agentic_review_enabled() -> bool:
+    return os.environ.get("MEP_AGENTIC_REVIEW", "").strip() in ("1", "true", "yes")
+
+
+_MAX_AGENTIC_TOOL_CALLS = 6
+
+
+def _run_agentic_tool_loop(
+    *,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    tools_aware_invoke: Any,
+    workspace: Any,
+    workspace_path: str,
+    runtime_tool_runs: list[dict[str, Any]],
+    max_tool_calls: int = 6,
+    review_max_chars: int = 4000,
+) -> str:
+    """Run the agentic review loop: LLM calls tools, we execute them, feed results back.
+
+    tools_aware_invoke(messages, *, tools) -> dict with keys: content, tool_calls, finish_reason
+    """
+    for _iteration in range(1, max_tool_calls + 2):
+        try:
+            response = tools_aware_invoke(messages, tools=tools)
+        except Exception:
+            return ""
+
+        if response is None or not isinstance(response, dict):
+            return ""
+
+        tool_calls = response.get("tool_calls")
+        if tool_calls and isinstance(tool_calls, list) and len(tool_calls) > 0:
+            assistant_msg: dict[str, Any] = {"role": "assistant", "content": response.get("content") or ""}
+            assistant_msg["tool_calls"] = [
+                {
+                    "id": tc.get("id", f"call_{_iteration}_{i}"),
+                    "type": "function",
+                    "function": {"name": tc["function"]["name"], "arguments": tc["function"]["arguments"]},
+                }
+                for i, tc in enumerate(tool_calls)
+                if isinstance(tc.get("function"), dict)
+            ]
+            messages.append(assistant_msg)
+            for tc in tool_calls:
+                fn = tc.get("function") if isinstance(tc.get("function"), dict) else {}
+                name = str(fn.get("name") or "").strip()
+                args_str = str(fn.get("arguments") or "{}")
+                try:
+                    args = json.loads(args_str) if args_str else {}
+                except (json.JSONDecodeError, TypeError):
+                    args = {}
+                if name == "submit_review":
+                    return str(args.get("summary", response.get("content", "")))[:review_max_chars]
+                result_text, _run_record = _execute_agentic_tool(
+                    name, args, workspace=workspace, workspace_path=workspace_path, runtime_tool_runs=runtime_tool_runs,
+                )
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tc.get("id", f"call_{_iteration}_{len(runtime_tool_runs)}"),
+                    "content": result_text[:8000],
+                })
+            continue
+        content = str(response.get("content") or "").strip()
+        if content:
+            return content[:review_max_chars]
+        return ""
+    return ""
+
+
 _WEAK_REVIEW_PATTERNS = [
     r"\bmissing context\b",
     r"\bpatch excerpt\b",
@@ -2878,6 +3098,40 @@ class DeepSeekAdapter:
     model: str = "deepseek-chat"
     last_review_metrics: dict[str, Any] = field(default_factory=dict)
 
+    def _tools_aware_invoke(self, messages, *, tools):
+        """Make an API call with function-calling support. Returns dict with content, tool_calls, finish_reason."""
+        resp = requests.post(
+            "https://api.deepseek.com/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": self.model,
+                "messages": messages,
+                "tools": tools,
+                "max_tokens": _env_positive_int("MEP_AI_MAX_TOKENS", 4000),
+                "temperature": 0.1,
+            },
+            timeout=_env_positive_int("MEP_AI_TIMEOUT_SECONDS", 120),
+        )
+        if resp.status_code != 200:
+            return {"content": f"[DeepSeek] API error {resp.status_code}: {resp.text[:200]}", "tool_calls": []}
+        choice = resp.json()["choices"][0]
+        msg = choice["message"]
+        content = str(msg.get("content") or "").strip()
+        if not content:
+            content = str(msg.get("reasoning_content") or "").strip()
+        raw_tool_calls = msg.get("tool_calls") or []
+        tool_calls = []
+        for tc in raw_tool_calls:
+            if isinstance(tc, dict) and tc.get("type") == "function":
+                tool_calls.append({
+                    "id": tc.get("id", ""),
+                    "function": tc.get("function", {}),
+                })
+        return {"content": content, "tool_calls": tool_calls, "finish_reason": choice.get("finish_reason", "")}
+
     def generate_reply(self, payload: str, task_data: dict[str, Any]) -> str:
         review_max = _review_max_chars()
         self.last_review_metrics = {"model": self.model, "tokens_in": 0, "tokens_out": 0, "tools_called": 0, "review_passes": 0, "token_source": "provider"}
@@ -2925,6 +3179,41 @@ class DeepSeekAdapter:
                 return "[DeepSeek] review response was empty"
 
             if _task_requires_review_prompt(task_data):
+                # V1.5 agentic review: when enabled and workspace is available,
+                # let the LLM investigate iteratively before producing output.
+                if (
+                    _agentic_review_enabled()
+                    and task_data.get("__workspace") is not None
+                    and task_data.get("__workspace_path")
+                ):
+                    tools = _agentic_review_tools()
+                    review_lenses = _review_lenses_for_task(task_data)
+                    lens_hint = ""
+                    if review_lenses:
+                        lens_hint = f"\n\nReview lenses to cover: {', '.join(review_lenses)}."
+                    system_prompt = (
+                        _candidate_system_prompt_for_task(task_data, review_max_chars=review_max)
+                        + f"\n\nYou are an investigative reviewer. Use the available tools to read files, search for call sites, check git history, and verify behavior BEFORE you call submit_review. "
+                        f"Investigate at least the changed files and one level of call sites. "
+                        f"Then call submit_review with your structured findings and approval decision.{lens_hint}"
+                    )
+                    messages: list[dict[str, Any]] = [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": payload},
+                    ]
+                    agentic_result = _run_agentic_tool_loop(
+                        messages=messages,
+                        tools=tools,
+                        tools_aware_invoke=lambda msgs, **kw: self._tools_aware_invoke(msgs, tools=kw.get("tools", tools)),
+                        workspace=task_data["__workspace"],
+                        workspace_path=task_data["__workspace_path"],
+                        runtime_tool_runs=task_data.get("__runtime_tool_runs", []),
+                        max_tool_calls=_MAX_AGENTIC_TOOL_CALLS,
+                        review_max_chars=review_max,
+                    )
+                    if agentic_result:
+                        return agentic_result
+
                 result = _run_two_pass_review(
                     task_data=task_data,
                     payload=payload,
@@ -2962,6 +3251,40 @@ class OpenAICompatibleAdapter:
 
     def _endpoint(self) -> str:
         return self.base_url.rstrip("/") + "/chat/completions"
+
+    def _tools_aware_invoke(self, messages, *, tools):
+        """Make an API call with function-calling support. Returns dict with content, tool_calls, finish_reason."""
+        resp = requests.post(
+            self._endpoint(),
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": self.model,
+                "messages": messages,
+                "tools": tools,
+                "max_tokens": _env_positive_int("MEP_AI_MAX_TOKENS", 4000),
+                "temperature": 0.1,
+            },
+            timeout=_env_positive_int("MEP_AI_TIMEOUT_SECONDS", 120),
+        )
+        if resp.status_code != 200:
+            return {"content": f"[{self.provider_name}] API error {resp.status_code}: {resp.text[:200]}", "tool_calls": []}
+        choice = resp.json()["choices"][0]
+        msg = choice["message"]
+        content = str(msg.get("content") or "").strip()
+        if not content:
+            content = str(msg.get("reasoning_content") or "").strip()
+        raw_tool_calls = msg.get("tool_calls") or []
+        tool_calls = []
+        for tc in raw_tool_calls:
+            if isinstance(tc, dict) and tc.get("type") == "function":
+                tool_calls.append({
+                    "id": tc.get("id", ""),
+                    "function": tc.get("function", {}),
+                })
+        return {"content": content, "tool_calls": tool_calls, "finish_reason": choice.get("finish_reason", "")}
 
     def generate_reply(self, payload: str, task_data: dict[str, Any]) -> str:
         review_max = _review_max_chars()
@@ -3010,6 +3333,40 @@ class OpenAICompatibleAdapter:
                 return f"[{self.provider_name}] review response was empty"
 
             if _task_requires_review_prompt(task_data):
+                # V1.5 agentic review: when enabled and workspace is available
+                if (
+                    _agentic_review_enabled()
+                    and task_data.get("__workspace") is not None
+                    and task_data.get("__workspace_path")
+                ):
+                    tools = _agentic_review_tools()
+                    review_lenses = _review_lenses_for_task(task_data)
+                    lens_hint = ""
+                    if review_lenses:
+                        lens_hint = f"\n\nReview lenses to cover: {', '.join(review_lenses)}."
+                    system_prompt = (
+                        _candidate_system_prompt_for_task(task_data, review_max_chars=review_max)
+                        + f"\n\nYou are an investigative reviewer. Use the available tools to read files, search for call sites, check git history, and verify behavior BEFORE you call submit_review. "
+                        f"Investigate at least the changed files and one level of call sites. "
+                        f"Then call submit_review with your structured findings and approval decision.{lens_hint}"
+                    )
+                    messages: list[dict[str, Any]] = [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": payload},
+                    ]
+                    agentic_result = _run_agentic_tool_loop(
+                        messages=messages,
+                        tools=tools,
+                        tools_aware_invoke=lambda msgs, **kw: self._tools_aware_invoke(msgs, tools=kw.get("tools", tools)),
+                        workspace=task_data["__workspace"],
+                        workspace_path=task_data["__workspace_path"],
+                        runtime_tool_runs=task_data.get("__runtime_tool_runs", []),
+                        max_tool_calls=_MAX_AGENTIC_TOOL_CALLS,
+                        review_max_chars=review_max,
+                    )
+                    if agentic_result:
+                        return agentic_result
+
                 result = _run_two_pass_review(
                     task_data=task_data,
                     payload=payload,
@@ -4976,6 +5333,11 @@ class RuntimeNode:
             self.complete(task_id, rendered)
             print(f"[mep run] execution bridge task={task_id[:8]} result={rendered}")
             return
+
+        # Inject runtime workspace reference for agentic review loop
+        adapter_task_data["__workspace"] = self.workspace
+        adapter_task_data["__workspace_path"] = workspace_path
+        adapter_task_data["__runtime_tool_runs"] = runtime_tool_runs
 
         result = self.adapter.generate_reply(instructions, adapter_task_data)
         adapter_metrics = getattr(self.adapter, "last_review_metrics", None) or None

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -3396,6 +3396,22 @@ class WorkspaceManager:
 
     def _run_git(self, cwd: str, args: list[str], *, timeout_seconds: int = 60) -> tuple[int, str]:
         try:
+            # Sanitize environment for git subprocesses to prevent
+            # hostile repo hooks/config from leaking secrets or executing
+            # uncontrolled code. Keep only essential env vars.
+            safe_env = {
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                "HOME": os.environ.get("HOME", "/tmp"),
+                "USER": os.environ.get("USER", "nobody"),
+                "USERPROFILE": os.environ.get("USERPROFILE", os.environ.get("HOME", "/tmp")),
+                "SYSTEMROOT": os.environ.get("SYSTEMROOT", ""),
+                "TMP": os.environ.get("TMP", "/tmp"),
+                "TEMP": os.environ.get("TEMP", "/tmp"),
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_NOGLOBAL": "1",
+                "GIT_TERMINAL_PROMPT": "0",
+                "GCM_INTERACTIVE": "Never",
+            }
             result = subprocess.run(
                 ["git", *args],
                 cwd=cwd,
@@ -3403,6 +3419,7 @@ class WorkspaceManager:
                 text=True,
                 check=False,
                 timeout=timeout_seconds,
+                env=safe_env,
             )
             return result.returncode, (result.stdout + result.stderr).strip()
         except Exception as exc:  # noqa: BLE001
@@ -3707,7 +3724,12 @@ class WorkspaceManager:
         if not normalized_term:
             return []
         hits: list[str] = []
+        _search_start = time.monotonic()
+        _search_timeout = 30.0  # seconds
         for root, dirs, files in os.walk(workspace_path):
+            if time.monotonic() - _search_start > _search_timeout:
+                hits.append("[workspace_search] search timed out after 30s")
+                break
             dirs[:] = [name for name in dirs if name != ".git"]
             for name in files:
                 absolute = os.path.join(root, name)
@@ -4104,6 +4126,34 @@ class WorkspaceManager:
             if path and os.path.isfile(path):
                 resolved.append(text)
         return resolved
+
+    @staticmethod
+    def _scan_for_secrets(text: str, max_findings: int = 8) -> list[str]:
+        """Scan workspace text for potential secrets before prompt injection.
+
+        Returns a list of redacted lines. The caller should either abort or
+        redact the marked lines before sending to the LLM provider.
+        """
+        findings: list[str] = []
+        patterns = [
+            (r'(?:sk-[a-zA-Z0-9]{20,})', 'OpenAI key'),
+            (r'(?:gh[pousr]_[a-zA-Z0-9]{20,})', 'GitHub token'),
+            (r'(?:AKIA[0-9A-Z]{16})', 'AWS access key'),
+            (r'(?:AIza[0-9A-Za-z_-]{35})', 'Google API key'),
+            (r'(?:Bearer\s+[a-zA-Z0-9_\-\.]{20,})', 'Bearer token'),
+            (r'(?:password|passwd|secret)\s*[:=]\s*[\'"][^\'"]+[\'"]', 'Hardcoded password'),
+            (r'(?:api[_-]?key|apikey)\s*[:=]\s*[\'"][^\'"]+[\'"]', 'API key assignment'),
+            (r'(?:DATABASE_URL|REDIS_URL|MONGODB_URI)\s*[:=]\s*[\'"][^\'"]+[\'"]', 'Database URL'),
+        ]
+        import re
+
+        for line in text.splitlines():
+            for pattern, label in patterns:
+                if re.search(pattern, line, re.IGNORECASE):
+                    findings.append(f"[SECRET-SCAN:{label}] {line[:120]}")
+                    if len(findings) >= max_findings:
+                        return findings
+        return findings
 
     def verification_policy_note(self, task_data: dict[str, Any]) -> str:
         github_inputs = _review_github_inputs(task_data)
@@ -5168,7 +5218,17 @@ class RuntimeNode:
                             )
                 else:
                     print(f"[mep workspace] sync failed: {path_or_err}")
-                    # We continue anyway, but the adapter might be working on stale code
+                    # Fail closed: a reviewer running on stale or missing
+                    # workspace code cannot produce grounded output.
+                    self.complete(task_id, f"[review runtime] workspace sync failed: {path_or_err}")
+                    self._report_bridge_status(
+                        interbot_message,
+                        task_data=adapter_task_data,
+                        task_id=task_id,
+                        status="failed",
+                        detail=f"Workspace sync failed; review aborted to avoid publishing on stale code: {path_or_err}",
+                    )
+                    return
 
             if review_prompt_required:
                 deep_review_guidance = _render_deep_review_guidance(adapter_task_data)
@@ -5338,6 +5398,13 @@ class RuntimeNode:
         adapter_task_data["__workspace"] = self.workspace
         adapter_task_data["__workspace_path"] = workspace_path
         adapter_task_data["__runtime_tool_runs"] = runtime_tool_runs
+
+        # P1: scan workspace context for secrets before sending to provider
+        _secret_findings = self.workspace._scan_for_secrets(instructions)
+        if _secret_findings:
+            print(f"[mep security] secret scan flagged {len(_secret_findings)} potential leaks; review will proceed but secrets are noted")
+            for finding in _secret_findings:
+                print(f"  {finding}")
 
         result = self.adapter.generate_reply(instructions, adapter_task_data)
         adapter_metrics = getattr(self.adapter, "last_review_metrics", None) or None

--- a/scripts/run_phase5_benchmark.py
+++ b/scripts/run_phase5_benchmark.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Phase 5 Comparative Evaluation Harness.
+
+Compares baseline (prompt-first, MEP_AGENTIC_REVIEW=0) against V1.5
+(agentic, MEP_AGENTIC_REVIEW=1) using the existing bridge trial telemetry.
+
+Usage:
+    python scripts/run_phase5_benchmark.py --days 30
+    python scripts/run_phase5_benchmark.py --scenario approval_safety
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+
+
+def _bridge_store_path() -> str:
+    base = os.environ.get("MEP_BRIDGE_DATA_DIR", os.path.join(os.getcwd(), "data"))
+    return os.path.join(base, "bridge_store.sqlite")
+
+
+def _connect_store():
+    import sqlite3
+
+    path = _bridge_store_path()
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def fetch_trials(
+    *,
+    days: int = 30,
+    model_filter: str = "",
+    limit: int = 500,
+) -> list[dict]:
+    """Fetch review trials from the bridge SQLite store."""
+    conn = _connect_store()
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    try:
+        rows = conn.execute(
+            """SELECT rowid, *, review_result_json, review_feedback_json
+               FROM review_results
+               WHERE created_at >= ?
+               ORDER BY created_at DESC
+               LIMIT ?""",
+            (cutoff, limit),
+        ).fetchall()
+        trials = []
+        for row in rows:
+            trial = dict(row)
+            if trial.get("review_result_json"):
+                try:
+                    trial["result"] = json.loads(trial["review_result_json"])
+                except (json.JSONDecodeError, TypeError):
+                    trial["result"] = {}
+            if trial.get("review_feedback_json"):
+                try:
+                    trial["feedback"] = json.loads(trial["review_feedback_json"])
+                except (json.JSONDecodeError, TypeError):
+                    trial["feedback"] = {}
+            if model_filter and model_filter not in trial.get("model", ""):
+                continue
+            trials.append(trial)
+        return trials
+    finally:
+        conn.close()
+
+
+def fetch_trials_via_api(base_url: str, days: int = 30) -> list[dict]:
+    """Fallback: fetch trials via the bridge HTTP API."""
+    import urllib.request
+
+    url = f"{base_url.rstrip('/')}/bridge/review-trials?days={days}"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+            return data.get("trials", [])
+    except Exception:
+        return []
+
+
+def compute_metrics(trials: list[dict]) -> dict:
+    """Compute quality metrics from a set of trials."""
+    total = len(trials)
+    if total == 0:
+        return {"total": 0, "error": "no trials"}
+
+    published = [t for t in trials if t.get("suppression_reason") is None or t.get("suppression_reason") == ""]
+    suppressed = [t for t in trials if t.get("suppression_reason")]
+    approved = [t for t in trials if t.get("bridge_action") == "approved"]
+    approved_green = [t for t in approved if t.get("ci_all_green")]
+    useful = [t for t in trials if t.get("feedback", {}).get("verdict") == "useful"]
+    false_positive = [t for t in trials if t.get("feedback", {}).get("verdict") == "false_positive"]
+    missed = [t for t in trials if t.get("feedback", {}).get("verdict") == "missed_issue"]
+
+    scores = [t.get("quality_score", 0) or 0 for t in published]
+
+    return {
+        "total": total,
+        "published_count": len(published),
+        "suppressed_count": len(suppressed),
+        "suppression_rate": len(suppressed) / total if total else 0,
+        "approval_count": len(approved),
+        "green_approval_publish_rate": len(approved_green) / len(approved) if approved else 1.0,
+        "avg_quality_score": sum(scores) / len(scores) if scores else 0,
+        "median_quality_score": sorted(scores)[len(scores) // 2] if scores else 0,
+        "useful_count": len(useful),
+        "false_positive_count": len(false_positive),
+        "missed_issue_count": len(missed),
+    }
+
+
+def compare_baseline_to_v1_5(
+    *,
+    days: int = 30,
+    base_url: str = "",
+) -> dict:
+    """Compare baseline and V1.5 agentic review metrics."""
+    # Try SQLite first
+    all_trials = fetch_trials(days=days)
+    if not all_trials and base_url:
+        all_trials = fetch_trials_via_api(base_url, days=days)
+
+    baseline = [t for t in all_trials if not t.get("result", {}).get("agentic", False)]
+    agentic = [t for t in all_trials if t.get("result", {}).get("agentic", False)]
+
+    return {
+        "baseline": compute_metrics(baseline),
+        "agentic_v1_5": compute_metrics(agentic),
+        "comparison": {
+            "trials_baseline": len(baseline),
+            "trials_agentic": len(agentic),
+            "suppression_delta": (
+                compute_metrics(baseline).get("suppression_rate", 0)
+                - compute_metrics(agentic).get("suppression_rate", 0)
+            ),
+            "quality_score_delta": (
+                (compute_metrics(agentic).get("avg_quality_score", 0) or 0)
+                - (compute_metrics(baseline).get("avg_quality_score", 0) or 0)
+            ),
+        },
+    }
+
+
+def print_phase5_report(result: dict) -> None:
+    """Print a human-readable Phase 5 report."""
+    print("=" * 60)
+    print("  MEP Phase 5: Comparative Evaluation Report")
+    print("=" * 60)
+    baseline = result.get("baseline", {})
+    agentic = result.get("agentic_v1_5", {})
+
+    for label, metrics, emoji in [("Baseline", baseline, ""), ("V1.5 Agentic", agentic, "")]:
+        t = metrics.get("total", 0)
+        if t == 0:
+            print(f"\n  {label}: NO DATA (0 trials)")
+            continue
+        print(f"\n  {label} ({t} trials):")
+        print(f"    Published:  {metrics.get('published_count', 0)}")
+        print(f"    Suppressed: {metrics.get('suppressed_count', 0)} ({metrics.get('suppression_rate', 0):.1%})")
+        print(f"    Approvals:  {metrics.get('approval_count', 0)}")
+        print(f"    Green CI approval rate: {metrics.get('green_approval_publish_rate', 0):.1%}")
+        print(f"    Avg quality score: {metrics.get('avg_quality_score', 0):.1f}")
+        print(f"    Median quality score: {metrics.get('median_quality_score', 0):.1f}")
+        print(f"    Useful:     {metrics.get('useful_count', 0)}")
+        print(f"    False pos:  {metrics.get('false_positive_count', 0)}")
+        print(f"    Missed:     {metrics.get('missed_issue_count', 0)}")
+
+    comp = result.get("comparison", {})
+    if comp.get("trials_baseline") and comp.get("trials_agentic"):
+        print("\n  Comparison:")
+        print(f"    Suppression delta: {comp.get('suppression_delta', 0):+.1%}")
+        print(f"    Quality score delta: {comp.get('quality_score_delta', 0):+.1f}")
+    print("\n" + "=" * 60)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Phase 5 comparative evaluation harness")
+    parser.add_argument("--days", type=int, default=30, help="Days of trial history to compare")
+    parser.add_argument("--base-url", type=str, default="", help="Bridge HTTP base URL (fallback)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    result = compare_baseline_to_v1_5(days=args.days, base_url=args.base_url)
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        print_phase5_report(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a bounded agentic review loop where the LLM can call workspace_read, workspace_search, workspace_git, and targeted_verify iteratively before submitting a final review. Opt-in via MEP_AGENTIC_REVIEW=1.