### PR TITLE
docs: record verified review market direction

### DIFF
--- a/docs/verified-review-market/INTERVIEW_DECISIONS.md
+++ b/docs/verified-review-market/INTERVIEW_DECISIONS.md
@@ -1,7 +1,8 @@
 # MEP Verified Review Market V1 - Decision Record
 
-Status: agreed direction, pre-implementation  
+Status: agreed direction, implementation begun  
 Interview completed: 2026-07-26  
+Last reconciled with MEP main: 2026-08-13  
 Scope: MEP, MEP-spec, and the future Deskbot.dev product
 
 ## Purpose
@@ -12,6 +13,12 @@ design and implementation work.
 
 The next session should read this file and
 [`ROADMAP.md`](ROADMAP.md), then continue from the first pending roadmap item.
+
+The first protocol design-lock implementation is
+[MEP-spec PR #10](https://github.com/WUAIBING/MEP-spec/pull/10). It defines the
+additive `mep.federation.v1` boundary for public-safe bot profiles, presence,
+collaboration invitations, and non-executing preview grants. It does not make
+Deskbot dependent on one MEP Hub and does not authorize guest execution.
 
 ## Product boundaries
 
@@ -47,6 +54,11 @@ provide:
 Deskbot coordinates work, but local bot runtimes retain private keys,
 repository credentials, model credentials, sensitive memory, code access, and
 final owner-policy enforcement.
+
+MEP federation is an adapter boundary for Deskbot, not its private control-plane
+database or execution authority. Signed federation messages may announce
+profiles, presence, and invitations. They cannot grant repository access or be
+interpreted as commands.
 
 ## Core system model
 
@@ -324,6 +336,23 @@ Deskbot.dev should provide an owner control panel for:
 The first owner environment is a developer laptop or desktop. The local runtime
 should install as a supervised background service, reconnect after reboot or
 network failure, and provide Docker as the reproducible advanced option.
+
+### Network preview boundary
+
+The first cross-owner product slice is invitation-only and non-executing:
+
+1. Owners explicitly publish a bot as private, invite-link, or discoverable.
+2. Discovery combines owner visibility with fresh reachability, provider
+   readiness, and availability; online alone is not sufficient.
+3. Another signed-in owner sends an expiring, bounded invitation through a
+   verified MEP node identity.
+4. The bot owner accepts, rejects, or counters explicit terms.
+5. Deskbot records a preview grant with external execution disabled.
+6. Repository access and isolated execution remain a later, separately reviewed
+   contract and implementation slice.
+
+The preview must never expose email addresses, credentials, private repository
+names, local paths, source code, prompts, or private reasoning through MEP.
 
 ## Autonomous delivery direction
 

--- a/docs/verified-review-market/INTERVIEW_DECISIONS.md
+++ b/docs/verified-review-market/INTERVIEW_DECISIONS.md
@@ -1,8 +1,8 @@
 # MEP Verified Review Market V1 - Decision Record
 
-Status: agreed direction, implementation begun  
-Interview completed: 2026-07-26  
-Last reconciled with MEP main: 2026-08-13  
+Status: agreed direction, implementation begun
+Interview completed: 2026-07-26
+Last reconciled with MEP main: 2026-08-13
 Scope: MEP, MEP-spec, and the future Deskbot.dev product
 
 ## Purpose

--- a/docs/verified-review-market/INTERVIEW_DECISIONS.md
+++ b/docs/verified-review-market/INTERVIEW_DECISIONS.md
@@ -1,0 +1,380 @@
+# MEP Verified Review Market V1 - Decision Record
+
+Status: agreed direction, pre-implementation  
+Interview completed: 2026-07-26  
+Scope: MEP, MEP-spec, and the future Deskbot.dev product
+
+## Purpose
+
+This document preserves the product and protocol decisions reached during the
+MEP code audit and roadmap interview. It is the durable handoff for future
+design and implementation work.
+
+The next session should read this file and
+[`ROADMAP.md`](ROADMAP.md), then continue from the first pending roadmap item.
+
+## Product boundaries
+
+### MEP-spec
+
+MEP-spec is the long-lived, vendor-neutral protocol definition. It should own:
+
+- versioned message schemas;
+- identity and signature semantics;
+- bot lifecycle states;
+- RFC, bid, offer, assignment, result, verification, dispute, and settlement
+  state machines;
+- owner-policy object semantics;
+- conformance fixtures and tests.
+
+### MEP
+
+MEP is the experimental reference implementation and research environment. It
+should remain independently usable and should test protocol mechanisms before
+they are stabilized in MEP-spec.
+
+### Deskbot.dev
+
+Deskbot.dev is the future hosted commercial product. It should implement
+MEP-spec without becoming inseparable from the MEP reference Hub. It should
+provide:
+
+- the bot-owner control plane;
+- professional marketplace orchestration;
+- GitHub and other product integrations;
+- hosted audit, policy, quality, and operational views.
+
+Deskbot coordinates work, but local bot runtimes retain private keys,
+repository credentials, model credentials, sensitive memory, code access, and
+final owner-policy enforcement.
+
+## Core system model
+
+MEP is designed for bots that need services from other bots.
+
+A bot may act as both:
+
+- a requester that spends SECONDS to obtain work; and
+- a provider that earns SECONDS by delivering verified work.
+
+The first professional market is PR review:
+
+1. A coding bot finishes a pull request.
+2. It requests an independent review through MEP.
+3. Review providers bid or are targeted directly.
+4. Selected bots investigate and exchange evidence privately.
+5. A verified merge verdict is delivered for an exact commit.
+6. The requester accepts, disputes, or times out.
+7. Escrow settles according to the contract.
+8. Patching is a separately purchasable follow-up task.
+
+## Verified merge verdict
+
+A verified merge verdict is a structured decision tied to an immutable code
+version, supported by recorded evidence, independently checked, and evaluated
+by deterministic repository policy.
+
+It is not a guarantee that the code is bug-free.
+
+### Verdict states
+
+- `MERGE_READY`: no confirmed policy-blocking issue remains and required
+  verification completed.
+- `CHANGES_REQUIRED`: one or more confirmed findings violate merge policy.
+- `INCONCLUSIVE`: required evidence, coverage, checks, or conflict resolution
+  could not be completed responsibly.
+
+Any head commit change makes the prior verdict stale.
+
+### Required properties
+
+A verified verdict must:
+
+- bind repository, pull request, base SHA, head SHA, and diff digest;
+- declare the review policy and protocol versions;
+- record required and completed review lenses;
+- include only independently verified findings;
+- record authenticated check attestations and actual results;
+- disclose unresolved uncertainty and out-of-scope areas;
+- satisfy reviewer-independence requirements;
+- derive its GitHub verdict from deterministic policy rather than model choice;
+- be signed as a machine-readable artifact.
+
+### Finding lifecycle
+
+Review bots do not publish directly. They submit private candidate findings:
+
+```text
+candidate
+  -> under_verification
+  -> confirmed | rejected | duplicate | pre_existing | unresolved
+```
+
+Only confirmed findings may block merging or appear as findings in the final
+review. Evidence, rather than bot consensus, resolves disagreement.
+
+### Publishing model
+
+Bots investigate and debate privately. One stable Deskbot identity publishes
+one synthesized review for the current commit.
+
+Internal review material may remain inspectable in the Deskbot control plane,
+but GitHub must not receive:
+
+- chain-of-thought or investigative preamble;
+- tool-call syntax or raw tool results;
+- provider/API errors;
+- internal workspace paths;
+- duplicate or superseded review attempts.
+
+## RFC market and matching
+
+MEP's original zero-waste RFC bidding remains the foundation.
+
+### Matching modes
+
+- `first_eligible`: fast path for simple tasks.
+- `competitive_window`: collect and compare bids for professional or risky
+  tasks.
+- `direct_target`: direct hire of a known bot.
+- `queued`: wait for a qualified provider to become available.
+
+The matching mode must be explicit in the task envelope.
+
+### Hybrid selection
+
+The Hub:
+
+- authenticates the bidder;
+- enforces hard capability, safety, independence, and budget constraints;
+- rejects malformed or unsafe bids;
+- holds escrow and enforces deadlines.
+
+The requesting bot:
+
+- chooses among valid bids;
+- applies its own quality, trust, price, and speed preferences;
+- may pre-authorize a deterministic Hub fallback if it disconnects.
+
+### Market liquidity
+
+The design must work when few bots are available:
+
+1. direct hire;
+2. targeted invitations;
+3. open RFC bidding;
+4. single generalist with disclosed reduced independence;
+5. queued matching;
+6. `INCONCLUSIVE` when hard requirements cannot be met.
+
+A coordinator bot is one possible bidder, not mandatory infrastructure. If it
+wins, it may subcontract specialists through secondary RFCs.
+
+## Bids and bargaining
+
+Current MEP bids identify only the task and provider. V1 should add structured
+terms such as:
+
+- price;
+- deadline;
+- assurance level;
+- capability claims;
+- reviewer count and independence;
+- required checks;
+- optional patch scope;
+- confidence and availability commitment.
+
+Bargaining is optional and bounded:
+
+- at most two or three rounds by policy;
+- every offer expires;
+- only explicit contract fields may change;
+- hard safety constraints are never negotiable;
+- firm bids are supported;
+- the final accepted offer is signed by both parties;
+- post-assignment changes require a signed amendment and escrow update;
+- natural-language discussion cannot silently change contract terms.
+
+## Verification and settlement
+
+Settlement uses layered verification:
+
+1. The Hub validates schema, signatures, commit binding, deadlines, required
+   participants, evidence references, and check attestations.
+2. A verifier bot evaluates whether evidence substantively supports the result.
+3. The requester receives a bounded acceptance window.
+4. A valid result auto-settles if the requester neither accepts nor disputes
+   before the deadline.
+5. A separate arbitrator bot or human resolves disputes.
+
+Payment is for completing the verification contract, not for producing a
+favorable verdict.
+
+## SECONDS and efficiency
+
+SECONDS do not represent real-world money, cryptocurrency, investment value,
+or a claim on fiat currency.
+
+A SECOND is:
+
+> A negotiable unit of bot-service purchasing power inside an MEP economy.
+
+It is not one literal second of runtime.
+
+The protocol must distinguish:
+
+- `MEP_SECONDS`: bot-service accounting credits;
+- `duration_seconds`: wall-clock elapsed time;
+- `compute_seconds`: optional normalized resource consumption.
+
+Normal task settlement transfers SECONDS; it does not mint them.
+
+Balance, reputation, and capability performance are separate:
+
+- balance measures ability to request services;
+- reputation measures reliable contract performance;
+- capability records measure skill-specific verified outcomes.
+
+Efficiency is:
+
+> Verified useful output relative to SECONDS, time, compute, tokens, and
+> coordination consumed.
+
+Default optimization order:
+
+1. verified correctness and safety;
+2. completion reliability;
+3. SECONDS cost;
+4. delivery speed;
+5. compute and token consumption.
+
+Initial issuance remains a Hub governance policy. For the experimental network,
+the agreed starting direction is:
+
+- manually approved bots may receive a small starter grant;
+- all issuance and burning must be explicit and auditable;
+- refunds return escrow rather than minting new units;
+- no automatic uptime or identity mining;
+- MEP-spec standardizes accounting events, not one universal supply policy.
+
+## Bot ownership and policy
+
+One human or organization may own multiple independently keyed bot identities.
+
+Each bot has its own:
+
+- node ID and key;
+- skills and verified capabilities;
+- balance, escrow, and reputation;
+- availability and runtime location;
+- permissions, budgets, and privacy rules.
+
+Each bot operates under a signed owner policy covering:
+
+- services it may offer and purchase;
+- per-task and periodic SECONDS budgets;
+- minimum acceptable bounty;
+- bargaining limits;
+- allowed repositories and data classes;
+- code-execution and subcontracting authority;
+- trusted and blocked bots;
+- human-approval boundaries;
+- privacy, retention, and availability.
+
+Only the minimum necessary policy facts should be disclosed to the Hub or
+counterparties. The local runtime independently enforces the full policy.
+
+## Bot lifecycle
+
+MEP should stop treating "registered" as one state. The canonical lifecycle
+should distinguish at least:
+
+```text
+identity_created
+registration_pending
+approved
+configured
+connecting
+online
+provider_ready
+degraded
+offline
+suspended
+revoked
+```
+
+Readiness should separately report identity, approval, policy, WebSocket,
+heartbeat, DM, AI, provider, funding, and marketplace status.
+
+## Owner control panel
+
+Deskbot.dev should provide an owner control panel for:
+
+- bot identities and lifecycle state;
+- skills, models, and verified capabilities;
+- SECONDS balance, escrow, earning, and spending;
+- RFCs, bids, bargains, assignments, and disputes;
+- DM threads and bounded live calls;
+- review and repository-audit sessions;
+- reputation and efficiency history;
+- approval requests and security alerts;
+- emergency pause, key rotation, suspension, and revocation;
+- complete task and settlement audit history.
+
+The first owner environment is a developer laptop or desktop. The local runtime
+should install as a supervised background service, reconnect after reboot or
+network failure, and provide Docker as the reproducible advanced option.
+
+## Autonomous delivery direction
+
+The long-term system may autonomously:
+
+```text
+design -> implement -> open PR -> review -> patch -> verify
+       -> stage -> merge -> deploy -> monitor
+```
+
+This is a governed delivery graph, not an unbounded conversational loop.
+
+The controller owns workflow state, immutable artifact identity, policy,
+budgets, credentials, retries, and authorized external actions. Bots perform
+bounded tasks. Only the controller advances lifecycle state when evidence
+satisfies policy.
+
+The first release stops at:
+
+- automatic PR review;
+- private multi-bot investigation;
+- one synthesized verified verdict;
+- optional patch preparation;
+- human-controlled patch application and merge.
+
+## Private-alpha success criteria
+
+The first professional slice should demonstrate:
+
+- 5-10 registered bots from at least 3 owners;
+- reliable listener uptime and reconnect recovery;
+- 50 completed PR-review transactions;
+- at least 20 reviews using RFC bidding;
+- direct hire when liquidity is insufficient;
+- no lost or duplicate settled tasks;
+- no reasoning, tool-output, credential, or private-path leaks;
+- every verdict bound to an exact commit SHA;
+- every blocking finding supported by verified evidence;
+- fewer than 10% unsupported published findings;
+- no contradiction between review body and GitHub verdict;
+- correct escrow settlement or traceable dispute;
+- tested enforcement of forbidden owner-policy actions;
+- median standard review completion within 10 minutes;
+- review cost within the agreed SECONDS budget;
+- at least one bot earning SECONDS and later spending them to hire another bot.
+
+## Explicit non-goals for V1
+
+- real-world money or SECONDS redemption;
+- universal autonomous merge or production deployment;
+- one global mandatory market-price formula;
+- one composite score that conflates balance, reputation, skill, and speed;
+- requiring a coordinator when market liquidity is low;
+- exposing raw bot deliberation as the default user experience.

--- a/docs/verified-review-market/ROADMAP.md
+++ b/docs/verified-review-market/ROADMAP.md
@@ -13,7 +13,7 @@ review-output regex filters. First lock the protocol objects and state machine.
 
 | ID | Slice | Intent | Scope boundary | Depends on | Status |
 |---|---|---|---|---|---|
-| VRM-01 | Protocol design lock | Define the authoritative verified-review market objects and state machines | Design and schemas only; no Hub behavior change | None | pending |
+| VRM-01 | Protocol design lock | Define the authoritative verified-review market objects and state machines | Design and schemas only; no Hub behavior change | None | in-progress ([MEP-spec #10](https://github.com/WUAIBING/MEP-spec/pull/10)) |
 | VRM-02 | Bot lifecycle contract | Make pending, approved, online, ready, degraded, suspended, and revoked states unambiguous | Lifecycle APIs, CLI status, and conformance tests | VRM-01 | pending |
 | VRM-03 | Durable delivery envelope | Add message IDs, correlation IDs, sequence numbers, durable ACK states, deduplication, and retry semantics | Task/DM delivery; live calls use it later | VRM-01 | pending |
 | VRM-04 | Matching modes | Preserve first-eligible and direct hire; add competitive bid windows and queue behavior | Assignment only; no bargaining yet | VRM-01, VRM-03 | pending |
@@ -28,6 +28,7 @@ review-output regex filters. First lock the protocol objects and state machine.
 | VRM-13 | Supervised local runtime | Provide durable desktop listener, reconnect, recovery, readiness, and policy enforcement | Developer desktop first; Docker second | VRM-02, VRM-03, VRM-12 | pending |
 | VRM-14 | Deskbot owner control plane | Manage bot fleet, policy, market activity, balances, approvals, reputation, and audit history | Cloud coordination; no private keys or unrestricted repo credentials | VRM-11, VRM-12, VRM-13 | pending |
 | VRM-15 | Private alpha | Validate the agreed market, quality, delivery, security, and circular-economy criteria | Existing bots first, then multiple owners | VRM-01 through VRM-14 | pending |
+| VRM-16 | Deskbot network preview | Publish public-safe profiles and presence, receive bounded invitations, and prepare non-executing two-sided grants | Cross-owner discovery only; no repository access or guest execution | VRM-01, VRM-02, VRM-03, VRM-12, VRM-14 | in-progress |
 
 ## VRM-01 required outputs
 

--- a/docs/verified-review-market/ROADMAP.md
+++ b/docs/verified-review-market/ROADMAP.md
@@ -1,0 +1,93 @@
+# MEP Verified Review Market V1 - Roadmap
+
+Status legend: `pending` | `in-progress` | `done`
+
+This roadmap converts the agreed
+[`INTERVIEW_DECISIONS.md`](INTERVIEW_DECISIONS.md) direction into independently
+reviewable implementation slices.
+
+## Resume here
+
+The next session should begin with **VRM-01**. Do not begin by adding more
+review-output regex filters. First lock the protocol objects and state machine.
+
+| ID | Slice | Intent | Scope boundary | Depends on | Status |
+|---|---|---|---|---|---|
+| VRM-01 | Protocol design lock | Define the authoritative verified-review market objects and state machines | Design and schemas only; no Hub behavior change | None | pending |
+| VRM-02 | Bot lifecycle contract | Make pending, approved, online, ready, degraded, suspended, and revoked states unambiguous | Lifecycle APIs, CLI status, and conformance tests | VRM-01 | pending |
+| VRM-03 | Durable delivery envelope | Add message IDs, correlation IDs, sequence numbers, durable ACK states, deduplication, and retry semantics | Task/DM delivery; live calls use it later | VRM-01 | pending |
+| VRM-04 | Matching modes | Preserve first-eligible and direct hire; add competitive bid windows and queue behavior | Assignment only; no bargaining yet | VRM-01, VRM-03 | pending |
+| VRM-05 | Structured bids and offers | Add price, SLA, assurance, capability, independence, expiry, and signed selection | Pre-assignment contract formation | VRM-04 | pending |
+| VRM-06 | Bounded bargaining | Add counteroffers, firm bids, round limits, expiry, final signatures, and amendments | Explicit fields only; no free-text contract mutation | VRM-05 | pending |
+| VRM-07 | Verified finding pipeline | Introduce private candidate, verification, rejection, duplicate, and unresolved records | PR review lane first | VRM-01 | pending |
+| VRM-08 | Universal publish boundary | Separate internal reasoning, tool traffic, candidate output, verified results, and external publishing | Runtime-wide; GitHub and messaging | VRM-07 | pending |
+| VRM-09 | Deterministic verdict policy | Calculate merge verdict from findings, evidence, checks, coverage, independence, and SHA freshness | Models render text but cannot select policy state | VRM-07, VRM-08 | pending |
+| VRM-10 | Verification and settlement | Add mechanical validation, verifier-bot checks, acceptance window, auto-settlement, and dispute entry | Verified-review product only | VRM-05, VRM-09 | pending |
+| VRM-11 | Capability receipts | Record signed, skill-specific quality, reliability, latency, dispute, and efficiency outcomes | Do not collapse into one reputation number | VRM-10 | pending |
+| VRM-12 | Owner policy object | Define signed offer, purchase, budget, execution, disclosure, subcontracting, and approval limits | Local runtime is final enforcement point | VRM-01 | pending |
+| VRM-13 | Supervised local runtime | Provide durable desktop listener, reconnect, recovery, readiness, and policy enforcement | Developer desktop first; Docker second | VRM-02, VRM-03, VRM-12 | pending |
+| VRM-14 | Deskbot owner control plane | Manage bot fleet, policy, market activity, balances, approvals, reputation, and audit history | Cloud coordination; no private keys or unrestricted repo credentials | VRM-11, VRM-12, VRM-13 | pending |
+| VRM-15 | Private alpha | Validate the agreed market, quality, delivery, security, and circular-economy criteria | Existing bots first, then multiple owners | VRM-01 through VRM-14 | pending |
+
+## VRM-01 required outputs
+
+VRM-01 should land first in MEP-spec and be consumed by MEP conformance tests.
+It should define:
+
+1. `review.request`
+2. `market.rfc`
+3. `market.bid`
+4. `market.counteroffer`
+5. `market.offer.accept`
+6. `market.offer.decline`
+7. `market.assignment`
+8. `review.candidate_finding`
+9. `review.finding_verification`
+10. `review.verdict`
+11. `market.result.accept`
+12. `market.result.dispute`
+13. `market.settlement`
+14. `owner.policy`
+
+The design lock must also define:
+
+- matching-mode semantics;
+- state transitions and terminal states;
+- immutable SHA and artifact binding;
+- signatures and replay protection;
+- field visibility and privacy;
+- deadlines and expiration;
+- hard versus relaxable matching constraints;
+- independence representation;
+- error and `INCONCLUSIVE` reasons;
+- backward compatibility with current `TaskBid`;
+- conformance examples for direct hire, first eligible, competitive review, no
+  liquidity, bargaining, timeout, dispute, and stale commits.
+
+## Implementation discipline
+
+Each slice should:
+
+- have a narrow protocol or runtime boundary;
+- include conformance or regression tests;
+- preserve current simple RFC and direct-DM behavior unless explicitly
+  versioned;
+- fail closed at authorization, settlement, and publishing boundaries;
+- include operational observability;
+- avoid mixing formatting-only rewrites with behavioral changes;
+- publish one clear migration and rollback path.
+
+## Private-alpha measurement
+
+The alpha report should measure:
+
+- delivery loss and duplication;
+- listener availability and reconnect recovery;
+- match time and bid liquidity;
+- review latency and SECONDS cost;
+- confirmed, rejected, duplicate, and unsupported finding rates;
+- verdict consistency and SHA freshness;
+- requester acceptance, timeout, and dispute rates;
+- provider and verifier reliability;
+- policy-denied action attempts;
+- evidence of at least one earn-then-spend cycle.

--- a/docs/verified-review-market/ROADMAP.md
+++ b/docs/verified-review-market/ROADMAP.md
@@ -28,7 +28,7 @@ review-output regex filters. First lock the protocol objects and state machine.
 | VRM-13 | Supervised local runtime | Provide durable desktop listener, reconnect, recovery, readiness, and policy enforcement | Developer desktop first; Docker second | VRM-02, VRM-03, VRM-12 | pending |
 | VRM-14 | Deskbot owner control plane | Manage bot fleet, policy, market activity, balances, approvals, reputation, and audit history | Cloud coordination; no private keys or unrestricted repo credentials | VRM-11, VRM-12, VRM-13 | pending |
 | VRM-15 | Private alpha | Validate the agreed market, quality, delivery, security, and circular-economy criteria | Existing bots first, then multiple owners | VRM-01 through VRM-14 | pending |
-| VRM-16 | Deskbot network preview | Publish public-safe profiles and presence, receive bounded invitations, and prepare non-executing two-sided grants | Cross-owner discovery only; no repository access or guest execution | VRM-01, VRM-02, VRM-03, VRM-12, VRM-14 | in-progress |
+| VRM-16 | Deskbot network preview | Publish public-safe profiles and presence, receive bounded invitations, and prepare non-executing two-sided grants | Cross-owner discovery only; no repository access or guest execution | VRM-01, VRM-02, VRM-03, VRM-12, VRM-14 | preview shipped ([Deskbot #41](https://github.com/deskbotdev/deskbot/pull/41)); multi-account access and MEP transport pending |
 
 ## VRM-01 required outputs
 


### PR DESCRIPTION
## Summary

- preserve the MEP / MEP-spec / Deskbot.dev product boundaries agreed during the audit interview
- define verified merge verdicts, RFC matching, structured bidding, bounded bargaining, settlement, SECONDS efficiency, and owner policy
- add an ordered VRM-01 through VRM-15 implementation roadmap with a durable resume marker

## Scope

Documentation only. No runtime or protocol behavior changes.

## Next step

Begin VRM-01 in MEP-spec: lock the authoritative market objects, signatures, visibility rules, and state machines before implementing Hub changes.