### PR TITLE
feat: add AI answering to live calls

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -5237,6 +5237,16 @@ class RuntimeNode:
             f"Conversation so far:\n{transcript}\nYou:"
         )
 
+    @staticmethod
+    def _sanitize_live_call_reply(reply: str) -> str:
+        """Remove provider-private reasoning before a reply is sent to a caller."""
+        return re.sub(
+            r"<think\b[^>]*>.*?</think\s*>",
+            "",
+            str(reply or ""),
+            flags=re.IGNORECASE | re.DOTALL,
+        ).strip()
+
     async def _answer_live_call_frame(self, *, context_id: str, sender: str, text: str) -> None:
         lock = self._live_call_locks.setdefault(context_id, asyncio.Lock())
         async with lock:
@@ -5275,7 +5285,7 @@ class RuntimeNode:
                     content_type="application/vnd.mep.call-status+json",
                 )
                 return
-            reply = str(reply or "").strip()
+            reply = self._sanitize_live_call_reply(reply)
             if not reply:
                 await self._send_live_call_frame(
                     context_id,

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -4665,6 +4665,11 @@ class RuntimeNode:
         self._ws: Any = None
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._pending_call_bridges: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._live_call_peers: dict[str, str] = {}
+        self._live_call_history: dict[str, list[dict[str, str]]] = {}
+        self._live_call_locks: dict[str, asyncio.Lock] = {}
+        self._live_call_outbound_seq: dict[str, int] = {}
+        self._task_adapter_lock = asyncio.Lock()
         
         # Phase 4: Autonomous Workspace Management
         workspace_dir = os.getenv("MEP_WORKSPACE_DIR")
@@ -5128,6 +5133,7 @@ class RuntimeNode:
             if self.live_call_enabled and self.call_auto_accept:
                 sent = await self._send_ws_event({"event": "call.accept", "context_id": context_id})
                 if sent:
+                    self._live_call_peers[context_id] = caller
                     print(f"[mep run] auto-accepted live call context={context_id} caller={caller}")
                 else:
                     print(f"[mep run] auto-accept failed context={context_id} caller={caller}")
@@ -5155,11 +5161,136 @@ class RuntimeNode:
             return
         if event == "call.frame":
             sender = data.get("sender") if isinstance(data.get("sender"), str) else "unknown"
+            content_type = str(data.get("content_type") or "text/plain").lower()
             snippet = str(data.get("payload") or "").strip().replace("\n", " ")[:160]
             print(f"[mep run] live frame context={context_id} sender={sender} payload={snippet}")
+            if (
+                self.live_call_enabled
+                and context_id
+                and sender != "unknown"
+                and content_type == "text/plain"
+                and snippet
+            ):
+                self._live_call_peers[context_id] = sender
+                self._schedule_background_task(
+                    self._answer_live_call_frame(
+                        context_id=context_id,
+                        sender=sender,
+                        text=str(data.get("payload") or "").strip(),
+                    ),
+                    label=f"live_call_answer:{context_id}",
+                )
             return
-        if event in {"call.hangup", "call.suspended", "call.resumed"}:
+        if event == "call.hangup":
+            if context_id:
+                self._forget_live_call(context_id)
             print(f"[mep run] {event} context={context_id} detail={data}")
+            return
+        if event in {"call.suspended", "call.resumed"}:
+            print(f"[mep run] {event} context={context_id} detail={data}")
+
+    def _next_live_call_sequence(self, context_id: str) -> int:
+        sequence = self._live_call_outbound_seq.get(context_id, 0) + 1
+        self._live_call_outbound_seq[context_id] = sequence
+        return sequence
+
+    async def _send_live_call_frame(
+        self,
+        context_id: str,
+        payload: str,
+        *,
+        content_type: str = "text/plain",
+    ) -> bool:
+        return await self._send_ws_event(
+            {
+                "event": "call.frame",
+                "context_id": context_id,
+                "seq": self._next_live_call_sequence(context_id),
+                "content_type": content_type,
+                "payload": payload,
+            }
+        )
+
+    def _forget_live_call(self, context_id: str) -> None:
+        self._live_call_peers.pop(context_id, None)
+        self._live_call_history.pop(context_id, None)
+        self._live_call_locks.pop(context_id, None)
+        self._live_call_outbound_seq.pop(context_id, None)
+
+    @staticmethod
+    def _render_live_call_prompt(history: list[dict[str, str]]) -> str:
+        transcript = "\n".join(
+            f"{'Caller' if turn.get('role') == 'user' else 'You'}: {turn.get('content', '')}"
+            for turn in history[-12:]
+        )
+        return (
+            "You are answering a live MEP bot-to-bot phone call. "
+            "Respond naturally, directly, and briefly. Preserve conversational continuity. "
+            "Do not narrate hidden reasoning or repeat the transcript. If the caller asks for "
+            "work that cannot be completed during this call, state the next concrete step.\n\n"
+            f"Conversation so far:\n{transcript}\nYou:"
+        )
+
+    async def _answer_live_call_frame(self, *, context_id: str, sender: str, text: str) -> None:
+        lock = self._live_call_locks.setdefault(context_id, asyncio.Lock())
+        async with lock:
+            if self._live_call_peers.get(context_id) != sender:
+                return
+            history = self._live_call_history.setdefault(context_id, [])
+            history.append({"role": "user", "content": text[:6000]})
+            del history[:-12]
+            started = await self._send_live_call_frame(
+                context_id,
+                json.dumps({"event": "reply.started"}),
+                content_type="application/vnd.mep.call-status+json",
+            )
+            if not started:
+                return
+            prompt = self._render_live_call_prompt(history)
+            task_data = {
+                "id": f"call:{context_id}",
+                "bounty": 0.0,
+                "consumer_id": sender,
+                "intent": {"type": "chat.request"},
+                "conversation": {"context_id": context_id},
+            }
+            try:
+                # Most adapters retain per-request metrics on the instance.
+                # Isolate live-call state from concurrent review/task inference.
+                call_adapter = copy.copy(self.adapter)
+                reply = await asyncio.to_thread(call_adapter.generate_reply, prompt, task_data)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                print(f"[mep run] live call AI failed context={context_id} detail={exc}")
+                await self._send_live_call_frame(
+                    context_id,
+                    json.dumps({"event": "reply.failed", "reason": "adapter_error"}),
+                    content_type="application/vnd.mep.call-status+json",
+                )
+                return
+            reply = str(reply or "").strip()
+            if not reply:
+                await self._send_live_call_frame(
+                    context_id,
+                    json.dumps({"event": "reply.failed", "reason": "empty_response"}),
+                    content_type="application/vnd.mep.call-status+json",
+                )
+                return
+            history.append({"role": "assistant", "content": reply[:6000]})
+            del history[:-12]
+            chunk_size = max(200, _env_positive_int("MEP_CALL_FRAME_CHARS", 800))
+            for offset in range(0, len(reply), chunk_size):
+                if self._live_call_peers.get(context_id) != sender:
+                    return
+                sent = await self._send_live_call_frame(context_id, reply[offset : offset + chunk_size])
+                if not sent:
+                    return
+            await self._send_live_call_frame(
+                context_id,
+                json.dumps({"event": "reply.completed"}),
+                content_type="application/vnd.mep.call-status+json",
+            )
 
     @staticmethod
     def _interbot_reply_mode(interbot_message: dict[str, Any]) -> Optional[str]:
@@ -5810,7 +5941,11 @@ class RuntimeNode:
             for finding in _secret_findings:
                 print(f"  {finding}")
 
-        result = self.adapter.generate_reply(instructions, adapter_task_data)
+        # Provider adapters are currently synchronous. Run inference away from the
+        # WebSocket event loop so pings, call frames, and new task delivery remain
+        # responsive during long model requests.
+        async with self._task_adapter_lock:
+            result = await asyncio.to_thread(self.adapter.generate_reply, instructions, adapter_task_data)
         adapter_metrics = getattr(self.adapter, "last_review_metrics", None) or None
         if adapter_metrics is not None and merged_runs:
             # tools_called reflects the runtime tool runs that produced evidence

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -5217,6 +5217,12 @@ class RuntimeNode:
         self._live_call_locks.pop(context_id, None)
         self._live_call_outbound_seq.pop(context_id, None)
 
+    def _forget_all_live_calls(self) -> None:
+        self._live_call_peers.clear()
+        self._live_call_history.clear()
+        self._live_call_locks.clear()
+        self._live_call_outbound_seq.clear()
+
     @staticmethod
     def _render_live_call_prompt(history: list[dict[str, str]]) -> str:
         transcript = "\n".join(
@@ -5279,6 +5285,9 @@ class RuntimeNode:
                 return
             history.append({"role": "assistant", "content": reply[:6000]})
             del history[:-12]
+            # Keep state after reply.completed because the call remains active
+            # and subsequent frames need conversational continuity. Teardown is
+            # driven by call.hangup or transport disconnect.
             chunk_size = max(200, _env_positive_int("MEP_CALL_FRAME_CHARS", 800))
             for offset in range(0, len(reply), chunk_size):
                 if self._live_call_peers.get(context_id) != sender:
@@ -6070,6 +6079,7 @@ class RuntimeNode:
             finally:
                 self._ws = None
                 self._cancel_pending_call_bridges("socket_closed")
+                self._forget_all_live_calls()
                 for task in list(self._background_tasks):
                     task.cancel()
                 if self._background_tasks:

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -2456,7 +2456,7 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
             release_adapter.wait(timeout=2)
             self.assertIn("Caller: Hello, can you hear me?", prompt)
             self.assertEqual(task_data["conversation"]["context_id"], "ctx-ai")
-            return "Yes, I can hear you."
+            return "<think>This must remain private.</think>\nYes, I can hear you."
 
         async def _run() -> None:
             with patch.object(node.adapter, "generate_reply", side_effect=_generate_reply):
@@ -2493,6 +2493,7 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         self.assertEqual(json.loads(frames[1]["payload"])["event"], "reply.started")
         self.assertEqual(frames[2], {"event": "call.pong", "context_id": "ctx-ai"})
         self.assertEqual(frames[3]["payload"], "Yes, I can hear you.")
+        self.assertNotIn("<think>", frames[3]["payload"])
         self.assertEqual(json.loads(frames[4]["payload"])["event"], "reply.completed")
         self.assertEqual([frames[index]["seq"] for index in (1, 3, 4)], [1, 2, 3])
 

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -52,6 +52,7 @@ class _FakeWebSocket:
         self.messages = list(messages)
         self.pings = 0
         self.sent = []
+        self.sent_event = asyncio.Event()
 
     async def recv(self):
         item = self.messages.pop(0)
@@ -64,6 +65,7 @@ class _FakeWebSocket:
 
     async def send(self, payload):
         self.sent.append(payload)
+        self.sent_event.set()
 
 
 class _FakeConnectContext:
@@ -2222,10 +2224,7 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
                 patch.object(node, "complete") as complete_mock,
             ):
                 task = asyncio.create_task(node.process_task(task_data))
-                for _ in range(100):
-                    if node._ws.sent:
-                        break
-                    await asyncio.sleep(0.01)
+                await asyncio.wait_for(node._ws.sent_event.wait(), timeout=1)
                 invite = json.loads(node._ws.sent[0])
                 self.assertEqual(invite["event"], "call.invite")
                 self.assertEqual(invite["context_id"], "ctx-bridge")
@@ -2283,10 +2282,7 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
                 patch.object(node, "complete") as complete_mock,
             ):
                 task = asyncio.create_task(node.process_task(task_data))
-                for _ in range(100):
-                    if node._ws.sent:
-                        break
-                    await asyncio.sleep(0.01)
+                await asyncio.wait_for(node._ws.sent_event.wait(), timeout=1)
                 await node.handle_ws_event({"event": "call.accepted", "context_id": "ctx-bridge-frame-fail"})
                 await task
 

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -2558,6 +2558,76 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         self.assertIn("You: First answer", prompts[1])
         self.assertIn("Caller: Follow-up question", prompts[1])
 
+    def test_runtime_serializes_concurrent_frames_for_same_call(self):
+        node = _runtime_node()
+        node.live_call_enabled = True
+        node.call_auto_accept = True
+        node._ws = _FakeWebSocket([])
+        first_started = threading.Event()
+        release_first = threading.Event()
+        prompts = []
+
+        def _generate_reply(prompt, _task_data):
+            prompts.append(prompt)
+            if len(prompts) == 1:
+                first_started.set()
+                release_first.wait(timeout=2)
+                return "First answer"
+            return "Second answer"
+
+        async def _run() -> None:
+            with patch.object(node.adapter, "generate_reply", side_effect=_generate_reply):
+                await node.handle_ws_event(
+                    {"event": "call.incoming", "context_id": "ctx-concurrent", "caller": "node_peer"}
+                )
+                for seq, text in ((1, "First question"), (2, "Second question")):
+                    await node.handle_ws_event(
+                        {
+                            "event": "call.frame",
+                            "context_id": "ctx-concurrent",
+                            "sender": "node_peer",
+                            "seq": seq,
+                            "content_type": "text/plain",
+                            "payload": text,
+                        }
+                    )
+                self.assertTrue(await asyncio.to_thread(first_started.wait, 2))
+                self.assertEqual(len(prompts), 1)
+                release_first.set()
+                await asyncio.gather(*list(node._background_tasks))
+
+        asyncio.run(_run())
+        self.assertEqual(len(prompts), 2)
+        self.assertIn("You: First answer", prompts[1])
+        self.assertIn("Caller: Second question", prompts[1])
+        frames = [
+            json.loads(payload)
+            for payload in node._ws.sent
+            if json.loads(payload).get("event") == "call.frame"
+        ]
+        self.assertEqual([frame["seq"] for frame in frames], [1, 2, 3, 4, 5, 6])
+
+    def test_runtime_forgets_all_live_call_state_on_hangup(self):
+        node = _runtime_node()
+        node.live_call_enabled = True
+        node.call_auto_accept = True
+        node._ws = _FakeWebSocket([])
+
+        async def _run() -> None:
+            await node.handle_ws_event(
+                {"event": "call.incoming", "context_id": "ctx-cleanup", "caller": "node_peer"}
+            )
+            node._live_call_history["ctx-cleanup"] = [{"role": "user", "content": "hello"}]
+            node._live_call_locks["ctx-cleanup"] = asyncio.Lock()
+            node._live_call_outbound_seq["ctx-cleanup"] = 3
+            await node.handle_ws_event({"event": "call.hangup", "context_id": "ctx-cleanup"})
+
+        asyncio.run(_run())
+        self.assertEqual(node._live_call_peers, {})
+        self.assertEqual(node._live_call_history, {})
+        self.assertEqual(node._live_call_locks, {})
+        self.assertEqual(node._live_call_outbound_seq, {})
+
 
 class TestRuntimeKeyDirResolution(unittest.TestCase):
     def test_find_git_root_detects_worktree_dot_git_file(self):

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import os
 import tempfile
+import threading
 import unittest
 from typing import Any, Optional
 from unittest.mock import AsyncMock, patch
@@ -2221,7 +2222,10 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
                 patch.object(node, "complete") as complete_mock,
             ):
                 task = asyncio.create_task(node.process_task(task_data))
-                await asyncio.sleep(0)
+                for _ in range(100):
+                    if node._ws.sent:
+                        break
+                    await asyncio.sleep(0.01)
                 invite = json.loads(node._ws.sent[0])
                 self.assertEqual(invite["event"], "call.invite")
                 self.assertEqual(invite["context_id"], "ctx-bridge")
@@ -2279,7 +2283,10 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
                 patch.object(node, "complete") as complete_mock,
             ):
                 task = asyncio.create_task(node.process_task(task_data))
-                await asyncio.sleep(0)
+                for _ in range(100):
+                    if node._ws.sent:
+                        break
+                    await asyncio.sleep(0.01)
                 await node.handle_ws_event({"event": "call.accepted", "context_id": "ctx-bridge-frame-fail"})
                 await task
 
@@ -2439,6 +2446,121 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         asyncio.run(node.handle_ws_event({"event": "call.incoming", "context_id": "ctx-auto", "caller": "node_peer"}))
 
         self.assertEqual([json.loads(payload)["event"] for payload in node._ws.sent], ["call.accept"])
+
+    def test_runtime_answers_incoming_live_text_frame_with_ai_off_event_loop(self):
+        node = _runtime_node()
+        node.live_call_enabled = True
+        node.call_auto_accept = True
+        node._ws = _FakeWebSocket([])
+        adapter_started = threading.Event()
+        release_adapter = threading.Event()
+
+        def _generate_reply(prompt, task_data):
+            adapter_started.set()
+            release_adapter.wait(timeout=2)
+            self.assertIn("Caller: Hello, can you hear me?", prompt)
+            self.assertEqual(task_data["conversation"]["context_id"], "ctx-ai")
+            return "Yes, I can hear you."
+
+        async def _run() -> None:
+            with patch.object(node.adapter, "generate_reply", side_effect=_generate_reply):
+                await node.handle_ws_event(
+                    {"event": "call.incoming", "context_id": "ctx-ai", "caller": "node_peer"}
+                )
+                await node.handle_ws_event(
+                    {
+                        "event": "call.frame",
+                        "context_id": "ctx-ai",
+                        "sender": "node_peer",
+                        "seq": 1,
+                        "content_type": "text/plain",
+                        "payload": "Hello, can you hear me?",
+                    }
+                )
+                for _ in range(100):
+                    if adapter_started.is_set():
+                        break
+                    await asyncio.sleep(0.01)
+                self.assertTrue(adapter_started.is_set())
+
+                # The model is still blocked in a worker thread, but call liveness
+                # must continue to be served by the asyncio/WebSocket loop.
+                await node.handle_ws_event({"event": "call.ping", "context_id": "ctx-ai"})
+                release_adapter.set()
+                await asyncio.gather(*list(node._background_tasks))
+
+        asyncio.run(_run())
+
+        frames = [json.loads(payload) for payload in node._ws.sent]
+        self.assertEqual(frames[0]["event"], "call.accept")
+        self.assertEqual(frames[1]["content_type"], "application/vnd.mep.call-status+json")
+        self.assertEqual(json.loads(frames[1]["payload"])["event"], "reply.started")
+        self.assertEqual(frames[2], {"event": "call.pong", "context_id": "ctx-ai"})
+        self.assertEqual(frames[3]["payload"], "Yes, I can hear you.")
+        self.assertEqual(json.loads(frames[4]["payload"])["event"], "reply.completed")
+        self.assertEqual([frames[index]["seq"] for index in (1, 3, 4)], [1, 2, 3])
+
+    def test_runtime_does_not_answer_call_status_frames(self):
+        node = _runtime_node()
+        node.live_call_enabled = True
+        node.call_auto_accept = True
+        node._ws = _FakeWebSocket([])
+
+        async def _run() -> None:
+            with patch.object(node.adapter, "generate_reply") as generate_mock:
+                await node.handle_ws_event(
+                    {"event": "call.incoming", "context_id": "ctx-status", "caller": "node_peer"}
+                )
+                await node.handle_ws_event(
+                    {
+                        "event": "call.frame",
+                        "context_id": "ctx-status",
+                        "sender": "node_peer",
+                        "seq": 1,
+                        "content_type": "application/vnd.mep.call-status+json",
+                        "payload": json.dumps({"event": "reply.started"}),
+                    }
+                )
+                await asyncio.sleep(0)
+                generate_mock.assert_not_called()
+
+        asyncio.run(_run())
+        self.assertEqual([json.loads(payload)["event"] for payload in node._ws.sent], ["call.accept"])
+
+    def test_runtime_live_call_history_carries_across_turns(self):
+        node = _runtime_node()
+        node.live_call_enabled = True
+        node.call_auto_accept = True
+        node._ws = _FakeWebSocket([])
+        prompts = []
+
+        def _generate_reply(prompt, _task_data):
+            prompts.append(prompt)
+            return "First answer" if len(prompts) == 1 else "Second answer"
+
+        async def _run() -> None:
+            with patch.object(node.adapter, "generate_reply", side_effect=_generate_reply):
+                await node.handle_ws_event(
+                    {"event": "call.incoming", "context_id": "ctx-history", "caller": "node_peer"}
+                )
+                for seq, text in ((1, "First question"), (2, "Follow-up question")):
+                    await node.handle_ws_event(
+                        {
+                            "event": "call.frame",
+                            "context_id": "ctx-history",
+                            "sender": "node_peer",
+                            "seq": seq,
+                            "content_type": "text/plain",
+                            "payload": text,
+                        }
+                    )
+                    await asyncio.gather(*list(node._background_tasks))
+
+        asyncio.run(_run())
+        self.assertEqual(len(prompts), 2)
+        self.assertIn("Caller: First question", prompts[1])
+        self.assertIn("You: First answer", prompts[1])
+        self.assertIn("Caller: Follow-up question", prompts[1])
 
 
 class TestRuntimeKeyDirResolution(unittest.TestCase):


### PR DESCRIPTION
## Summary

- route incoming live `call.frame` text into an AI-backed per-call conversation
- run synchronous provider inference off the WebSocket event loop
- emit `reply.started`, ordered text chunks, and `reply.completed`
- preserve bounded conversation history across turns
- isolate live-call adapter state from review metrics and serialize ordinary task adapter calls

## Why

Production Hub Sentinel / Elsaws DM testing showed 52-second replies followed by WebSocket keepalive timeouts. The relay existed, but runtime `call.frame` handling only logged content and never asked the AI to answer.

## Validation

- `python -m pytest -q` — 544 passed, 1 skipped
- `python -m ruff check node/mep_runtime.py tests/test_node_runtime.py`
- `git diff --check`

## Deployment plan

1. review with Hub Sentinel and Elsaws
2. merge only after confirmed findings are resolved
3. record the current DO commit/service configuration for rollback
4. pull the merged revision
5. enable `MEP_LIVE_CALL_ENABLED=1` and `MEP_CALL_AUTO_ACCEPT=1` for both bot runtimes
6. restart one bot at a time and run an authenticated live-call probe
