### PR TITLE
feat: stream persistent multi-bot action progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,40 @@ Use `session_safety={...}` with `MEPClient.submit_dm(...)` or `submit_checkpoint
 Use `MEPClient.evaluate_interbot_session_safety(...)` on the receiving side before sending the next reply turn if you want the runtime to stop or checkpoint automatically.
 Use `MEPClient.submit_safe_dm_reply(...)` when a runtime wants one call that either replies, emits a checkpoint turn, or stops because the declared session limits were exceeded.
 
+### Coordinate work with streamed action progress
+
+`mep.action.v1` adds a durable work timeline beside DM and `call.*`. A coordinator
+creates one context for all participating nodes, then gives each task a unique
+`action_id`:
+
+```python
+context = await client.create_action_context(
+    [hub_sentinel_id, elsaws_id, codex_id],
+    topic="Review one PR in parallel",
+)
+context_id = context["json"]["context_id"]
+
+task_inputs = {
+    "action_context": client.build_action_context_metadata(
+        context_id,
+        action_id="review-runtime",
+    )
+}
+```
+
+The standard runtime recognizes that metadata and publishes authenticated
+`action.started`, `action.progress`, and terminal `action.completed` or
+`action.failed` events. Every participant receives relevant events over its
+existing WebSocket and can recover missed events with
+`get_action_context(context_id, after_seq=...)`.
+
+The Hub assigns one persistent, monotonic sequence across the context, rejects
+duplicate event IDs, and prevents updates after an action becomes terminal.
+Visibility can be `private`, `owner`, `participants`, or `scoped`. Progress
+messages should contain meaningful checkpoints such as “workspace synchronized”
+or “AI inference started”; do not put raw stdout, secrets, or full model context
+in action events.
+
 </details>
 
 <a id="option-3-host-the-hub"></a>

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -390,6 +390,110 @@ class MEPClient:
         )
         return {"status_code": response.status_code, "json": response.json()}
 
+    async def create_action_context(
+        self,
+        participants: list[str],
+        *,
+        topic: Optional[str] = None,
+        context_id: Optional[str] = None,
+        max_events: int = 500,
+    ) -> dict:
+        body: dict[str, Any] = {
+            "owner_id": self.node_id,
+            "participants": participants,
+            "max_events": max_events,
+        }
+        if topic:
+            body["topic"] = topic
+        if context_id:
+            body["context_id"] = context_id
+        payload_str = json.dumps(body)
+        headers = self._auth_headers(payload_str)
+        response = await asyncio.to_thread(
+            self.session.post,
+            f"{self.hub_url}/actions/contexts",
+            data=payload_str,
+            headers=headers,
+            timeout=20,
+        )
+        return {"status_code": response.status_code, "json": response.json()}
+
+    @staticmethod
+    def build_action_context_metadata(
+        context_id: str,
+        action_id: str,
+        *,
+        parent_action_id: Optional[str] = None,
+    ) -> dict[str, str]:
+        metadata = {
+            "spec_version": "mep.action.v1",
+            "context_id": context_id,
+            "action_id": action_id,
+        }
+        if parent_action_id:
+            metadata["parent_action_id"] = parent_action_id
+        return metadata
+
+    async def post_action_event(
+        self,
+        context_id: str,
+        action_id: str,
+        event_type: str,
+        *,
+        event_id: Optional[str] = None,
+        parent_action_id: Optional[str] = None,
+        visibility: str = "participants",
+        audience: Optional[list[str]] = None,
+        phase: Optional[str] = None,
+        message: Optional[str] = None,
+        progress: Optional[int] = None,
+        artifacts: Optional[list[dict[str, Any]]] = None,
+    ) -> dict:
+        body: dict[str, Any] = {
+            "context_id": context_id,
+            "action_id": action_id,
+            "event_type": event_type,
+            "event_id": event_id or f"evt-{uuid.uuid4()}",
+            "visibility": visibility,
+        }
+        optional = {
+            "parent_action_id": parent_action_id,
+            "audience": audience,
+            "phase": phase,
+            "message": message,
+            "progress": progress,
+            "artifacts": artifacts,
+        }
+        body.update({key: value for key, value in optional.items() if value is not None})
+        payload_str = json.dumps(body)
+        headers = self._auth_headers(payload_str)
+        response = await asyncio.to_thread(
+            self.session.post,
+            f"{self.hub_url}/actions/events",
+            data=payload_str,
+            headers=headers,
+            timeout=20,
+        )
+        return {"status_code": response.status_code, "json": response.json()}
+
+    async def get_action_context(
+        self,
+        context_id: str,
+        *,
+        after_seq: int = 0,
+        limit: int = 100,
+    ) -> dict:
+        payload_str = ""
+        headers = self._auth_headers(payload_str)
+        response = await asyncio.to_thread(
+            self.session.get,
+            f"{self.hub_url}/actions/contexts/{context_id}",
+            params={"after_seq": after_seq, "limit": limit},
+            headers=headers,
+            timeout=20,
+        )
+        return {"status_code": response.status_code, "json": response.json()}
+
     def build_interbot_message(
         self,
         message: str,

--- a/hub/db.py
+++ b/hub/db.py
@@ -583,11 +583,329 @@ def init_db():
         CREATE INDEX IF NOT EXISTS idx_pending_dms_target_created
         ON pending_dms (target_node, created_at)
     ''')
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS action_contexts (
+            context_id TEXT PRIMARY KEY,
+            owner_id TEXT NOT NULL,
+            participants_json TEXT NOT NULL,
+            topic TEXT,
+            status TEXT NOT NULL,
+            max_events INTEGER NOT NULL,
+            next_seq INTEGER NOT NULL,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        )
+    ''')
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS action_events (
+            context_id TEXT NOT NULL,
+            seq INTEGER NOT NULL,
+            event_id TEXT NOT NULL,
+            producer_id TEXT NOT NULL,
+            action_id TEXT NOT NULL,
+            parent_action_id TEXT,
+            event_type TEXT NOT NULL,
+            visibility TEXT NOT NULL,
+            audience_json TEXT NOT NULL,
+            phase TEXT,
+            message TEXT,
+            progress INTEGER,
+            artifacts_json TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            PRIMARY KEY (context_id, seq),
+            UNIQUE (context_id, event_id)
+        )
+    ''')
+    cursor.execute('''
+        CREATE INDEX IF NOT EXISTS idx_action_events_context_action
+        ON action_events (context_id, action_id, seq)
+    ''')
     conn.commit()
     _release_conn(conn)
     global FINANCIAL_NS_BACKFILL_REPORT
     FINANCIAL_NS_BACKFILL_REPORT = backfill_financial_ns_columns()
     FINANCIAL_NS_BACKFILL_REPORT.extend(validate_financial_ns_storage())
+
+
+def _decode_action_context_row(row) -> Optional[dict]:
+    if row is None:
+        return None
+    participants = json.loads(row[2]) if row[2] else []
+    return {
+        "context_id": row[0],
+        "owner_id": row[1],
+        "participants": participants if isinstance(participants, list) else [],
+        "topic": row[3] or "",
+        "status": row[4],
+        "max_events": int(row[5]),
+        "next_seq": int(row[6]),
+        "created_at": float(row[7]),
+        "updated_at": float(row[8]),
+    }
+
+
+def create_action_context(
+    context_id: str,
+    owner_id: str,
+    participants: list[str],
+    topic: str,
+    max_events: int,
+    created_at: float,
+) -> bool:
+    conn = _get_conn()
+    cursor = conn.cursor()
+    values = (
+        context_id,
+        owner_id,
+        json.dumps(participants, separators=(",", ":")),
+        topic,
+        "active",
+        max_events,
+        1,
+        created_at,
+        created_at,
+    )
+    if _is_postgres():
+        cursor.execute(
+            """
+            INSERT INTO action_contexts (
+                context_id, owner_id, participants_json, topic, status,
+                max_events, next_seq, created_at, updated_at
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (context_id) DO NOTHING
+            """,
+            values,
+        )
+    else:
+        cursor.execute(
+            """
+            INSERT OR IGNORE INTO action_contexts (
+                context_id, owner_id, participants_json, topic, status,
+                max_events, next_seq, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            values,
+        )
+    created = int(cursor.rowcount or 0) == 1
+    conn.commit()
+    _release_conn(conn)
+    return created
+
+
+def get_action_context(context_id: str) -> Optional[dict]:
+    conn = _get_conn()
+    cursor = conn.cursor()
+    placeholder = _sql_placeholder()
+    cursor.execute(
+        f"""
+        SELECT context_id, owner_id, participants_json, topic, status,
+               max_events, next_seq, created_at, updated_at
+        FROM action_contexts
+        WHERE context_id = {placeholder}
+        """,
+        (context_id,),
+    )
+    result = _decode_action_context_row(cursor.fetchone())
+    _release_conn(conn)
+    return result
+
+
+def append_action_event(
+    *,
+    context_id: str,
+    event_id: str,
+    producer_id: str,
+    action_id: str,
+    parent_action_id: Optional[str],
+    event_type: str,
+    visibility: str,
+    audience: list[str],
+    phase: Optional[str],
+    message: Optional[str],
+    progress: Optional[int],
+    artifacts: list[dict],
+    created_at: float,
+) -> dict:
+    conn = _get_conn()
+    cursor = conn.cursor()
+    placeholder = _sql_placeholder()
+    if not _is_postgres():
+        cursor.execute("BEGIN IMMEDIATE")
+    lock_clause = " FOR UPDATE" if _is_postgres() else ""
+    cursor.execute(
+        f"""
+        SELECT context_id, owner_id, participants_json, topic, status,
+               max_events, next_seq, created_at, updated_at
+        FROM action_contexts
+        WHERE context_id = {placeholder}
+        {lock_clause}
+        """,
+        (context_id,),
+    )
+    context = _decode_action_context_row(cursor.fetchone())
+    if context is None:
+        conn.rollback()
+        _release_conn(conn)
+        return {"status": "missing_context"}
+
+    cursor.execute(
+        f"""
+        SELECT seq FROM action_events
+        WHERE context_id = {placeholder} AND event_id = {placeholder}
+        """,
+        (context_id, event_id),
+    )
+    duplicate = cursor.fetchone()
+    if duplicate:
+        conn.rollback()
+        _release_conn(conn)
+        return {"status": "duplicate", "seq": int(duplicate[0]), "context": context}
+
+    cursor.execute(
+        f"""
+        SELECT event_type FROM action_events
+        WHERE context_id = {placeholder} AND action_id = {placeholder}
+        ORDER BY seq DESC
+        LIMIT 1
+        """,
+        (context_id, action_id),
+    )
+    last_event = cursor.fetchone()
+    if last_event and last_event[0] in {"action.completed", "action.failed", "action.cancelled"}:
+        conn.rollback()
+        _release_conn(conn)
+        return {"status": "terminal", "terminal_event": last_event[0], "context": context}
+
+    seq = int(context["next_seq"])
+    if seq > int(context["max_events"]):
+        conn.rollback()
+        _release_conn(conn)
+        return {"status": "full", "context": context}
+
+    values = (
+        context_id,
+        seq,
+        event_id,
+        producer_id,
+        action_id,
+        parent_action_id,
+        event_type,
+        visibility,
+        json.dumps(audience, separators=(",", ":")),
+        phase,
+        message,
+        progress,
+        json.dumps(artifacts, separators=(",", ":")),
+        created_at,
+    )
+    if _is_postgres():
+        cursor.execute(
+            """
+            INSERT INTO action_events (
+                context_id, seq, event_id, producer_id, action_id,
+                parent_action_id, event_type, visibility, audience_json,
+                phase, message, progress, artifacts_json, created_at
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            values,
+        )
+        cursor.execute(
+            """
+            UPDATE action_contexts
+            SET next_seq = %s, updated_at = %s
+            WHERE context_id = %s
+            """,
+            (seq + 1, created_at, context_id),
+        )
+    else:
+        cursor.execute(
+            """
+            INSERT INTO action_events (
+                context_id, seq, event_id, producer_id, action_id,
+                parent_action_id, event_type, visibility, audience_json,
+                phase, message, progress, artifacts_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            values,
+        )
+        cursor.execute(
+            """
+            UPDATE action_contexts
+            SET next_seq = ?, updated_at = ?
+            WHERE context_id = ?
+            """,
+            (seq + 1, created_at, context_id),
+        )
+    conn.commit()
+    context["next_seq"] = seq + 1
+    context["updated_at"] = created_at
+    _release_conn(conn)
+    return {
+        "status": "created",
+        "seq": seq,
+        "context": context,
+        "event": {
+            "spec_version": "mep.action.v1",
+            "context_id": context_id,
+            "seq": seq,
+            "event_id": event_id,
+            "producer_id": producer_id,
+            "action_id": action_id,
+            "parent_action_id": parent_action_id,
+            "event_type": event_type,
+            "visibility": visibility,
+            "audience": audience,
+            "phase": phase,
+            "message": message,
+            "progress": progress,
+            "artifacts": artifacts,
+            "created_at": created_at,
+        },
+    }
+
+
+def list_action_events(context_id: str, *, after_seq: int = 0, limit: int = 100) -> list[dict]:
+    conn = _get_conn()
+    cursor = conn.cursor()
+    placeholder = _sql_placeholder()
+    cursor.execute(
+        f"""
+        SELECT context_id, seq, event_id, producer_id, action_id,
+               parent_action_id, event_type, visibility, audience_json,
+               phase, message, progress, artifacts_json, created_at
+        FROM action_events
+        WHERE context_id = {placeholder} AND seq > {placeholder}
+        ORDER BY seq ASC
+        LIMIT {placeholder}
+        """,
+        (context_id, after_seq, limit),
+    )
+    events: list[dict] = []
+    for row in cursor.fetchall():
+        audience = json.loads(row[8]) if row[8] else []
+        artifacts = json.loads(row[12]) if row[12] else []
+        events.append(
+            {
+                "spec_version": "mep.action.v1",
+                "context_id": row[0],
+                "seq": int(row[1]),
+                "event_id": row[2],
+                "producer_id": row[3],
+                "action_id": row[4],
+                "parent_action_id": row[5],
+                "event_type": row[6],
+                "visibility": row[7],
+                "audience": audience if isinstance(audience, list) else [],
+                "phase": row[9],
+                "message": row[10],
+                "progress": row[11],
+                "artifacts": artifacts if isinstance(artifacts, list) else [],
+                "created_at": float(row[13]),
+            }
+        )
+    _release_conn(conn)
+    return events
+
 
 def register_node(node_id: str, pub_pem: str) -> dict:
     conn = _get_conn()

--- a/hub/main.py
+++ b/hub/main.py
@@ -39,6 +39,8 @@ from models import (
     MeshAssembleRequest,
     BrainstormSessionCreate,
     BrainstormSessionPost,
+    ActionContextCreate,
+    ActionEventPost,
 )
 
 from v2_models import (
@@ -234,6 +236,18 @@ ANTI_LOOP_WINDOW_SECONDS = float(os.getenv("MEP_ANTI_LOOP_WINDOW_SECONDS", "90")
 ANTI_LOOP_MAX_MESSAGES = int(os.getenv("MEP_ANTI_LOOP_MAX_MESSAGES", "6"))
 ANTI_LOOP_COOLDOWN_SECONDS = int(os.getenv("MEP_ANTI_LOOP_COOLDOWN_SECONDS", "60"))
 ANTI_LOOP_TERMINATION_TOKENS = ("[end]", "[no_relay]", "[ack_only]")
+ACTION_SPEC_VERSION = "mep.action.v1"
+ACTION_EVENT_TYPES = {
+    "action.proposed",
+    "action.started",
+    "action.progress",
+    "action.needs_approval",
+    "action.completed",
+    "action.failed",
+    "action.cancelled",
+}
+ACTION_TERMINAL_EVENTS = {"action.completed", "action.failed", "action.cancelled"}
+ACTION_VISIBILITIES = {"private", "owner", "participants", "scoped"}
 PRIVACY_MODE_PLAINTEXT_ONLY = "plaintext_only"
 PRIVACY_MODE_PREFER_ENCRYPTED = "prefer_encrypted"
 PRIVACY_MODE_REQUIRE_ENCRYPTED = "require_encrypted"
@@ -1348,6 +1362,56 @@ def _normalize_brainstorm_participants(owner_id: str, participants: list[str]) -
     return cleaned
 
 
+def _action_event_recipients(
+    *,
+    owner_id: str,
+    participants: list[str],
+    producer_id: str,
+    visibility: str,
+    audience: Optional[list[str]],
+) -> list[str]:
+    if visibility not in ACTION_VISIBILITIES:
+        allowed = ", ".join(sorted(ACTION_VISIBILITIES))
+        raise HTTPException(status_code=400, detail=f"Invalid action visibility. Allowed values: {allowed}")
+    if visibility != "scoped" and audience:
+        raise HTTPException(status_code=400, detail="action audience is only valid with scoped visibility")
+    if visibility == "private":
+        candidates = [producer_id]
+    elif visibility == "owner":
+        candidates = [owner_id, producer_id]
+    elif visibility == "participants":
+        candidates = participants
+    else:
+        if not audience:
+            raise HTTPException(status_code=400, detail="scoped action visibility requires an audience")
+        invalid = [node_id for node_id in audience if node_id not in participants]
+        if invalid:
+            raise HTTPException(status_code=400, detail="action audience must contain participants only")
+        candidates = [*audience, producer_id]
+    recipients: list[str] = []
+    seen: set[str] = set()
+    for node_id in candidates:
+        if node_id in participants and node_id not in seen:
+            recipients.append(node_id)
+            seen.add(node_id)
+    return recipients
+
+
+def _normalize_action_artifacts(artifacts: Optional[list[dict[str, Any]]]) -> list[dict[str, str]]:
+    normalized: list[dict[str, str]] = []
+    for raw in artifacts or []:
+        if not isinstance(raw, dict):
+            continue
+        item: dict[str, str] = {}
+        for key, max_chars in (("type", 40), ("uri", 1000), ("label", 200), ("digest", 160)):
+            value = raw.get(key)
+            if isinstance(value, str) and value.strip():
+                item[key] = value.strip()[:max_chars]
+        if item:
+            normalized.append(item)
+    return normalized[:20]
+
+
 def _normalize_mesh_trigger(value: str) -> str:
     normalized = (value or "").strip().lower()
     if normalized not in MESH_ALLOWED_TRIGGERS:
@@ -2435,6 +2499,197 @@ async def brainstorm_list_sessions(authenticated_node: str = Depends(verify_requ
         ]
     sessions.sort(key=lambda item: float(item.get("updated_at") or now), reverse=True)
     return {"count": len(sessions), "sessions": sessions}
+
+@app.post("/actions/contexts")
+async def action_context_create(
+    payload: ActionContextCreate,
+    authenticated_node: str = Depends(verify_request),
+):
+    if authenticated_node != payload.owner_id:
+        raise HTTPException(status_code=403, detail="Cannot create an action context for another node")
+    participants = _normalize_brainstorm_participants(payload.owner_id, payload.participants)
+    if len(participants) < 2:
+        raise HTTPException(status_code=400, detail="Action context requires at least 2 participants")
+    context_id = (payload.context_id or f"action-{uuid.uuid4()}").strip()
+    topic = (payload.topic or "").strip()
+    max_events = int(payload.max_events or 500)
+    created_at = time.time()
+    created = await asyncio.to_thread(
+        db.create_action_context,
+        context_id,
+        payload.owner_id,
+        participants,
+        topic,
+        max_events,
+        created_at,
+    )
+    context = await asyncio.to_thread(db.get_action_context, context_id)
+    if not created:
+        if (
+            context is None
+            or context.get("owner_id") != payload.owner_id
+            or context.get("participants") != participants
+        ):
+            raise HTTPException(status_code=409, detail="Action context ID already exists with different membership")
+        status = "existing"
+    else:
+        status = "created"
+        log_event(
+            "action_context_created",
+            f"Action context {context_id[:12]} created by {payload.owner_id}",
+            context_id=context_id,
+            owner_id=payload.owner_id,
+            participant_count=len(participants),
+        )
+    return {
+        "status": status,
+        "spec_version": ACTION_SPEC_VERSION,
+        **(context or {}),
+    }
+
+
+@app.post("/actions/events")
+async def action_event_post(
+    payload: ActionEventPost,
+    authenticated_node: str = Depends(verify_request),
+):
+    if payload.event_type not in ACTION_EVENT_TYPES:
+        allowed = ", ".join(sorted(ACTION_EVENT_TYPES))
+        raise HTTPException(status_code=400, detail=f"Invalid action event type. Allowed values: {allowed}")
+    context = await asyncio.to_thread(db.get_action_context, payload.context_id)
+    if context is None or context.get("status") != "active":
+        raise HTTPException(status_code=404, detail="Action context not found or inactive")
+    participants = list(context.get("participants") or [])
+    if authenticated_node not in participants:
+        raise HTTPException(status_code=403, detail="Node is not a participant of this action context")
+    recipients = _action_event_recipients(
+        owner_id=str(context["owner_id"]),
+        participants=participants,
+        producer_id=authenticated_node,
+        visibility=payload.visibility,
+        audience=payload.audience,
+    )
+    if payload.event_type == "action.progress" and payload.message is None and payload.progress is None:
+        raise HTTPException(status_code=400, detail="action.progress requires a message or progress value")
+    result = await asyncio.to_thread(
+        db.append_action_event,
+        context_id=payload.context_id,
+        event_id=(payload.event_id or f"evt-{uuid.uuid4()}").strip(),
+        producer_id=authenticated_node,
+        action_id=payload.action_id.strip(),
+        parent_action_id=(payload.parent_action_id or "").strip() or None,
+        event_type=payload.event_type,
+        visibility=payload.visibility,
+        audience=recipients,
+        phase=(payload.phase or "").strip() or None,
+        message=(payload.message or "").strip() or None,
+        progress=payload.progress,
+        artifacts=_normalize_action_artifacts(payload.artifacts),
+        created_at=time.time(),
+    )
+
+    if result["status"] == "duplicate":
+        return {
+            "status": "duplicate",
+            "spec_version": ACTION_SPEC_VERSION,
+            "context_id": payload.context_id,
+            "seq": result["seq"],
+            "delivered_to": [],
+        }
+    if result["status"] == "terminal":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Action is already terminal: {result.get('terminal_event')}",
+        )
+    if result["status"] == "full":
+        raise HTTPException(status_code=409, detail="Action context reached max_events")
+    if result["status"] != "created":
+        raise HTTPException(status_code=404, detail="Action context not found")
+
+    event = result["event"]
+    fanout_payload = {"event": "action_event", "data": event}
+    async with node_lock:
+        recipient_sockets = [(node_id, connected_nodes.get(node_id)) for node_id in recipients]
+
+    async def deliver(node_id: str, ws: Optional[WebSocket]) -> Optional[str]:
+        if ws is None:
+            return None
+        try:
+            await ws.send_json(fanout_payload)
+            return node_id
+        except Exception as exc:
+            log_event(
+                "action_fanout_failed",
+                f"Failed action fanout for context {payload.context_id[:12]} to {node_id}: {exc}",
+                context_id=payload.context_id,
+                action_id=payload.action_id,
+                node_id=node_id,
+            )
+            async with node_lock:
+                if connected_nodes.get(node_id) is ws:
+                    del connected_nodes[node_id]
+            return None
+
+    delivery_results = await asyncio.gather(
+        *(deliver(node_id, ws) for node_id, ws in recipient_sockets)
+    )
+    delivered_to = [node_id for node_id in delivery_results if node_id is not None]
+    log_event(
+        "action_event",
+        f"{payload.event_type} action={payload.action_id[:24]} context={payload.context_id[:12]}",
+        context_id=payload.context_id,
+        action_id=payload.action_id,
+        producer_id=authenticated_node,
+        seq=result["seq"],
+        delivered_count=len(delivered_to),
+    )
+    return {
+        "status": "created",
+        "spec_version": ACTION_SPEC_VERSION,
+        "context_id": payload.context_id,
+        "seq": result["seq"],
+        "event": event,
+        "delivered_to": delivered_to,
+    }
+
+
+@app.get("/actions/contexts/{context_id}")
+async def action_context_get(
+    context_id: str,
+    after_seq: int = 0,
+    limit: int = 100,
+    authenticated_node: str = Depends(verify_request),
+):
+    safe_after_seq = max(0, int(after_seq))
+    safe_limit = max(1, min(int(limit), 500))
+    context = await asyncio.to_thread(db.get_action_context, context_id)
+    if context is None:
+        raise HTTPException(status_code=404, detail="Action context not found")
+    participants = list(context.get("participants") or [])
+    if authenticated_node not in participants:
+        raise HTTPException(status_code=403, detail="Node is not a participant of this action context")
+    events = await asyncio.to_thread(
+        db.list_action_events,
+        context_id,
+        after_seq=safe_after_seq,
+        limit=safe_limit,
+    )
+    visible_events = [
+        event
+        for event in events
+        if authenticated_node in (event.get("audience") or [])
+    ]
+    latest_seq = max(0, int(context.get("next_seq") or 1) - 1)
+    scanned_through_seq = int(events[-1]["seq"]) if events else safe_after_seq
+    return {
+        "spec_version": ACTION_SPEC_VERSION,
+        **context,
+        "latest_seq": latest_seq,
+        "scanned_through_seq": scanned_through_seq,
+        "has_more": scanned_through_seq < latest_seq,
+        "events": visible_events,
+    }
+
 
 @app.get("/federation/peers")
 async def get_federation_peers():

--- a/hub/models.py
+++ b/hub/models.py
@@ -106,3 +106,25 @@ class BrainstormSessionPost(BaseModel):
     session_id: str
     message: str = Field(..., min_length=1, max_length=5000)
     reply_to_message_id: Optional[str] = None
+
+
+class ActionContextCreate(BaseModel):
+    owner_id: str
+    participants: List[str] = Field(..., min_length=1, max_length=128)
+    context_id: Optional[str] = Field(default=None, min_length=8, max_length=160)
+    topic: Optional[str] = Field(default=None, max_length=500)
+    max_events: Optional[int] = Field(default=500, ge=10, le=5000)
+
+
+class ActionEventPost(BaseModel):
+    context_id: str = Field(..., min_length=8, max_length=160)
+    action_id: str = Field(..., min_length=1, max_length=160)
+    event_type: str = Field(..., min_length=1, max_length=40)
+    event_id: Optional[str] = Field(default=None, min_length=8, max_length=160)
+    parent_action_id: Optional[str] = Field(default=None, max_length=160)
+    visibility: str = Field(default="participants", max_length=20)
+    audience: Optional[List[str]] = Field(default=None, max_length=128)
+    phase: Optional[str] = Field(default=None, max_length=80)
+    message: Optional[str] = Field(default=None, max_length=2000)
+    progress: Optional[int] = Field(default=None, ge=0, le=100)
+    artifacts: Optional[List[Dict[str, Any]]] = Field(default=None, max_length=20)

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -5337,6 +5337,9 @@ class RuntimeNode:
         self._live_call_locks: dict[str, asyncio.Lock] = {}
         self._live_call_outbound_seq: dict[str, int] = {}
         self._task_adapter_lock = asyncio.Lock()
+        self._task_action_contexts: dict[str, dict[str, str]] = {}
+        self._action_event_history: dict[str, list[dict[str, Any]]] = {}
+        self._action_history_limit = _env_positive_int("MEP_ACTION_HISTORY_LIMIT", 128)
         
         # Phase 4: Autonomous Workspace Management
         workspace_dir = os.getenv("MEP_WORKSPACE_DIR")
@@ -5350,6 +5353,174 @@ class RuntimeNode:
         headers = self.identity.get_auth_headers(payload)
         headers["Content-Type"] = "application/json"
         return headers
+
+    @staticmethod
+    def _action_context_metadata(
+        task_data: dict[str, Any],
+        interbot_message: Optional[dict[str, Any]],
+    ) -> Optional[dict[str, str]]:
+        candidates: list[Any] = []
+        for container in (interbot_message, task_data):
+            if not isinstance(container, dict):
+                continue
+            task = container.get("task")
+            if not isinstance(task, dict):
+                continue
+            inputs = task.get("inputs")
+            if isinstance(inputs, dict):
+                candidates.append(inputs.get("action_context"))
+        for raw in candidates:
+            if not isinstance(raw, dict) or raw.get("spec_version") != "mep.action.v1":
+                continue
+            context_id = str(raw.get("context_id") or "").strip()
+            action_id = str(raw.get("action_id") or "").strip()
+            parent_action_id = str(raw.get("parent_action_id") or "").strip()
+            if not context_id or not action_id:
+                continue
+            metadata = {
+                "spec_version": "mep.action.v1",
+                "context_id": context_id[:160],
+                "action_id": action_id[:160],
+            }
+            if parent_action_id:
+                metadata["parent_action_id"] = parent_action_id[:160]
+            return metadata
+        return None
+
+    def _remember_action_event(self, event: Any) -> None:
+        if not isinstance(event, dict) or event.get("spec_version") != "mep.action.v1":
+            return
+        context_id = str(event.get("context_id") or "").strip()
+        event_id = str(event.get("event_id") or "").strip()
+        if not context_id or not event_id:
+            return
+        history = self._action_event_history.setdefault(context_id, [])
+        if any(item.get("event_id") == event_id for item in history):
+            return
+        history.append(copy.deepcopy(event))
+        history.sort(key=lambda item: int(item.get("seq") or 0))
+        if len(history) > self._action_history_limit:
+            del history[:-self._action_history_limit]
+        print(
+            f"[mep action] context={context_id[:12]} seq={event.get('seq')} "
+            f"producer={str(event.get('producer_id') or '')[:18]} "
+            f"type={event.get('event_type')} phase={event.get('phase') or '-'}"
+        )
+
+    def _post_action_event_sync(
+        self,
+        metadata: dict[str, str],
+        event_type: str,
+        *,
+        phase: Optional[str] = None,
+        message: Optional[str] = None,
+        progress: Optional[int] = None,
+        artifacts: Optional[list[dict[str, str]]] = None,
+    ) -> bool:
+        body: dict[str, Any] = {
+            "context_id": metadata["context_id"],
+            "action_id": metadata["action_id"],
+            "event_type": event_type,
+            "event_id": f"evt-{uuid.uuid4()}",
+            "visibility": "participants",
+        }
+        for key in ("parent_action_id",):
+            if metadata.get(key):
+                body[key] = metadata[key]
+        optional: dict[str, Any] = {
+            "phase": phase,
+            "message": message,
+            "progress": progress,
+            "artifacts": artifacts,
+        }
+        body.update({key: value for key, value in optional.items() if value is not None})
+        payload = json.dumps(body)
+        code, response, raw = _safe_request(
+            "POST",
+            f"{self.hub_url}/actions/events",
+            data_body=payload,
+            headers=self._auth_headers(payload),
+            timeout=20.0,
+        )
+        if code == 200 and isinstance(response, dict):
+            event = response.get("event")
+            if isinstance(event, dict):
+                self._remember_action_event(event)
+            return True
+        print(
+            f"[mep action] publish failed context={metadata['context_id'][:12]} "
+            f"action={metadata['action_id'][:18]} type={event_type} "
+            f"status={code} detail={raw[:300]}"
+        )
+        return False
+
+    async def _emit_action_event(
+        self,
+        metadata: dict[str, str],
+        event_type: str,
+        *,
+        phase: Optional[str] = None,
+        message: Optional[str] = None,
+        progress: Optional[int] = None,
+        artifacts: Optional[list[dict[str, str]]] = None,
+    ) -> bool:
+        return await asyncio.to_thread(
+            self._post_action_event_sync,
+            metadata,
+            event_type,
+            phase=phase,
+            message=message,
+            progress=progress,
+            artifacts=artifacts,
+        )
+
+    def _schedule_action_event(
+        self,
+        metadata: Optional[dict[str, str]],
+        event_type: str,
+        *,
+        phase: Optional[str] = None,
+        message: Optional[str] = None,
+        progress: Optional[int] = None,
+        artifacts: Optional[list[dict[str, str]]] = None,
+    ) -> None:
+        if metadata is None:
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            self._post_action_event_sync(
+                metadata,
+                event_type,
+                phase=phase,
+                message=message,
+                progress=progress,
+                artifacts=artifacts,
+            )
+            return
+        self._schedule_background_task(
+            self._emit_action_event(
+                metadata,
+                event_type,
+                phase=phase,
+                message=message,
+                progress=progress,
+                artifacts=artifacts,
+            ),
+            label=f"{event_type}:{metadata['action_id'][:18]}",
+        )
+
+    @staticmethod
+    def _action_result_failed(result_payload: str) -> bool:
+        normalized = str(result_payload or "").strip().lower()
+        failure_markers = (
+            "[interbot] routing contract rejected",
+            "[review runtime]",
+            "[repo audit]",
+            "error:",
+            "failed:",
+        )
+        return _is_adapter_error(result_payload) or normalized.startswith(failure_markers)
 
     @staticmethod
     def _bridge_metadata(interbot_message: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
@@ -5610,6 +5781,7 @@ class RuntimeNode:
         return False
 
     def complete(self, task_id: str, result_payload: str) -> None:
+        action_metadata = self._task_action_contexts.pop(task_id, None)
         payload = json.dumps(
             {
                 "task_id": task_id,
@@ -5626,8 +5798,26 @@ class RuntimeNode:
         )
         if code == 200:
             print(f"[mep run] completed task={task_id[:8]}")
+            failed = self._action_result_failed(result_payload)
+            self._schedule_action_event(
+                action_metadata,
+                "action.failed" if failed else "action.completed",
+                phase="complete",
+                message=(
+                    "Task failed; diagnostic result was submitted."
+                    if failed
+                    else "Task completed and its result was submitted."
+                ),
+                progress=100,
+            )
         else:
             print(f"[mep run] complete failed task={task_id[:8]} status={code} detail={raw}")
+            self._schedule_action_event(
+                action_metadata,
+                "action.failed",
+                phase="settlement",
+                message="Task result could not be submitted to the Hub.",
+            )
 
     def _schedule_background_task(self, coroutine: Any, *, label: str) -> None:
         task = asyncio.create_task(coroutine)
@@ -6348,6 +6538,25 @@ class RuntimeNode:
             f"origin_task={task_id[:8]}"
         )
 
+    async def _process_task_with_failure_boundary(self, task_data: dict[str, Any]) -> None:
+        task_id = str(task_data.get("id") or "")
+        try:
+            await self.process_task(task_data)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            action_metadata = self._task_action_contexts.pop(task_id, None)
+            if action_metadata is None:
+                action_metadata = self._action_context_metadata(task_data, None)
+            if action_metadata is not None:
+                await self._emit_action_event(
+                    action_metadata,
+                    "action.failed",
+                    phase="runtime",
+                    message="The runtime stopped unexpectedly while processing the task.",
+                )
+            raise
+
     async def process_task(self, task_data: dict[str, Any]) -> None:
         task_id = str(task_data.get("id") or "")
         payload = str(task_data.get("payload") or "")
@@ -6364,6 +6573,16 @@ class RuntimeNode:
         interbot_message: Optional[dict[str, Any]] = None
         if MEPClient is not None:
             instructions, interbot_message = MEPClient.extract_interbot_instructions(payload)
+        action_metadata = self._action_context_metadata(task_data, interbot_message)
+        if task_id and action_metadata is not None:
+            self._task_action_contexts[task_id] = action_metadata
+            await self._emit_action_event(
+                action_metadata,
+                "action.started",
+                phase="accepted",
+                message="Accepted the structured work task.",
+                progress=5,
+            )
         if isinstance(interbot_message, dict):
             contract_error = _interbot_routing_contract_error(
                 task_data,
@@ -6418,6 +6637,13 @@ class RuntimeNode:
                 f"[mep tools] task={task_id[:8]} "
                 f"tool={entry.get('tool')} status={entry.get('status')} "
                 f"summary={entry.get('summary')}"
+            )
+            self._schedule_action_event(
+                action_metadata,
+                "action.progress",
+                phase=str(entry.get("tool") or "tool")[:80],
+                message=str(entry.get("summary") or "Runtime tool checkpoint.")[:2000],
+                progress=min(80, 10 + len(runtime_tool_runs) * 10),
             )
 
         if repo_audit_required:
@@ -6723,6 +6949,14 @@ class RuntimeNode:
             and is_execution_request is not None
             and is_execution_request(interbot_message)
         ):
+            if action_metadata is not None:
+                await self._emit_action_event(
+                    action_metadata,
+                    "action.progress",
+                    phase="execution",
+                    message="Starting the authorized execution bridge.",
+                    progress=85,
+                )
             bridge_request = build_execution_bridge_request(
                 interbot_message,
                 consumer_id=str(task_data.get("consumer_id") or ""),
@@ -6757,6 +6991,14 @@ class RuntimeNode:
         # Provider adapters are currently synchronous. Run inference away from the
         # WebSocket event loop so pings, call frames, and new task delivery remain
         # responsive during long model requests.
+        if action_metadata is not None:
+            await self._emit_action_event(
+                action_metadata,
+                "action.progress",
+                phase="inference",
+                message="Prepared scoped context and started AI inference.",
+                progress=85,
+            )
         async with self._task_adapter_lock:
             result = await asyncio.to_thread(self.adapter.generate_reply, instructions, adapter_task_data)
         adapter_metrics = getattr(self.adapter, "last_review_metrics", None) or None
@@ -6839,7 +7081,12 @@ class RuntimeNode:
             if task_id and self.should_bid(task):
                 self.bid(task_id)
         elif event == "new_task":
-            self._schedule_background_task(self.process_task(data.get("data", {})), label="process_task")
+            self._schedule_background_task(
+                self._process_task_with_failure_boundary(data.get("data", {})),
+                label="process_task",
+            )
+        elif event == "action_event":
+            self._remember_action_event(data.get("data"))
         elif isinstance(event, str) and event.startswith("call."):
             await self._handle_call_event(data)
 

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -3301,6 +3301,170 @@ class TestBrainstormSessions(unittest.TestCase):
 
 
 
+class TestActionProgressV1(unittest.TestCase):
+    def setUp(self):
+        conn = db._get_conn()
+        conn.execute("DELETE FROM action_events")
+        conn.execute("DELETE FROM action_contexts")
+        conn.commit()
+        db._release_conn(conn)
+        main.connected_nodes.clear()
+        main.rate_limits.clear()
+
+    def tearDown(self):
+        main.connected_nodes.clear()
+        main.rate_limits.clear()
+
+    @staticmethod
+    def _create_context(owner, participants, *, context_id="action-test-context"):
+        owner_priv, _owner_pub, owner_id = owner
+        payload = json.dumps(
+            {
+                "owner_id": owner_id,
+                "participants": [identity[2] for identity in participants],
+                "context_id": context_id,
+                "topic": "Parallel review",
+            }
+        )
+        return client.post(
+            "/actions/contexts",
+            content=payload,
+            headers=_auth_headers(owner_priv, owner_id, payload),
+        )
+
+    @staticmethod
+    def _post_event(identity, body):
+        private_key, _pub_pem, node_id = identity
+        payload = json.dumps(body)
+        return client.post(
+            "/actions/events",
+            content=payload,
+            headers=_auth_headers(private_key, node_id, payload),
+        )
+
+    def test_persistent_lifecycle_replay_visibility_and_idempotency(self):
+        owner = _make_identity()
+        worker_a = _make_identity()
+        worker_b = _make_identity()
+        outsider = _make_identity()
+        for _private_key, pub_pem, _node_id in (owner, worker_a, worker_b, outsider):
+            _register(pub_pem)
+
+        create_resp = self._create_context(owner, [worker_a, worker_b])
+        self.assertEqual(create_resp.status_code, 200, create_resp.text)
+        context_id = create_resp.json()["context_id"]
+
+        started = {
+            "context_id": context_id,
+            "action_id": "review-runtime",
+            "event_id": "evt-started-0001",
+            "event_type": "action.started",
+            "visibility": "participants",
+            "phase": "accepted",
+            "progress": 5,
+        }
+        started_resp = self._post_event(worker_a, started)
+        self.assertEqual(started_resp.status_code, 200, started_resp.text)
+        self.assertEqual(started_resp.json()["seq"], 1)
+
+        duplicate_resp = self._post_event(worker_a, started)
+        self.assertEqual(duplicate_resp.status_code, 200, duplicate_resp.text)
+        self.assertEqual(duplicate_resp.json()["status"], "duplicate")
+        self.assertEqual(duplicate_resp.json()["seq"], 1)
+
+        private_resp = self._post_event(
+            worker_b,
+            {
+                "context_id": context_id,
+                "action_id": "private-diagnostic",
+                "event_id": "evt-private-0002",
+                "event_type": "action.progress",
+                "visibility": "private",
+                "message": "Local diagnostic checkpoint.",
+            },
+        )
+        self.assertEqual(private_resp.status_code, 200, private_resp.text)
+
+        completed = {
+            "context_id": context_id,
+            "action_id": "review-runtime",
+            "event_id": "evt-complete-0003",
+            "event_type": "action.completed",
+            "visibility": "participants",
+            "phase": "complete",
+            "progress": 100,
+        }
+        completed_resp = self._post_event(worker_a, completed)
+        self.assertEqual(completed_resp.status_code, 200, completed_resp.text)
+        self.assertEqual(completed_resp.json()["seq"], 3)
+
+        post_terminal = dict(completed, event_id="evt-after-terminal", event_type="action.progress")
+        terminal_resp = self._post_event(worker_a, post_terminal)
+        self.assertEqual(terminal_resp.status_code, 409)
+
+        replay_resp = client.get(
+            f"/actions/contexts/{context_id}?after_seq=0&limit=20",
+            headers=_auth_headers(owner[0], owner[2], ""),
+        )
+        self.assertEqual(replay_resp.status_code, 200, replay_resp.text)
+        replay = replay_resp.json()
+        self.assertEqual(replay["latest_seq"], 3)
+        self.assertEqual([event["seq"] for event in replay["events"]], [1, 3])
+
+        worker_b_replay = client.get(
+            f"/actions/contexts/{context_id}?after_seq=1&limit=20",
+            headers=_auth_headers(worker_b[0], worker_b[2], ""),
+        )
+        self.assertEqual([event["seq"] for event in worker_b_replay.json()["events"]], [2, 3])
+
+        outsider_resp = client.get(
+            f"/actions/contexts/{context_id}",
+            headers=_auth_headers(outsider[0], outsider[2], ""),
+        )
+        self.assertEqual(outsider_resp.status_code, 403)
+
+    def test_three_workers_publish_in_parallel_and_all_receive_progress(self):
+        owner = _make_identity()
+        workers = [_make_identity() for _ in range(3)]
+        for _private_key, pub_pem, _node_id in (owner, *workers):
+            _register(pub_pem)
+
+        create_resp = self._create_context(owner, workers, context_id="action-three-workers")
+        self.assertEqual(create_resp.status_code, 200, create_resp.text)
+        context_id = create_resp.json()["context_id"]
+
+        sockets = {}
+        for _private_key, _pub_pem, node_id in workers:
+            sockets[node_id] = _FakeWebSocket()
+            main.connected_nodes[node_id] = sockets[node_id]
+
+        def publish(index):
+            return self._post_event(
+                workers[index],
+                {
+                    "context_id": context_id,
+                    "action_id": f"parallel-worker-{index}",
+                    "event_id": f"evt-parallel-{index:04d}",
+                    "event_type": "action.started",
+                    "visibility": "participants",
+                    "phase": "accepted",
+                    "progress": 5,
+                },
+            )
+
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            responses = list(executor.map(publish, range(3)))
+
+        self.assertTrue(all(response.status_code == 200 for response in responses))
+        self.assertEqual(sorted(response.json()["seq"] for response in responses), [1, 2, 3])
+        for socket in sockets.values():
+            self.assertEqual(len(socket.sent), 3)
+            self.assertEqual(
+                sorted(message["data"]["seq"] for message in socket.sent),
+                [1, 2, 3],
+            )
+
+
 def tearDownModule():
 
     """Clean up test database."""

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -1988,6 +1988,106 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         self.assertEqual(handle_mock.await_args_list[0].args[0], {"event": "new_task", "data": {"id": "task_one"}})
         self.assertEqual(handle_mock.await_args_list[1].args[0], {"event": "new_task", "data": {"id": "task_two"}})
 
+    def test_action_event_fanout_is_retained_once_in_sequence_order(self):
+        node = _runtime_node()
+        later = {
+            "spec_version": "mep.action.v1",
+            "context_id": "action-context-123",
+            "event_id": "evt-later",
+            "seq": 2,
+            "producer_id": "node_peer_b",
+            "action_id": "review-b",
+            "event_type": "action.progress",
+        }
+        earlier = {
+            "spec_version": "mep.action.v1",
+            "context_id": "action-context-123",
+            "event_id": "evt-earlier",
+            "seq": 1,
+            "producer_id": "node_peer_a",
+            "action_id": "review-a",
+            "event_type": "action.started",
+        }
+
+        asyncio.run(node.handle_ws_event({"event": "action_event", "data": later}))
+        asyncio.run(node.handle_ws_event({"event": "action_event", "data": earlier}))
+        asyncio.run(node.handle_ws_event({"event": "action_event", "data": earlier}))
+
+        history = node._action_event_history["action-context-123"]  # noqa: SLF001
+        self.assertEqual([event["seq"] for event in history], [1, 2])
+        self.assertEqual([event["event_id"] for event in history], ["evt-earlier", "evt-later"])
+
+    def test_process_task_publishes_started_inference_and_terminal_action_events(self):
+        node = _runtime_node()
+        task_data = {
+            "id": "task_action_progress",
+            "bounty": 0.0,
+            "payload": "Analyze this change.",
+            "task": {
+                "inputs": {
+                    "action_context": {
+                        "spec_version": "mep.action.v1",
+                        "context_id": "action-context-123",
+                        "action_id": "review-runtime",
+                    }
+                }
+            },
+        }
+        published = []
+
+        def capture(metadata, event_type, **kwargs):
+            published.append((metadata, event_type, kwargs))
+            return True
+
+        async def run():
+            with (
+                patch.object(node.adapter, "generate_reply", return_value="Analysis completed."),
+                patch.object(node, "_post_action_event_sync", side_effect=capture),
+                patch("node.mep_runtime._safe_request", return_value=(200, {"status": "completed"}, "")),
+            ):
+                await node.process_task(task_data)
+                if node._background_tasks:  # noqa: SLF001
+                    await asyncio.gather(*list(node._background_tasks))  # noqa: SLF001
+
+        asyncio.run(run())
+
+        self.assertEqual(
+            [event_type for _metadata, event_type, _kwargs in published],
+            ["action.started", "action.progress", "action.completed"],
+        )
+        self.assertEqual(published[1][2]["phase"], "inference")
+        self.assertEqual(published[2][2]["progress"], 100)
+        self.assertNotIn("task_action_progress", node._task_action_contexts)  # noqa: SLF001
+
+    def test_process_task_failure_boundary_publishes_terminal_failure(self):
+        node = _runtime_node()
+        task_data = {
+            "id": "task_action_failure",
+            "task": {
+                "inputs": {
+                    "action_context": {
+                        "spec_version": "mep.action.v1",
+                        "context_id": "action-context-123",
+                        "action_id": "review-failure",
+                    }
+                }
+            },
+        }
+
+        async def run():
+            with (
+                patch.object(node, "process_task", new=AsyncMock(side_effect=RuntimeError("boom"))),
+                patch.object(node, "_emit_action_event", new=AsyncMock(return_value=True)) as emit_mock,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "boom"):
+                    await node._process_task_with_failure_boundary(task_data)  # noqa: SLF001
+                return emit_mock
+
+        emit_mock = asyncio.run(run())
+        emit_mock.assert_awaited_once()
+        self.assertEqual(emit_mock.await_args.args[1], "action.failed")
+        self.assertEqual(emit_mock.await_args.kwargs["phase"], "runtime")
+
     def test_run_forever_recovers_pending_tasks_after_connect(self):
         node = _runtime_node()
 

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -98,6 +98,73 @@ class TestSharedMEPClient(unittest.TestCase):
         )
         self.assertEqual(body["routing"], {"target_node_id": "node_provider", "target_capability": "text"})
 
+    def test_action_context_helpers_use_signed_persistent_endpoints(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.post.return_value = _FakeResponse(json_data={"status": "created"})
+            session.get.return_value = _FakeResponse(json_data={"events": []})
+            client = MEPClient("unused.pem")
+
+            created = asyncio.run(
+                client.create_action_context(
+                    ["node_hub", "node_elsaws"],
+                    topic="Parallel review",
+                    context_id="action-context-123",
+                    max_events=250,
+                )
+            )
+            posted = asyncio.run(
+                client.post_action_event(
+                    "action-context-123",
+                    "review-client",
+                    "action.progress",
+                    event_id="evt-progress-123",
+                    phase="workspace_read",
+                    message="Read the changed files.",
+                    progress=40,
+                )
+            )
+            replay = asyncio.run(
+                client.get_action_context(
+                    "action-context-123",
+                    after_seq=7,
+                    limit=25,
+                )
+            )
+
+        self.assertEqual(created["status_code"], 200)
+        self.assertEqual(posted["status_code"], 200)
+        self.assertEqual(replay["status_code"], 200)
+        create_body = json.loads(session.post.call_args_list[0].kwargs["data"])
+        self.assertEqual(create_body["owner_id"], "node_consumer")
+        self.assertEqual(create_body["participants"], ["node_hub", "node_elsaws"])
+        self.assertEqual(create_body["context_id"], "action-context-123")
+        event_body = json.loads(session.post.call_args_list[1].kwargs["data"])
+        self.assertEqual(event_body["event_type"], "action.progress")
+        self.assertEqual(event_body["progress"], 40)
+        self.assertEqual(
+            session.get.call_args.kwargs["params"],
+            {"after_seq": 7, "limit": 25},
+        )
+
+        metadata = MEPClient.build_action_context_metadata(
+            "action-context-123",
+            "review-client",
+            parent_action_id="review-parent",
+        )
+        self.assertEqual(
+            metadata,
+            {
+                "spec_version": "mep.action.v1",
+                "context_id": "action-context-123",
+                "action_id": "review-client",
+                "parent_action_id": "review-parent",
+            },
+        )
+
     def test_send_ws_event_uses_active_socket_when_present(self):
         with patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()):
             client = MEPClient("unused.pem")


### PR DESCRIPTION
## Summary
- add persistent mep.action.v1 contexts and monotonic action events
- stream authenticated started/progress/terminal checkpoints to all relevant bot participants
- add scoped visibility, idempotency, replay cursors, terminal enforcement, and concurrent fanout
- wire shared clients and runtimes so bots see peer work without exposing raw logs
- cover three workers publishing concurrently and runtime failure termination

## Validation
- python -m pytest -q: 594 passed, 1 skipped
- python -m ruff check ...: clean
- git diff --check: clean