### PR TITLE
fix: reuse exact local review workspace

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -4757,6 +4757,59 @@ class WorkspaceManager:
         except Exception as exc:  # noqa: BLE001
             return -1, str(exc)
 
+    @staticmethod
+    def _canonical_repo_identity(repo_url: str) -> str:
+        """Normalize common Git remote spellings for exact-workspace matching."""
+        normalized = str(repo_url or "").strip().replace("\\", "/").rstrip("/")
+        if not normalized:
+            return ""
+        normalized = re.sub(r"^[a-z][a-z0-9+.-]*://", "", normalized, flags=re.IGNORECASE)
+        normalized = re.sub(r"^[^/@]+@", "", normalized)
+        if ":" in normalized and "/" not in normalized.split(":", 1)[0]:
+            normalized = normalized.replace(":", "/", 1)
+        normalized = normalized.removeprefix("www.")
+        if normalized.lower().endswith(".git"):
+            normalized = normalized[:-4]
+        return normalized.rstrip("/").lower()
+
+    def is_exact_clean_workspace(
+        self,
+        workspace_path: str,
+        repo_url: str,
+        head_sha: str,
+    ) -> bool:
+        """Return true only for a clean local checkout of the requested repo/head.
+
+        Codex-style nodes commonly already run inside the repository being
+        reviewed. Reusing that checkout avoids a redundant network clone, but
+        only when the remote identity, full commit SHA, and worktree cleanliness
+        all match the signed task contract.
+        """
+        candidate = os.path.abspath(str(workspace_path or "").strip())
+        expected_repo = self._canonical_repo_identity(repo_url)
+        expected_head = str(head_sha or "").strip().lower()
+        if (
+            not candidate
+            or not expected_repo
+            or not re.fullmatch(r"[0-9a-f]{40}", expected_head)
+            or not os.path.isdir(os.path.join(candidate, ".git"))
+        ):
+            return False
+        head_code, actual_head = self._run_git(candidate, ["rev-parse", "HEAD"])
+        if head_code != 0 or actual_head.strip().lower() != expected_head:
+            return False
+        remote_code, actual_remote = self._run_git(candidate, ["remote", "get-url", "origin"])
+        if (
+            remote_code != 0
+            or self._canonical_repo_identity(actual_remote) != expected_repo
+        ):
+            return False
+        status_code, status = self._run_git(
+            candidate,
+            ["status", "--porcelain", "--untracked-files=all"],
+        )
+        return status_code == 0 and not status.strip()
+
     def sync_pr_workspace(self, repo_url: str, head_sha: str, head_ref: str, bridge_id: Optional[str] = None) -> tuple[bool, str]:
         """Ensures the local workspace is synced to the target PR branch/commit."""
         # Phase 4 Isolation: Use a specific directory for this bridge_id if provided
@@ -7021,8 +7074,31 @@ class RuntimeNode:
             bridge_id = interbot_message.get("trace_id") or interbot_message.get("task", {}).get("inputs", {}).get("bridge_metadata", {}).get("bridge_id")
 
             if repo_url and head_sha and head_ref:
-                print(f"[mep workspace] auto-syncing for task={task_id[:8]} bridge_id={bridge_id}")
-                ok, path_or_err = await asyncio.to_thread(self.workspace.sync_pr_workspace, repo_url, head_sha, head_ref, bridge_id=bridge_id)
+                local_workspace = str(getattr(self.adapter, "workspace", "") or "").strip()
+                reuse_local = bool(
+                    local_workspace
+                    and await asyncio.to_thread(
+                        self.workspace.is_exact_clean_workspace,
+                        local_workspace,
+                        repo_url,
+                        head_sha,
+                    )
+                )
+                if reuse_local:
+                    ok, path_or_err = True, os.path.abspath(local_workspace)
+                    print(
+                        f"[mep workspace] reusing exact clean adapter workspace "
+                        f"for task={task_id[:8]} path={path_or_err}"
+                    )
+                else:
+                    print(f"[mep workspace] auto-syncing for task={task_id[:8]} bridge_id={bridge_id}")
+                    ok, path_or_err = await asyncio.to_thread(
+                        self.workspace.sync_pr_workspace,
+                        repo_url,
+                        head_sha,
+                        head_ref,
+                        bridge_id=bridge_id,
+                    )
                 if ok:
                     print(f"[mep workspace] synced to {path_or_err}")
                     workspace_path = path_or_err

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -2584,6 +2584,46 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         )
         complete_mock.assert_called_once_with("task_bridge_review", "reply")
 
+    def test_process_task_reuses_exact_clean_adapter_workspace_before_network_sync(self):
+        node = _runtime_node()
+        task_data = TestRuntimeReviewPrompts._bridge_review_task_data()
+        payload = json.loads(task_data["payload"])
+        payload["task"]["inputs"]["github"].update(
+            {
+                "repo_clone_url": "https://github.com/WUAIBING/MEP.git",
+                "head_sha": "a" * 40,
+                "head_ref": "feature/test",
+            }
+        )
+        task_data["payload"] = json.dumps(payload)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "bridge"), exist_ok=True)
+            os.makedirs(os.path.join(tmpdir, "tests"), exist_ok=True)
+            with open(os.path.join(tmpdir, "bridge", "github_to_mep.py"), "w", encoding="utf-8") as handle:
+                handle.write("def local_exact_head():\n    return True\n")
+            with open(os.path.join(tmpdir, "tests", "test_github_bridge.py"), "w", encoding="utf-8") as handle:
+                handle.write("def test_local_exact_head():\n    assert True\n")
+            node.adapter.workspace = tmpdir
+            with (
+                patch.object(node.workspace, "is_exact_clean_workspace", return_value=True) as exact_mock,
+                patch.object(node.workspace, "sync_pr_workspace") as sync_mock,
+                patch.object(node.adapter, "generate_reply", return_value="reply") as adapter_mock,
+                patch.object(node, "complete"),
+            ):
+                asyncio.run(node.process_task(task_data))
+
+        exact_mock.assert_called_once_with(
+            tmpdir,
+            "https://github.com/WUAIBING/MEP.git",
+            "a" * 40,
+        )
+        sync_mock.assert_not_called()
+        _instructions, normalized_task = adapter_mock.call_args.args
+        self.assertEqual(
+            normalized_task["task"]["inputs"]["github"]["local_workspace_path"],
+            os.path.abspath(tmpdir),
+        )
+
     def test_process_task_appends_synced_repo_audit_context_and_inventory(self):
         node = _runtime_node()
         task_data = {
@@ -3975,6 +4015,66 @@ class TestProviderNormalization(unittest.TestCase):
 
 
 class TestWorkspaceReviewContext(unittest.TestCase):
+    def test_exact_clean_workspace_requires_matching_remote_head_and_clean_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, ".git"))
+            wm = mep_runtime.WorkspaceManager(os.path.join(tmp, "managed"))
+            head = "a" * 40
+            with patch.object(
+                wm,
+                "_run_git",
+                side_effect=[
+                    (0, head),
+                    (0, "git@github.com:WUAIBING/MEP.git"),
+                    (0, ""),
+                ],
+            ) as git_mock:
+                matched = wm.is_exact_clean_workspace(
+                    tmp,
+                    "https://github.com/WUAIBING/MEP.git",
+                    head,
+                )
+
+        self.assertTrue(matched)
+        self.assertEqual(
+            [call.args[1] for call in git_mock.call_args_list],
+            [
+                ["rev-parse", "HEAD"],
+                ["remote", "get-url", "origin"],
+                ["status", "--porcelain", "--untracked-files=all"],
+            ],
+        )
+
+    def test_exact_clean_workspace_rejects_dirty_or_wrong_head_checkout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, ".git"))
+            wm = mep_runtime.WorkspaceManager(os.path.join(tmp, "managed"))
+            head = "b" * 40
+            with patch.object(wm, "_run_git", return_value=(0, "c" * 40)):
+                self.assertFalse(
+                    wm.is_exact_clean_workspace(
+                        tmp,
+                        "https://github.com/WUAIBING/MEP.git",
+                        head,
+                    )
+                )
+            with patch.object(
+                wm,
+                "_run_git",
+                side_effect=[
+                    (0, head),
+                    (0, "https://github.com/WUAIBING/MEP"),
+                    (0, " M node/mep_runtime.py"),
+                ],
+            ):
+                self.assertFalse(
+                    wm.is_exact_clean_workspace(
+                        tmp,
+                        "https://github.com/WUAIBING/MEP.git",
+                        head,
+                    )
+                )
+
     def test_build_review_context_includes_full_file_contents(self):
         with tempfile.TemporaryDirectory() as tmp:
             os.makedirs(os.path.join(tmp, "bridge"), exist_ok=True)


### PR DESCRIPTION
## Summary

- reuse a Codex-style node local checkout only when origin, full HEAD SHA, and clean worktree exactly match the signed review task
- retain isolated network sync as the fail-closed fallback
- avoid redundant clones and transient GitHub reset failures for local CLI bots

## Validation

- `python -m pytest -q`: 606 passed, 1 skipped
- `python -m ruff check node/mep_runtime.py tests/test_node_runtime.py`
- `python -m py_compile node/mep_runtime.py tests/test_node_runtime.py`
- `git diff --check`