### PR TITLE
fix: support linked review worktrees

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -5534,23 +5534,20 @@ class WorkspaceManager:
         }
         env = {key: value for key, value in os.environ.items() if key in allowed_passthrough and value}
         # HOME/USERPROFILE are intentionally replaced below, which also hides
-        # Python's per-user site-packages directory on Windows. Preserve only
-        # the already-installed package search roots so allowlisted tools such
-        # as ``python -m pytest`` remain available without forwarding provider
-        # credentials or other deployment environment variables.
+        # Python's per-user site-packages directory on Windows. Preserve the
+        # original Python user base so allowlisted tools such as
+        # ``python -m pytest`` remain available at normal site-package
+        # precedence. Using PYTHONPATH here would put user packages before the
+        # standard library and can let stale backports (for example typing.py)
+        # shadow the interpreter's own modules.
         import site
 
-        python_paths = [item for item in env.get("PYTHONPATH", "").split(os.pathsep) if item]
         try:
-            site_paths = [*site.getsitepackages(), site.getusersitepackages()]
+            user_base = str(site.getuserbase() or "").strip()
         except (AttributeError, OSError):
-            site_paths = []
-        for path in site_paths:
-            normalized = str(path or "").strip()
-            if normalized and os.path.isdir(normalized) and normalized not in python_paths:
-                python_paths.append(normalized)
-        if python_paths:
-            env["PYTHONPATH"] = os.pathsep.join(python_paths)
+            user_base = ""
+        if user_base and os.path.isdir(user_base):
+            env["PYTHONUSERBASE"] = user_base
         env["HOME"] = temp_home
         env["USERPROFILE"] = temp_home
         env["TMPDIR"] = temp_home

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -118,6 +118,17 @@ def _review_allow_external_checks() -> bool:
     return _env_truthy("MEP_REVIEW_ALLOW_EXTERNAL_CHECKS", "0")
 
 
+def _verification_report_has_failures(report: str) -> bool:
+    """Return whether an allowlisted verification command failed.
+
+    The report is also prompt context, but its presence alone must not count as
+    successful approval evidence. Keep this parser tied to the status labels
+    emitted by ``build_verification_report`` so failed commands stay
+    fail-closed in the runtime tool bundle.
+    """
+    return bool(re.search(r"^\$ .+: failed \(exit -?\d+\)", str(report or ""), re.MULTILINE))
+
+
 def _is_adapter_error(text: str) -> bool:
     """Detect adapter failures that must never be published as a real review.
 
@@ -1087,6 +1098,13 @@ def _runtime_tool_successful_runs(task_data: Optional[dict[str, Any]]) -> list[d
 
 
 def _runtime_tool_evidence_satisfies_approval(task_data: Optional[dict[str, Any]]) -> bool:
+    runs = _runtime_tool_run_entries(task_data)
+    if any(
+        str(item.get("tool") or "").strip().lower() == "targeted_verify"
+        and str(item.get("status") or "").strip().lower() == "failed"
+        for item in runs
+    ):
+        return False
     successful_runs = _runtime_tool_successful_runs(task_data)
     successful_tools = {
         str(item.get("tool") or "").strip().lower()
@@ -5515,6 +5533,24 @@ class WorkspaceManager:
             "VIRTUAL_ENV",
         }
         env = {key: value for key, value in os.environ.items() if key in allowed_passthrough and value}
+        # HOME/USERPROFILE are intentionally replaced below, which also hides
+        # Python's per-user site-packages directory on Windows. Preserve only
+        # the already-installed package search roots so allowlisted tools such
+        # as ``python -m pytest`` remain available without forwarding provider
+        # credentials or other deployment environment variables.
+        import site
+
+        python_paths = [item for item in env.get("PYTHONPATH", "").split(os.pathsep) if item]
+        try:
+            site_paths = [*site.getsitepackages(), site.getusersitepackages()]
+        except (AttributeError, OSError):
+            site_paths = []
+        for path in site_paths:
+            normalized = str(path or "").strip()
+            if normalized and os.path.isdir(normalized) and normalized not in python_paths:
+                python_paths.append(normalized)
+        if python_paths:
+            env["PYTHONPATH"] = os.pathsep.join(python_paths)
         env["HOME"] = temp_home
         env["USERPROFILE"] = temp_home
         env["TMPDIR"] = temp_home
@@ -7220,11 +7256,16 @@ class RuntimeNode:
                         )
                         if verification_report:
                             instructions = f"{instructions}\n\n{verification_report}"
+                            verification_failed = _verification_report_has_failures(verification_report)
                             _record_runtime_tool_run(
                                 "targeted_verify",
                                 purpose="Run allowlisted verification against the checked-out PR head",
-                                status="success",
-                                summary="ran targeted verification on the synced PR workspace",
+                                status="failed" if verification_failed else "success",
+                                summary=(
+                                    "targeted verification reported a failed command on the synced PR workspace"
+                                    if verification_failed
+                                    else "ran targeted verification on the synced PR workspace"
+                                ),
                                 scope="pr_review",
                                 evidence=[str(path) for path in touched_tests[:2] or touched_paths[:2]],
                             )

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -1817,6 +1817,19 @@ def _run_two_pass_review(
     rendered = _render_structured_review_with_task_data(final_reply, max_chars=review_max_chars, task_data=task_data)
     if rendered:
         return rendered
+    if _task_is_approval_review(task_data) and not _is_adapter_error(final_reply):
+        # Approval reviews intentionally reject unstructured model output. Do
+        # not undo that fail-closed boundary by publishing the raw response.
+        # Re-render an empty structured packet so authoritative runtime tool
+        # evidence can produce a grounded deterministic decision, while weak
+        # evidence remains an explicit non-approval comment.
+        grounded = _render_structured_review_with_task_data(
+            "{}",
+            max_chars=review_max_chars,
+            task_data=task_data,
+        )
+        if grounded:
+            return grounded
     finalized = _finalize_model_reply(final_reply, max_chars=review_max_chars)
     if finalized:
         return finalized
@@ -3411,8 +3424,16 @@ def _render_structured_review_with_task_data(
 ) -> str:
     if _task_requires_repo_audit_prompt(task_data or {}):
         return _render_structured_repo_audit_with_task_data(text, max_chars=max_chars, task_data=task_data)
-    parsed = _extract_first_json_object(text)
     approval_mode = _task_is_approval_review(task_data or {})
+    if _looks_like_agent_scratchpad(text):
+        # Treat leaked planning/reasoning as absent model output. Discovery
+        # reviews can still use the deterministic, task-grounded renderer;
+        # approval reviews fail closed here and are normalized by the
+        # two-pass caller using the runtime evidence bundle.
+        if approval_mode:
+            return ""
+        return _render_default_structured_review(task_data=task_data, max_chars=max_chars)
+    parsed = _extract_first_json_object(text)
     if not isinstance(parsed, dict):
         if _is_adapter_error(text) or approval_mode:
             return ""

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -4726,7 +4726,14 @@ class WorkspaceManager:
         self.base_dir = os.path.abspath(base_dir)
         os.makedirs(self.base_dir, exist_ok=True)
 
-    def _run_git(self, cwd: str, args: list[str], *, timeout_seconds: int = 60) -> tuple[int, str]:
+    def _run_git(
+        self,
+        cwd: str,
+        args: list[str],
+        *,
+        timeout_seconds: int = 60,
+        include_stderr: bool = True,
+    ) -> tuple[int, str]:
         try:
             # Sanitize environment for git subprocesses to prevent
             # hostile repo hooks/config from leaking secrets or executing
@@ -4753,7 +4760,8 @@ class WorkspaceManager:
                 timeout=timeout_seconds,
                 env=safe_env,
             )
-            return result.returncode, (result.stdout + result.stderr).strip()
+            output = result.stdout + result.stderr if include_stderr else result.stdout
+            return result.returncode, output.strip()
         except Exception as exc:  # noqa: BLE001
             return -1, str(exc)
 
@@ -4792,13 +4800,21 @@ class WorkspaceManager:
             not candidate
             or not expected_repo
             or not re.fullmatch(r"[0-9a-f]{40}", expected_head)
-            or not os.path.isdir(os.path.join(candidate, ".git"))
+            or not os.path.exists(os.path.join(candidate, ".git"))
         ):
             return False
-        head_code, actual_head = self._run_git(candidate, ["rev-parse", "HEAD"])
+        head_code, actual_head = self._run_git(
+            candidate,
+            ["rev-parse", "HEAD"],
+            include_stderr=False,
+        )
         if head_code != 0 or actual_head.strip().lower() != expected_head:
             return False
-        remote_code, actual_remote = self._run_git(candidate, ["remote", "get-url", "origin"])
+        remote_code, actual_remote = self._run_git(
+            candidate,
+            ["remote", "get-url", "origin"],
+            include_stderr=False,
+        )
         if (
             remote_code != 0
             or self._canonical_repo_identity(actual_remote) != expected_repo
@@ -4807,6 +4823,7 @@ class WorkspaceManager:
         status_code, status = self._run_git(
             candidate,
             ["status", "--porcelain", "--untracked-files=all"],
+            include_stderr=False,
         )
         return status_code == 0 and not status.strip()
 

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -4017,7 +4017,10 @@ class TestProviderNormalization(unittest.TestCase):
 class TestWorkspaceReviewContext(unittest.TestCase):
     def test_exact_clean_workspace_requires_matching_remote_head_and_clean_status(self):
         with tempfile.TemporaryDirectory() as tmp:
-            os.makedirs(os.path.join(tmp, ".git"))
+            # Linked Git worktrees (including Codex worktrees) use a .git file
+            # pointing at the primary repository rather than a .git directory.
+            with open(os.path.join(tmp, ".git"), "w", encoding="utf-8") as handle:
+                handle.write("gitdir: C:/repo/.git/worktrees/review\n")
             wm = mep_runtime.WorkspaceManager(os.path.join(tmp, "managed"))
             head = "a" * 40
             with patch.object(

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -5054,8 +5054,7 @@ class TestWorkspaceReviewContext(unittest.TestCase):
                     "PYTHONPATH": "repo",
                 },
             ),
-            patch("site.getsitepackages", return_value=["C:/python/site-packages"]),
-            patch("site.getusersitepackages", return_value="C:/user/site-packages"),
+            patch("site.getuserbase", return_value="C:/user/python"),
             patch("os.path.isdir", return_value=True),
         ):
             env = mep_runtime.WorkspaceManager._clean_check_env("C:/tmp/mep-review-home")  # noqa: SLF001
@@ -5066,10 +5065,8 @@ class TestWorkspaceReviewContext(unittest.TestCase):
         self.assertIn("PATH", env)
         self.assertEqual(env["HOME"], "C:/tmp/mep-review-home")
         self.assertEqual(env["USERPROFILE"], "C:/tmp/mep-review-home")
-        self.assertEqual(
-            env["PYTHONPATH"].split(os.pathsep),
-            ["repo", "C:/python/site-packages", "C:/user/site-packages"],
-        )
+        self.assertEqual(env["PYTHONPATH"], "repo")
+        self.assertEqual(env["PYTHONUSERBASE"], "C:/user/python")
 
     def test_build_verification_report_runs_pytest_when_enabled(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -2956,6 +2956,57 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
             ["github_context", "workspace_read", "workspace_search", "workspace_git", "targeted_verify"],
         )
 
+    def test_process_task_marks_failed_targeted_verification_as_failed_evidence(self):
+        node = _runtime_node()
+        captured = {}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "bridge"), exist_ok=True)
+            with open(os.path.join(tmpdir, "bridge", "github_to_mep.py"), "w", encoding="utf-8") as handle:
+                handle.write("def live_sync_context():\n    return True\n")
+
+            task_data = TestRuntimeReviewPrompts._bridge_review_task_data()
+            payload = json.loads(task_data["payload"])
+            payload["task"]["inputs"]["github"].update(
+                {
+                    "repo_clone_url": "https://github.com/example/repo.git",
+                    "head_sha": "abc12345",
+                    "head_ref": "feature/test",
+                }
+            )
+            task_data["payload"] = json.dumps(payload)
+
+            def _reply(_instructions, adapter_task_data):
+                captured.update(adapter_task_data["task"]["inputs"]["runtime_tool_bundle"])
+                return "reply"
+
+            failed_report = (
+                "Automated verification run on the checked-out PR head (authoritative; "
+                "use these results in your review):\n\n"
+                "$ pytest (changed tests): failed (exit 1)\n1 failed"
+            )
+            with (
+                patch.object(
+                    node,
+                    "_build_github_context",
+                    return_value=("GitHub context", {"scope": "WUAIBING/MEP#246"}),
+                ),
+                patch.object(node.workspace, "sync_pr_workspace", return_value=(True, tmpdir)),
+                patch.object(node.workspace, "build_review_context", return_value="Local workspace path: tmpdir"),
+                patch.object(node.workspace, "build_workspace_search_context", return_value="workspace search"),
+                patch.object(node.workspace, "build_workspace_git_context", return_value="workspace git"),
+                patch.object(node.workspace, "build_verification_report", return_value=failed_report),
+                patch.object(node.adapter, "generate_reply", side_effect=_reply),
+                patch.object(node, "complete"),
+            ):
+                asyncio.run(node.process_task(task_data))
+
+        targeted_verify = next(item for item in captured["runs"] if item["tool"] == "targeted_verify")
+        self.assertEqual(targeted_verify["status"], "failed")
+        self.assertIn("failed command", targeted_verify["summary"])
+        self.assertFalse(mep_runtime._runtime_tool_evidence_satisfies_approval(  # noqa: SLF001
+            {"task": {"inputs": {"runtime_tool_bundle": captured}}}
+        ))
+
     def test_process_task_reports_tools_called_from_runtime_tool_runs(self):
         node = _runtime_node()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -4991,16 +5042,21 @@ class TestWorkspaceReviewContext(unittest.TestCase):
         self.assertIn('"candidate_coverage"', second_user_payload)
 
     def test_clean_check_env_uses_allowlist_and_throwaway_home(self):
-        with patch.dict(
-            os.environ,
-            {
-                "MEP_REVIEW_RUN_CHECKS": "true",
-                "MEP_AI_MAX_TOKENS": "4000",
-                "DEEPSEEK_API_KEY": "super-secret",
-                "R2_SECRET_ACCESS_KEY": "hidden",
-                "PATH": os.environ.get("PATH", ""),
-                "PYTHONPATH": "repo",
-            },
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "MEP_REVIEW_RUN_CHECKS": "true",
+                    "MEP_AI_MAX_TOKENS": "4000",
+                    "DEEPSEEK_API_KEY": "super-secret",
+                    "R2_SECRET_ACCESS_KEY": "hidden",
+                    "PATH": os.environ.get("PATH", ""),
+                    "PYTHONPATH": "repo",
+                },
+            ),
+            patch("site.getsitepackages", return_value=["C:/python/site-packages"]),
+            patch("site.getusersitepackages", return_value="C:/user/site-packages"),
+            patch("os.path.isdir", return_value=True),
         ):
             env = mep_runtime.WorkspaceManager._clean_check_env("C:/tmp/mep-review-home")  # noqa: SLF001
         self.assertNotIn("MEP_REVIEW_RUN_CHECKS", env)
@@ -5010,7 +5066,10 @@ class TestWorkspaceReviewContext(unittest.TestCase):
         self.assertIn("PATH", env)
         self.assertEqual(env["HOME"], "C:/tmp/mep-review-home")
         self.assertEqual(env["USERPROFILE"], "C:/tmp/mep-review-home")
-        self.assertEqual(env["PYTHONPATH"], "repo")
+        self.assertEqual(
+            env["PYTHONPATH"].split(os.pathsep),
+            ["repo", "C:/python/site-packages", "C:/user/site-packages"],
+        )
 
     def test_build_verification_report_runs_pytest_when_enabled(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -1089,6 +1089,80 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("always anchor the output to the actual diff", prompt)
         self.assertIn("Review mode is `discovery_review`.", prompt)
 
+    def test_structured_discovery_review_replaces_scratchpad_with_grounded_default(self):
+        scratchpad = "Let me carefully analyze this PR. I need to inspect the actual code changes."
+
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            scratchpad,
+            max_chars=1200,
+            task_data=self._bridge_review_task_data(),
+        )
+
+        self.assertIn("## Review Summary", rendered)
+        self.assertIn("Touched paths reviewed: `bridge/github_to_mep.py`", rendered)
+        self.assertNotIn("Let me carefully analyze", rendered)
+        self.assertNotIn("I need to inspect", rendered)
+
+    def test_two_pass_approval_review_normalizes_scratchpad_with_runtime_evidence(self):
+        replies = iter(
+            [
+                '{"risk_candidates":[]}',
+                "Let me carefully analyze this PR. I need to inspect the actual code changes.",
+            ]
+        )
+
+        rendered = mep_runtime._run_two_pass_review(  # noqa: SLF001
+            task_data=self._bridge_review_task_data(intent_type="code.review.approve"),
+            payload="Review this PR and approve only if the exact-head evidence is sufficient.",
+            review_max_chars=1400,
+            invoke_model=lambda _system, _payload: next(replies),
+        )
+
+        self.assertIn("## Review Summary", rendered)
+        self.assertIn("Touched paths reviewed: `bridge/github_to_mep.py`", rendered)
+        self.assertIn("Changed identifiers verified:", rendered)
+        self.assertNotIn("Let me carefully analyze", rendered)
+        self.assertNotIn("I need to inspect", rendered)
+
+    def test_two_pass_approval_review_downgrades_scratchpad_when_runtime_evidence_is_weak(self):
+        replies = iter(
+            [
+                '{"risk_candidates":[]}',
+                "Let me carefully analyze this PR. I need to inspect the actual code changes.",
+            ]
+        )
+        task_data = self._bridge_review_task_data(
+            intent_type="code.review.approve",
+            runtime_tool_bundle={
+                "contract_version": "mep.runtime_tools.v1",
+                "task_mode": "review",
+                "runs": [
+                    {
+                        "tool": "workspace_read",
+                        "status": "success",
+                        "summary": "assembled local context",
+                        "evidence": ["bridge/github_to_mep.py"],
+                    }
+                ],
+            },
+        )
+
+        rendered = mep_runtime._run_two_pass_review(  # noqa: SLF001
+            task_data=task_data,
+            payload="Review this PR and approve only if the exact-head evidence is sufficient.",
+            review_max_chars=1400,
+            invoke_model=lambda _system, _payload: next(replies),
+        )
+
+        self.assertIn("did not yet clear the approval bar", rendered)
+        self.assertNotIn("Let me carefully analyze", rendered)
+        action = mep_runtime.RuntimeNode._bridge_status_action(  # noqa: SLF001
+            mep_runtime._interbot_message_from_task_data(task_data),  # noqa: SLF001
+            detail=rendered,
+            task_data=task_data,
+        )
+        self.assertEqual(action, "reviewed")
+
     def test_approval_review_prompt_requires_verified_identifiers_and_test_awareness(self):
         task_data = self._bridge_review_task_data(intent_type="code.review.approve")
         prompt = mep_runtime._system_prompt_for_task(  # noqa: SLF001


### PR DESCRIPTION
## Summary

- accept both `.git` directories and linked-worktree `.git` files in the exact local workspace reuse gate
- evaluate clean Git stdout without treating harmless stderr warnings as uncommitted source changes
- retain nonzero Git exit codes, origin matching, full-SHA matching, and worktree cleanliness as fail-closed requirements

## Live finding

The deployed PR #349 gate rejected a valid Codex linked worktree, then its network-clone fallback timed out. This patch makes the real checkout pass the trust gate.

## Validation

- actual Codex checkout exact-workspace predicate: `True`
- `python -m pytest -q`: 606 passed, 1 skipped
- Ruff, py_compile, and diff-check clean