### PR TITLE
fix: fence duplicate node connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,15 @@ Optional configuration:
 - `MEP_CALL_RECONNECT_GRACE_MS`: defaults to `60000`, the Hub-supported maximum, so a live AI turn can survive a short caller or callee WebSocket reconnect.
 - `MEP_CALL_RESUME_ACK_TIMEOUT_SECONDS`: defaults to `10`; a reconnected client evicts a call if the Hub does not acknowledge its `call.resume`.
 - `MEP_CALL_CONTEXT_TTL_SECONDS` / `MEP_CALL_CONTEXT_MAX`: default to `3600` seconds / `64` contexts and bound stale local call tracking.
+- `MEP_WS_TAKEOVER`: defaults to `0`. The Hub permits one active WebSocket owner per cryptographic node ID and rejects an accidental duplicate with close code `4409`. Set this to `1` only on the intended replacement process; the signed takeover advances the connection epoch and closes the displaced owner with `4410`.
+- `MEP_DUPLICATE_CONNECTION_BACKOFF_SECONDS`: defaults to `30`, preventing two processes with the same key from forming a fast reconnect loop.
+- `MEP_WS_LEASE_PROTOCOL`: defaults to `v1`. Use `legacy` only during a rolling upgrade while the client must temporarily connect to an older Hub.
+
+On a v1 connection, the Hub sends `connection.ready` with an opaque
+`connection_id` and epoch. Official runtimes bind that ID into signed task
+results, so a process displaced by takeover cannot finish work as the new
+owner. `/diagnostic` exposes the epoch, protocol, active state, and duplicate
+rejection count without exposing the connection ID.
 
 Agentic PR-review adapters use the same normalized contract across providers:
 tool-call IDs are canonicalized, successful workspace-tool results count as

--- a/clients/adapters/mep_codex_provider.py
+++ b/clients/adapters/mep_codex_provider.py
@@ -2,8 +2,6 @@ import asyncio
 import json
 import os
 import re
-import time
-import urllib.parse
 from typing import Any
 
 from clients.shared.dm_crypto import decode_dm_envelope
@@ -284,11 +282,13 @@ class CodexProvider:
                 consumer_id,
                 require_encrypted=encrypted_inbound,
             )
-        body = {
-            "task_id": task_id,
-            "provider_id": self.client.node_id,
-            "result_payload": result_payload,
-        }
+        body = self.client.bind_connection_lease(
+            {
+                "task_id": task_id,
+                "provider_id": self.client.node_id,
+                "result_payload": result_payload,
+            }
+        )
         payload_str = json.dumps(body)
         response = await asyncio.to_thread(
             self.client.session.post,
@@ -304,9 +304,8 @@ class CodexProvider:
         import websockets
 
         while not self._stop.is_set():
-            ts = str(int(time.time()))
-            sig = urllib.parse.quote(self.client.identity.sign(self.client.node_id, ts))
-            uri = f"{self.client.ws_url}/ws/{self.client.node_id}?timestamp={ts}&signature={sig}"
+            uri = self.client.websocket_uri()
+            duplicate_rejected = False
             try:
                 async with websockets.connect(uri) as ws:
                     self._log(f"[codex-provider] websocket connected: {self.client.node_id}")
@@ -318,6 +317,10 @@ class CodexProvider:
                             continue
                         data = json.loads(raw)
                         event = data.get("event")
+                        if self.client.observe_connection_event(data):
+                            if event == "connection.rejected":
+                                duplicate_rejected = True
+                            continue
                         task = data.get("data", {})
                         if event == "new_task":
                             await self.complete_task(task)
@@ -327,7 +330,11 @@ class CodexProvider:
                             self._log(f"[codex-provider] rfc ignored: {task.get('id')}")
             except Exception as exc:
                 self._log(f"[codex-provider] websocket disconnected: {exc}")
-                await asyncio.sleep(3)
+                await asyncio.sleep(
+                    self.client.duplicate_connection_backoff_seconds
+                    if duplicate_rejected
+                    else 3
+                )
 
     async def run(self) -> None:
         registration = await self.register()

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -46,6 +46,22 @@ class MEPClient:
         self.task_channels: dict[str, str] = {}
         self._stop = asyncio.Event()
         self._active_ws = None
+        self.connection_id: Optional[str] = None
+        self.connection_epoch: Optional[int] = None
+        configured_lease_protocol = os.getenv("MEP_WS_LEASE_PROTOCOL", "v1").strip().lower()
+        self.connection_lease_protocol = (
+            "v1" if configured_lease_protocol == "v1" else "legacy"
+        )
+        self.ws_takeover = os.getenv("MEP_WS_TAKEOVER", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        self.duplicate_connection_backoff_seconds = self._positive_env_int(
+            "MEP_DUPLICATE_CONNECTION_BACKOFF_SECONDS",
+            30,
+        )
         self._heartbeat_task: asyncio.Task | None = None
         self._live_call_contexts: set[str] = set()
         self._live_call_last_seen: dict[str, float] = {}
@@ -169,6 +185,51 @@ class MEPClient:
         headers = self.identity.get_auth_headers(payload_str)
         headers["Content-Type"] = "application/json"
         return headers
+
+    def bind_connection_lease(self, payload: dict[str, Any]) -> dict[str, Any]:
+        bound = dict(payload)
+        if self.connection_id:
+            bound["connection_id"] = self.connection_id
+        return bound
+
+    def websocket_uri(self) -> str:
+        ts = str(int(time.time()))
+        if self.connection_lease_protocol != "v1":
+            query = urllib.parse.urlencode(
+                {
+                    "timestamp": ts,
+                    "signature": self.identity.sign(self.node_id, ts),
+                }
+            )
+            return f"{self.ws_url}/ws/{self.node_id}?{query}"
+        takeover = int(self.ws_takeover)
+        auth_payload = (
+            f"{self.node_id}|lease={self.connection_lease_protocol}|"
+            f"takeover={takeover}"
+        )
+        query = urllib.parse.urlencode(
+            {
+                "timestamp": ts,
+                "signature": self.identity.sign(auth_payload, ts),
+                "lease_protocol": self.connection_lease_protocol,
+                "takeover": takeover,
+            }
+        )
+        return f"{self.ws_url}/ws/{self.node_id}?{query}"
+
+    def observe_connection_event(self, data: Any) -> bool:
+        if not isinstance(data, dict):
+            return False
+        event = data.get("event")
+        if event == "connection.ready":
+            connection_id = data.get("connection_id")
+            epoch = data.get("epoch")
+            if isinstance(connection_id, str) and connection_id:
+                self.connection_id = connection_id
+            if isinstance(epoch, int) and not isinstance(epoch, bool):
+                self.connection_epoch = epoch
+            return True
+        return event == "connection.rejected"
 
     async def heartbeat_loop(self, availability: str = "online") -> None:
         while not self._stop.is_set():
@@ -1551,9 +1612,8 @@ class MEPClient:
         on_event: Optional[Callable[[dict], Awaitable[None]]] = None,
     ) -> None:
         while not self._stop.is_set():
-            ts = str(int(time.time()))
-            sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))
-            uri = f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
+            uri = self.websocket_uri()
+            duplicate_rejected = False
             try:
                 async with ws_connect(uri) as ws:
                     self._active_ws = ws
@@ -1566,6 +1626,10 @@ class MEPClient:
                             msg = await ws.recv()
                             data = json.loads(msg)
                             event = data.get("event")
+                            if self.observe_connection_event(data):
+                                if event == "connection.rejected":
+                                    duplicate_rejected = True
+                                continue
                             context_id = data.get("context_id")
                             if event == "call.ping" and isinstance(context_id, str) and context_id:
                                 await ws.send(json.dumps({"event": "call.pong", "context_id": context_id}))
@@ -1603,7 +1667,11 @@ class MEPClient:
                             await asyncio.gather(heartbeat_task, return_exceptions=True)
             except Exception:
                 self._active_ws = None
-                await asyncio.sleep(2)
+                await asyncio.sleep(
+                    self.duplicate_connection_backoff_seconds
+                    if duplicate_rejected
+                    else 2
+                )
 
     async def send_ws_event(self, payload: dict[str, Any]) -> bool:
         if self._active_ws is None:

--- a/hub/main.py
+++ b/hub/main.py
@@ -63,12 +63,128 @@ app = FastAPI(title="MEP Hub", description="The Time Exchange Clearinghouse", ve
 active_tasks: Dict[str, dict] = {}
 completed_tasks: Dict[str, dict] = {}
 connected_nodes: Dict[str, WebSocket] = {}
+node_connection_leases: Dict[str, dict[str, Any]] = {}
+node_connection_epochs: Dict[str, int] = {}
+node_duplicate_connection_rejections: Dict[str, int] = {}
+duplicate_connection_rejections_total = 0
 rate_limits: Dict[str, List[float]] = {}
 task_lock = asyncio.Lock()
 node_lock = asyncio.Lock()
 mesh_lock = asyncio.Lock()
 
 CALL_RELAY_ENABLED = os.getenv("MEP_CALL_RELAY_ENABLED", "1") not in ("0", "false", "False")
+CONNECTION_LEASE_PROTOCOL = "v1"
+ENFORCE_CONNECTION_LEASE_RESULTS = os.getenv(
+    "MEP_ENFORCE_CONNECTION_LEASE_RESULTS",
+    "true",
+).lower() in ("1", "true", "yes", "on")
+
+
+def _connection_lease_auth_payload(node_id: str, protocol: str, takeover: bool) -> Optional[str]:
+    normalized_protocol = str(protocol or "").strip().lower()
+    if normalized_protocol == CONNECTION_LEASE_PROTOCOL:
+        return f"{node_id}|lease={CONNECTION_LEASE_PROTOCOL}|takeover={int(takeover)}"
+    if normalized_protocol or takeover:
+        return None
+    return node_id
+
+
+def _public_connection_lease(lease: Optional[dict[str, Any]]) -> dict[str, Any]:
+    if not isinstance(lease, dict):
+        return {}
+    return {
+        "epoch": lease.get("epoch"),
+        "protocol": lease.get("protocol"),
+        "connected_at": lease.get("connected_at"),
+        "last_activity": lease.get("last_activity"),
+        "active": bool(lease.get("active")),
+        "takeover": bool(lease.get("takeover")),
+    }
+
+
+def _deactivate_connection_lease_locked(node_id: str) -> None:
+    lease = node_connection_leases.get(node_id)
+    if isinstance(lease, dict):
+        lease["active"] = False
+        lease["disconnected_at"] = time.time()
+
+
+async def _claim_node_connection(
+    node_id: str,
+    websocket: WebSocket,
+    *,
+    protocol: str,
+    takeover: bool,
+    client_host: Optional[str],
+) -> tuple[bool, dict[str, Any], Optional[WebSocket]]:
+    """Atomically claim one live connection owner for a cryptographic node ID."""
+    global duplicate_connection_rejections_total
+
+    now = time.time()
+    async with node_lock:
+        existing = connected_nodes.get(node_id)
+        current_lease = node_connection_leases.get(node_id)
+        if existing is not None and existing is not websocket and not takeover:
+            duplicate_connection_rejections_total += 1
+            node_duplicate_connection_rejections[node_id] = (
+                node_duplicate_connection_rejections.get(node_id, 0) + 1
+            )
+            return False, _public_connection_lease(current_lease), None
+
+        epoch = node_connection_epochs.get(node_id, 0) + 1
+        node_connection_epochs[node_id] = epoch
+        lease = {
+            "connection_id": str(uuid.uuid4()),
+            "epoch": epoch,
+            "protocol": (
+                CONNECTION_LEASE_PROTOCOL
+                if str(protocol or "").strip().lower() == CONNECTION_LEASE_PROTOCOL
+                else "legacy"
+            ),
+            "connected_at": now,
+            "last_activity": now,
+            "active": True,
+            "takeover": bool(existing is not None and takeover),
+            "client_host": client_host,
+        }
+        connected_nodes[node_id] = websocket
+        node_connection_leases[node_id] = lease
+        return True, dict(lease), existing if existing is not websocket else None
+
+
+async def _release_node_connection(node_id: str, websocket: WebSocket) -> bool:
+    """Release only when websocket still owns the node's current lease."""
+    async with node_lock:
+        if connected_nodes.get(node_id) is not websocket:
+            return False
+        del connected_nodes[node_id]
+        _deactivate_connection_lease_locked(node_id)
+        return True
+
+
+async def _close_displaced_connection(websocket: Optional[WebSocket]) -> None:
+    if websocket is None:
+        return
+    try:
+        await websocket.close(code=4410, reason="Node identity lease taken over")
+    except Exception:
+        pass
+
+
+async def _enforce_task_completion_lease(node_id: str, connection_id: Optional[str]) -> None:
+    """Reject results from displaced v1 connections while keeping legacy compatibility."""
+    if not ENFORCE_CONNECTION_LEASE_RESULTS:
+        return
+    async with node_lock:
+        lease = dict(node_connection_leases.get(node_id) or {})
+    if not lease or lease.get("protocol") != CONNECTION_LEASE_PROTOCOL:
+        return
+    expected = str(lease.get("connection_id") or "")
+    supplied = str(connection_id or "")
+    if not supplied:
+        raise HTTPException(status_code=409, detail="Active node connection lease is required")
+    if not expected or not hmac.compare_digest(expected, supplied):
+        raise HTTPException(status_code=409, detail="Stale node connection lease")
 
 
 def _hub_build_info() -> dict[str, str]:
@@ -95,6 +211,7 @@ async def _call_relay_send(node_id: str, message: dict) -> bool:
         async with node_lock:
             if connected_nodes.get(node_id) is ws:
                 del connected_nodes[node_id]
+                _deactivate_connection_lease_locked(node_id)
         return False
 
 
@@ -286,8 +403,13 @@ DEGRADED_THRESHOLD_SECONDS = float(os.getenv("MEP_DEGRADED_THRESHOLD_SECONDS", "
 
 
 async def _track_node_activity(node_id: str):
+    observed_at = time.time()
     async with node_activity_lock:
-        node_last_activity[node_id] = time.time()
+        node_last_activity[node_id] = observed_at
+    async with node_lock:
+        lease = node_connection_leases.get(node_id)
+        if isinstance(lease, dict) and lease.get("active"):
+            lease["last_activity"] = observed_at
 
 
 async def _sweep_node_activity():
@@ -1921,6 +2043,7 @@ async def _sweep_assigned_timeouts():
                         async with node_lock:
                             if connected_nodes.get(node_id) is ws:
                                 del connected_nodes[node_id]
+                                _deactivate_connection_lease_locked(node_id)
                 log_event("task_requeued_timeout", f"Task {task['task_id'][:8]} requeued after timeout", task_id=task["task_id"], consumer_id=task["consumer_id"], bounty=task["bounty"], rebroadcast_count=rebroadcast_count + 1)
                 continue
         if not db.expire_task_if_assigned(task["task_id"], now):
@@ -2052,6 +2175,9 @@ async def shutdown_hub():
     async with node_lock:
         sockets = list(connected_nodes.values())
         connected_nodes.clear()
+        for lease in node_connection_leases.values():
+            lease["active"] = False
+            lease["disconnected_at"] = time.time()
     for socket in sockets:
         try:
             await socket.close(code=1001, reason="Hub shutting down")
@@ -2449,6 +2575,7 @@ async def brainstorm_post(
             async with node_lock:
                 if connected_nodes.get(node_id) is ws:
                     del connected_nodes[node_id]
+                    _deactivate_connection_lease_locked(node_id)
     return {"status": "success", "message_id": message_id, "delivered_to": delivered_to}
 
 
@@ -2628,6 +2755,7 @@ async def action_event_post(
             async with node_lock:
                 if connected_nodes.get(node_id) is ws:
                     del connected_nodes[node_id]
+                    _deactivate_connection_lease_locked(node_id)
             return None
 
     delivery_results = await asyncio.gather(
@@ -2977,6 +3105,7 @@ async def submit_task(
                 async with node_lock:
                     if connected_nodes.get(target_node) is target_ws:
                         del connected_nodes[target_node]
+                        _deactivate_connection_lease_locked(target_node)
                 return {"status": "error", "detail": "Target node disconnected"}
         # Target offline. For zero-bounty direct messages, store-and-forward the DM
         # so it is delivered when the target reconnects (voicemail, not a dropped
@@ -3025,6 +3154,7 @@ async def submit_task(
             async with node_lock:
                 if connected_nodes.get(node_id) is ws:
                     del connected_nodes[node_id]
+                    _deactivate_connection_lease_locked(node_id)
 
     response_payload = {"status": "success", "task_id": task_id}
     if not candidate_nodes and FEDERATION_ENABLED:
@@ -3240,6 +3370,7 @@ async def _finalize_settled_task(settled: dict, task_id: str, provider_id: str, 
             async with node_lock:
                 if connected_nodes.get(consumer_id) is consumer_ws:
                     del connected_nodes[consumer_id]
+                    _deactivate_connection_lease_locked(consumer_id)
 
     return settled["response"]
 
@@ -3252,6 +3383,7 @@ async def complete_task(
 ):
     if authenticated_node != result.provider_id:
         raise HTTPException(status_code=403, detail="Cannot complete tasks on behalf of another node")
+    await _enforce_task_completion_lease(result.provider_id, result.connection_id)
 
     normalized_result_uri = _normalize_artifact_uri(result.result_uri, "result_uri")
     result_payload = result.result_payload or ""
@@ -3613,6 +3745,9 @@ async def health_check():
     db_health = db.check_database_health()
     async with node_lock:
         online_count = len(connected_nodes)
+        active_lease_count = sum(
+            1 for lease in node_connection_leases.values() if lease.get("active")
+        )
     async with registry_reconcile_lock:
         reconcile_snapshot = dict(registry_reconcile_metrics)
     async with task_lock:
@@ -3623,6 +3758,8 @@ async def health_check():
         "database": db_health,
         "metrics": {
             "connected_nodes": online_count,
+            "active_connection_leases": active_lease_count,
+            "duplicate_connection_rejections": duplicate_connection_rejections_total,
             "active_tasks": active_count,
             "completed_task_cache": completed_count,
             "registry_reconcile": reconcile_snapshot,
@@ -3652,6 +3789,10 @@ class DiagnosticResponse(BaseModel):
     last_heartbeat: Optional[float] = None
     ws_connected: bool = False
     connected_since: Optional[float] = None
+    connection_epoch: Optional[int] = None
+    connection_protocol: Optional[str] = None
+    connection_lease_active: Optional[bool] = None
+    duplicate_connections_rejected: int = 0
     last_ws_activity: Optional[float] = None
     auth_ok: Optional[bool] = None
     error: Optional[str] = None
@@ -3825,7 +3966,10 @@ async def diagnostic(
         registry = db.get_registry(node_id)
         if not registry:
             return DiagnosticResponse(error="node_not_found", node_id=node_id)
-        ws_connected = node_id in connected_nodes
+        async with node_lock:
+            ws_connected = node_id in connected_nodes
+            lease = _public_connection_lease(node_connection_leases.get(node_id))
+            duplicate_rejections = node_duplicate_connection_rejections.get(node_id, 0)
         async with node_activity_lock:
             last_ws = node_last_activity.get(node_id)
         return DiagnosticResponse(
@@ -3834,6 +3978,11 @@ async def diagnostic(
             availability=registry.get("availability"),
             last_heartbeat=registry.get("updated_at"),
             ws_connected=ws_connected,
+            connected_since=lease.get("connected_at"),
+            connection_epoch=lease.get("epoch"),
+            connection_protocol=lease.get("protocol"),
+            connection_lease_active=bool(lease.get("active")) if lease else False,
+            duplicate_connections_rejected=duplicate_rejections,
             last_ws_activity=last_ws,
         )
 
@@ -3851,7 +4000,10 @@ async def diagnostic(
         if not auth.verify_signature(pub_pem, requesting_node, ts, sig):
             raise HTTPException(status_code=401, detail="Invalid cryptographic signature.")
 
-        ws_connected = requesting_node in connected_nodes
+        async with node_lock:
+            ws_connected = requesting_node in connected_nodes
+            lease = _public_connection_lease(node_connection_leases.get(requesting_node))
+            duplicate_rejections = node_duplicate_connection_rejections.get(requesting_node, 0)
         async with node_activity_lock:
             last_ws = node_last_activity.get(requesting_node)
         registry = db.get_registry(requesting_node)
@@ -3862,7 +4014,11 @@ async def diagnostic(
             availability=registry.get("availability") if registry else None,
             last_heartbeat=registry.get("updated_at") if registry else None,
             ws_connected=ws_connected,
-            connected_since=None,
+            connected_since=lease.get("connected_at"),
+            connection_epoch=lease.get("epoch"),
+            connection_protocol=lease.get("protocol"),
+            connection_lease_active=bool(lease.get("active")) if lease else False,
+            duplicate_connections_rejected=duplicate_rejections,
             last_ws_activity=last_ws,
             auth_ok=True,
         )
@@ -4216,6 +4372,8 @@ async def websocket_endpoint(
     node_id: str,
     timestamp: Optional[str] = None,
     signature: Optional[str] = None,
+    lease_protocol: Optional[str] = None,
+    takeover: Optional[str] = None,
     x_mep_timestamp: Optional[str] = Header(default=None),
     x_mep_signature: Optional[str] = Header(default=None),
 ):
@@ -4252,16 +4410,73 @@ async def websocket_endpoint(
         await websocket.close(code=4001, reason="Unknown Node ID")
         return
 
-    if not auth.verify_signature(pub_pem, node_id, ws_timestamp, ws_signature):
+    takeover_requested = str(takeover or "").strip().lower() in ("1", "true", "yes", "on")
+    auth_payload = _connection_lease_auth_payload(
+        node_id,
+        str(lease_protocol or ""),
+        takeover_requested,
+    )
+    if auth_payload is None or not auth.verify_signature(
+        pub_pem,
+        auth_payload,
+        ws_timestamp,
+        ws_signature,
+    ):
         await websocket.close(code=4002, reason="Invalid Signature")
         return
 
     await websocket.accept()
-    async with node_lock:
-        connected_nodes[node_id] = websocket
-    db.update_registry_availability(node_id, "online", time.time())
-    await _flush_queued_dms(node_id, websocket)
+    claimed, lease, displaced = await _claim_node_connection(
+        node_id,
+        websocket,
+        protocol=str(lease_protocol or ""),
+        takeover=takeover_requested,
+        client_host=client_host,
+    )
+    if not claimed:
+        log_event(
+            "duplicate_node_connection_rejected",
+            f"Rejected duplicate live connection for {node_id}",
+            node_id=node_id,
+            current_epoch=lease.get("epoch"),
+            current_protocol=lease.get("protocol"),
+            client_host=client_host,
+        )
+        try:
+            await websocket.send_json(
+                {
+                    "event": "connection.rejected",
+                    "reason": "node_identity_already_connected",
+                    "current_epoch": lease.get("epoch"),
+                    "takeover_supported": True,
+                }
+            )
+            await websocket.close(code=4409, reason="Node identity already connected")
+        except Exception:
+            pass
+        return
+
+    if displaced is not None:
+        log_event(
+            "node_connection_taken_over",
+            f"Connection lease for {node_id} moved to epoch {lease['epoch']}",
+            node_id=node_id,
+            connection_epoch=lease["epoch"],
+            client_host=client_host,
+        )
+        await _close_displaced_connection(displaced)
     try:
+        await websocket.send_json(
+            {
+                "event": "connection.ready",
+                "connection_id": lease["connection_id"],
+                "epoch": lease["epoch"],
+                "lease_protocol": lease["protocol"],
+                "takeover": bool(lease.get("takeover")),
+            }
+        )
+        db.update_registry_availability(node_id, "online", time.time())
+        await _flush_queued_dms(node_id, websocket)
         while True:
             raw = await websocket.receive_text()
             await _track_node_activity(node_id)
@@ -4270,9 +4485,17 @@ async def websocket_endpoint(
                 if event is not None:
                     await call_relay.handle(node_id, event)
     except WebSocketDisconnect:
-        async with node_lock:
-            if connected_nodes.get(node_id) is websocket:
-                del connected_nodes[node_id]
-        db.update_registry_availability(node_id, "offline", time.time())
-        if CALL_RELAY_ENABLED:
-            await call_relay.on_node_disconnect(node_id)
+        pass
+    except Exception as exc:
+        log_event(
+            "node_websocket_error",
+            f"WebSocket loop failed for {node_id}: {exc}",
+            node_id=node_id,
+            connection_epoch=lease.get("epoch"),
+        )
+    finally:
+        released = await _release_node_connection(node_id, websocket)
+        if released:
+            db.update_registry_availability(node_id, "offline", time.time())
+            if CALL_RELAY_ENABLED:
+                await call_relay.on_node_disconnect(node_id)

--- a/hub/models.py
+++ b/hub/models.py
@@ -38,6 +38,7 @@ class TaskBid(BaseModel):
 class TaskResult(BaseModel):
     task_id: str
     provider_id: str
+    connection_id: Optional[str] = Field(default=None, max_length=128)
     result_payload: Optional[str] = None
     result_uri: Optional[str] = None  # IPFS or HTTP link to result payload
     in_reply_to: Optional[str] = None

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -5717,6 +5717,17 @@ class RuntimeNode:
         self.call_reconnect_grace_ms = _env_positive_int("MEP_CALL_RECONNECT_GRACE_MS", 60000)
         self._ws: Any = None
         self._ws_ready = asyncio.Event()
+        self._connection_id = ""
+        self._connection_epoch: Optional[int] = None
+        configured_lease_protocol = os.getenv("MEP_WS_LEASE_PROTOCOL", "v1").strip().lower()
+        self._connection_lease_protocol = (
+            "v1" if configured_lease_protocol == "v1" else "legacy"
+        )
+        self._ws_takeover = _env_truthy("MEP_WS_TAKEOVER", "0")
+        self._duplicate_connection_backoff_seconds = _env_positive_int(
+            "MEP_DUPLICATE_CONNECTION_BACKOFF_SECONDS",
+            30,
+        )
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._pending_call_bridges: dict[str, asyncio.Future[dict[str, Any]]] = {}
         self._live_call_peers: dict[str, str] = {}
@@ -6223,6 +6234,7 @@ class RuntimeNode:
                 "task_id": task_id,
                 "provider_id": self.node_id,
                 "result_payload": result_payload,
+                **({"connection_id": self._connection_id} if self._connection_id else {}),
             }
         )
         code, _body, raw = _safe_request(
@@ -7564,12 +7576,48 @@ class RuntimeNode:
 
     def _ws_uri(self) -> str:
         ts = str(int(time.time()))
-        sig = urllib.parse.quote(self.identity.sign(self.node_id, ts))
-        return f"{self.ws_url}/ws/{self.node_id}?timestamp={ts}&signature={sig}"
+        if self._connection_lease_protocol != "v1":
+            query = urllib.parse.urlencode(
+                {
+                    "timestamp": ts,
+                    "signature": self.identity.sign(self.node_id, ts),
+                }
+            )
+            return f"{self.ws_url}/ws/{self.node_id}?{query}"
+        takeover = int(self._ws_takeover)
+        auth_payload = (
+            f"{self.node_id}|lease={self._connection_lease_protocol}|"
+            f"takeover={takeover}"
+        )
+        query = urllib.parse.urlencode(
+            {
+                "timestamp": ts,
+                "signature": self.identity.sign(auth_payload, ts),
+                "lease_protocol": self._connection_lease_protocol,
+                "takeover": takeover,
+            }
+        )
+        return f"{self.ws_url}/ws/{self.node_id}?{query}"
 
     async def handle_ws_event(self, data: dict[str, Any]) -> None:
         event = data.get("event")
-        if event == "rfc":
+        if event == "connection.ready":
+            connection_id = data.get("connection_id")
+            epoch = data.get("epoch")
+            if isinstance(connection_id, str) and connection_id:
+                self._connection_id = connection_id
+            if isinstance(epoch, int) and not isinstance(epoch, bool):
+                self._connection_epoch = epoch
+            print(
+                f"[mep run] connection lease ready node={self.node_id} "
+                f"epoch={self._connection_epoch}"
+            )
+        elif event == "connection.rejected":
+            print(
+                f"[mep run] duplicate connection rejected node={self.node_id} "
+                f"current_epoch={data.get('current_epoch')}"
+            )
+        elif event == "rfc":
             task = data.get("data", {})
             task_id = str(task.get("id") or "")
             if task_id and self.should_bid(task):
@@ -7593,6 +7641,16 @@ class RuntimeNode:
                 continue
             await self.handle_ws_event(json.loads(msg))
 
+    async def _prime_connection_lease(self, ws: Any) -> bool:
+        """Consume Hub's lease handshake before recovering or completing tasks."""
+        try:
+            msg = await asyncio.wait_for(ws.recv(), timeout=5.0)
+        except asyncio.TimeoutError:
+            return True
+        data = json.loads(msg)
+        await self.handle_ws_event(data)
+        return data.get("event") != "connection.rejected"
+
     async def run_forever(self) -> int:
         try:
             try:
@@ -7614,15 +7672,22 @@ class RuntimeNode:
                 try:
                     async with ws_connect(uri) as ws:
                         self._ws = ws
-                        self._ws_ready.set()
                         print(f"[mep run] connected ws node={self.node_id}")
+                        if not await self._prime_connection_lease(ws):
+                            await asyncio.sleep(self._duplicate_connection_backoff_seconds)
+                            continue
+                        self._ws_ready.set()
                         await self._recover_pending_tasks()
                         await self._recv_loop(ws)
                 except KeyboardInterrupt:
                     self.running = False
                 except Exception as exc:  # noqa: BLE001
                     print(f"[mep run] websocket reconnect after error: {exc}")
-                    await asyncio.sleep(3.0)
+                    await asyncio.sleep(
+                        self._duplicate_connection_backoff_seconds
+                        if getattr(exc, "code", None) == 4409
+                        else 3.0
+                    )
                 finally:
                     self._ws = None
                     self._ws_ready.clear()

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -7,6 +7,7 @@ No running server or Postgres needed; uses SQLite backend automatically.
 """
 
 import base64
+import asyncio
 
 from contextlib import contextmanager
 
@@ -80,6 +81,19 @@ class _FakeWebSocket:
     async def send_json(self, payload):
 
         self.sent.append(payload)
+
+
+class _LeaseWebSocket(_FakeWebSocket):
+
+    def __init__(self):
+
+        super().__init__()
+
+        self.closed = []
+
+    async def close(self, code=1000, reason=None):
+
+        self.closed.append({"code": code, "reason": reason})
 
 
 
@@ -4297,3 +4311,182 @@ class TestAutomatedVerifier(unittest.TestCase):
 
 
         self.assertEqual(verify_resp.status_code, 400, f"Expected rejection: {verify_resp.text}")
+
+
+class TestNodeConnectionLeases(unittest.TestCase):
+
+    def setUp(self):
+
+        main.connected_nodes.clear()
+
+        main.node_connection_leases.clear()
+
+        main.node_connection_epochs.clear()
+
+        main.node_duplicate_connection_rejections.clear()
+
+        main.duplicate_connection_rejections_total = 0
+
+    def tearDown(self):
+
+        main.connected_nodes.clear()
+
+        main.node_connection_leases.clear()
+
+        main.node_connection_epochs.clear()
+
+        main.node_duplicate_connection_rejections.clear()
+
+        main.duplicate_connection_rejections_total = 0
+
+    def test_first_owner_wins_and_duplicate_is_observable(self):
+
+        first = _LeaseWebSocket()
+
+        duplicate = _LeaseWebSocket()
+
+        claimed, lease, displaced = asyncio.run(
+            main._claim_node_connection(
+                "node_lease",
+                first,
+                protocol="v1",
+                takeover=False,
+                client_host="127.0.0.1",
+            )
+        )
+
+        duplicate_claimed, current, duplicate_displaced = asyncio.run(
+            main._claim_node_connection(
+                "node_lease",
+                duplicate,
+                protocol="v1",
+                takeover=False,
+                client_host="127.0.0.2",
+            )
+        )
+
+        self.assertTrue(claimed)
+
+        self.assertEqual(lease["epoch"], 1)
+
+        self.assertIsNone(displaced)
+
+        self.assertFalse(duplicate_claimed)
+
+        self.assertEqual(current["epoch"], 1)
+
+        self.assertIsNone(duplicate_displaced)
+
+        self.assertIs(main.connected_nodes["node_lease"], first)
+
+        self.assertEqual(main.node_duplicate_connection_rejections["node_lease"], 1)
+
+        self.assertEqual(main.duplicate_connection_rejections_total, 1)
+
+    def test_signed_takeover_displaces_owner_without_stale_cleanup(self):
+
+        first = _LeaseWebSocket()
+
+        replacement = _LeaseWebSocket()
+
+        claimed, first_lease, _ = asyncio.run(
+            main._claim_node_connection(
+                "node_lease",
+                first,
+                protocol="v1",
+                takeover=False,
+                client_host=None,
+            )
+        )
+
+        replacement_claimed, replacement_lease, displaced = asyncio.run(
+            main._claim_node_connection(
+                "node_lease",
+                replacement,
+                protocol="v1",
+                takeover=True,
+                client_host=None,
+            )
+        )
+
+        asyncio.run(main._close_displaced_connection(displaced))
+
+        stale_released = asyncio.run(main._release_node_connection("node_lease", first))
+
+        self.assertTrue(claimed)
+
+        self.assertTrue(replacement_claimed)
+
+        self.assertEqual(first_lease["epoch"], 1)
+
+        self.assertEqual(replacement_lease["epoch"], 2)
+
+        self.assertTrue(replacement_lease["takeover"])
+
+        self.assertIs(displaced, first)
+
+        self.assertEqual(first.closed[0]["code"], 4410)
+
+        self.assertFalse(stale_released)
+
+        self.assertIs(main.connected_nodes["node_lease"], replacement)
+
+        self.assertTrue(main.node_connection_leases["node_lease"]["active"])
+
+    def test_task_result_requires_current_v1_connection_id(self):
+
+        websocket = _LeaseWebSocket()
+
+        _, lease, _ = asyncio.run(
+            main._claim_node_connection(
+                "node_lease",
+                websocket,
+                protocol="v1",
+                takeover=False,
+                client_host=None,
+            )
+        )
+
+        with self.assertRaises(main.HTTPException) as missing:
+
+            asyncio.run(main._enforce_task_completion_lease("node_lease", None))
+
+        with self.assertRaises(main.HTTPException) as stale:
+
+            asyncio.run(main._enforce_task_completion_lease("node_lease", "old-connection"))
+
+        asyncio.run(
+            main._enforce_task_completion_lease(
+                "node_lease",
+                lease["connection_id"],
+            )
+        )
+
+        self.assertEqual(missing.exception.status_code, 409)
+
+        self.assertEqual(stale.exception.status_code, 409)
+
+    def test_takeover_intent_is_cryptographically_bound(self):
+
+        self.assertEqual(
+            main._connection_lease_auth_payload("node_lease", "v1", False),
+            "node_lease|lease=v1|takeover=0",
+        )
+
+        self.assertEqual(
+            main._connection_lease_auth_payload("node_lease", "v1", True),
+            "node_lease|lease=v1|takeover=1",
+        )
+
+        self.assertEqual(
+            main._connection_lease_auth_payload("node_lease", "", False),
+            "node_lease",
+        )
+
+        self.assertIsNone(
+            main._connection_lease_auth_payload("node_lease", "", True)
+        )
+
+        self.assertIsNone(
+            main._connection_lease_auth_payload("node_lease", "v2", False)
+        )

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import threading
 import unittest
+import urllib.parse
 from typing import Any, Optional
 from unittest.mock import AsyncMock, patch
 
@@ -2023,6 +2024,75 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
 
 
 class TestRuntimeWebSocketLoop(unittest.TestCase):
+    def test_v1_websocket_uri_signs_takeover_intent(self):
+        node = _runtime_node()
+        node._ws_takeover = True  # noqa: SLF001
+
+        uri = urllib.parse.urlparse(node._ws_uri())  # noqa: SLF001
+        query = urllib.parse.parse_qs(uri.query)
+
+        self.assertEqual(query["lease_protocol"], ["v1"])
+        self.assertEqual(query["takeover"], ["1"])
+        self.assertEqual(query["signature"], ["sig"])
+
+    def test_legacy_websocket_uri_supports_rolling_hub_upgrade(self):
+        node = _runtime_node()
+        node._connection_lease_protocol = "legacy"  # noqa: SLF001
+
+        uri = urllib.parse.urlparse(node._ws_uri())  # noqa: SLF001
+        query = urllib.parse.parse_qs(uri.query)
+
+        self.assertNotIn("lease_protocol", query)
+        self.assertNotIn("takeover", query)
+        self.assertEqual(query["signature"], ["sig"])
+
+    def test_connection_ready_updates_result_fence(self):
+        node = _runtime_node()
+
+        asyncio.run(
+            node.handle_ws_event(
+                {
+                    "event": "connection.ready",
+                    "connection_id": "connection-runtime",
+                    "epoch": 9,
+                }
+            )
+        )
+
+        self.assertEqual(node._connection_id, "connection-runtime")  # noqa: SLF001
+        self.assertEqual(node._connection_epoch, 9)  # noqa: SLF001
+
+    def test_completion_includes_current_connection_id(self):
+        node = _runtime_node()
+        node._connection_id = "connection-runtime"  # noqa: SLF001
+
+        with patch(
+            "node.mep_runtime._safe_request",
+            return_value=(200, {"status": "completed"}, ""),
+        ) as request_mock:
+            node.complete("task-runtime", "done")
+
+        payload = json.loads(request_mock.call_args.kwargs["data_body"])
+        self.assertEqual(payload["connection_id"], "connection-runtime")
+
+    def test_duplicate_lease_handshake_stops_pending_task_recovery(self):
+        node = _runtime_node()
+        ws = _FakeWebSocket(
+            [
+                json.dumps(
+                    {
+                        "event": "connection.rejected",
+                        "reason": "node_identity_already_connected",
+                        "current_epoch": 4,
+                    }
+                )
+            ]
+        )
+
+        accepted = asyncio.run(node._prime_connection_lease(ws))  # noqa: SLF001
+
+        self.assertFalse(accepted)
+
     def test_idle_timeout_pings_without_reconnecting(self):
         node = _runtime_node()
         task_payload = json.dumps({"event": "rfc", "data": {"id": "task_compute", "bounty": 1.0}})
@@ -2046,6 +2116,7 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         async def _run() -> asyncio.Task:
             with (
                 patch.object(node, "register", return_value=(True, "registered")),
+                patch.object(node, "_prime_connection_lease", new=AsyncMock(return_value=True)),
                 patch.object(node, "_recv_loop", side_effect=_recv_loop),
                 patch("node.ws_connect.ws_connect", return_value=_FakeConnectContext(_FakeWebSocket([]))),
                 patch("builtins.print") as print_mock,
@@ -2357,6 +2428,7 @@ class TestRuntimeWebSocketLoop(unittest.TestCase):
         async def _run() -> int:
             with (
                 patch.object(node, "register", return_value=(True, "registered")),
+                patch.object(node, "_prime_connection_lease", new=AsyncMock(return_value=True)),
                 patch.object(node, "_recover_pending_tasks", new=AsyncMock()) as recover_mock,
                 patch.object(node, "_recv_loop", side_effect=_recv_loop),
                 patch("node.ws_connect.ws_connect", return_value=_FakeConnectContext(_FakeWebSocket([]))),

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
+import os
 import unittest
+import urllib.parse
 from unittest.mock import patch
 
 from clients.shared.mep_client import MEPClient
@@ -64,6 +66,94 @@ class _SelectivelyFailingWebSocket(_FakeWebSocket):
 
 
 class TestSharedMEPClient(unittest.TestCase):
+    def test_websocket_uri_binds_takeover_to_v1_signature(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch.dict(os.environ, {"MEP_WS_TAKEOVER": "1"}, clear=False),
+        ):
+            client = MEPClient("unused.pem")
+            uri = urllib.parse.urlparse(client.websocket_uri())
+
+        query = urllib.parse.parse_qs(uri.query)
+        self.assertEqual(query["lease_protocol"], ["v1"])
+        self.assertEqual(query["takeover"], ["1"])
+        self.assertEqual(
+            query["signature"],
+            [f"sig:node_consumer|lease=v1|takeover=1:{query['timestamp'][0]}"],
+        )
+
+    def test_legacy_websocket_uri_supports_rolling_hub_upgrade(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch.dict(os.environ, {"MEP_WS_LEASE_PROTOCOL": "legacy"}, clear=False),
+        ):
+            client = MEPClient("unused.pem")
+            uri = urllib.parse.urlparse(client.websocket_uri())
+
+        query = urllib.parse.parse_qs(uri.query)
+        self.assertNotIn("lease_protocol", query)
+        self.assertNotIn("takeover", query)
+        self.assertEqual(
+            query["signature"],
+            [f"sig:node_consumer:{query['timestamp'][0]}"],
+        )
+
+    def test_connection_ready_binds_task_results_to_current_lease(self):
+        with patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()):
+            client = MEPClient("unused.pem")
+
+        consumed = client.observe_connection_event(
+            {
+                "event": "connection.ready",
+                "connection_id": "connection-123",
+                "epoch": 7,
+            }
+        )
+
+        self.assertTrue(consumed)
+        self.assertEqual(client.connection_id, "connection-123")
+        self.assertEqual(client.connection_epoch, 7)
+        self.assertEqual(
+            client.bind_connection_lease({"task_id": "task-1"}),
+            {"task_id": "task-1", "connection_id": "connection-123"},
+        )
+
+    def test_listener_consumes_lease_handshake_before_application_events(self):
+        ws = _ScriptedWebSocket(
+            [
+                {
+                    "event": "connection.ready",
+                    "connection_id": "connection-123",
+                    "epoch": 3,
+                },
+                {"event": "call.ping", "context_id": "ctx-ping"},
+            ]
+        )
+        observed = []
+
+        async def _run():
+            with (
+                patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+                patch("clients.shared.mep_client.ws_connect", return_value=ws),
+            ):
+                client = MEPClient("unused.pem")
+                client.heartbeat_seconds = 0
+
+                async def on_result(_data):
+                    return None
+
+                async def on_event(data):
+                    observed.append(data)
+                    client.stop()
+
+                await client.listen_results(on_result, on_event)
+                return client
+
+        client = asyncio.run(_run())
+        self.assertEqual(client.connection_id, "connection-123")
+        self.assertEqual(client.connection_epoch, 3)
+        self.assertEqual([event["event"] for event in observed], ["call.ping"])
+
     def test_submit_task_uses_spec_shaped_envelope(self):
         with (
             patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),


### PR DESCRIPTION
## Summary
- enforce one active WebSocket owner per cryptographic node ID
- support signed, explicit takeover with connection epochs and stale-result fencing
- add rolling-upgrade compatibility, diagnostics, official runtime/client support, and regression coverage

## Validation
- python -m ruff check hub/main.py hub/models.py clients/shared/mep_client.py clients/adapters/mep_codex_provider.py node/mep_runtime.py tests/test_hub_api.py tests/test_node_runtime.py tests/test_shared_mep_client.py
- python -m pytest -q (623 passed, 1 skipped)