### PR TITLE
fix: normalize runtime failure responses

### DIFF
--- a/hub/main.py
+++ b/hub/main.py
@@ -620,6 +620,34 @@ def _normalize_error_detail(detail):
         return detail
     return str(detail)
 
+
+def _safe_validation_errors(exc: RequestValidationError) -> list[dict[str, Any]]:
+    """Return stable 422 details without echoing raw request bodies."""
+    safe_errors: list[dict[str, Any]] = []
+    for error in exc.errors():
+        location = error.get("loc")
+        if isinstance(location, (list, tuple)):
+            safe_location = [
+                value if isinstance(value, (str, int)) else str(value)
+                for value in location
+            ]
+        else:
+            safe_location = [str(location)] if location is not None else []
+        safe_error: dict[str, Any] = {
+            "type": str(error.get("type") or "validation_error"),
+            "loc": safe_location,
+            "msg": str(error.get("msg") or "Request validation failed"),
+        }
+        context = error.get("ctx")
+        if isinstance(context, dict) and context:
+            safe_error["ctx"] = {
+                str(key): str(value)
+                for key, value in context.items()
+            }
+        safe_errors.append(safe_error)
+    return safe_errors
+
+
 @app.exception_handler(HTTPException)
 async def http_exception_handler(_: Request, exc: HTTPException):
     return JSONResponse(
@@ -631,7 +659,7 @@ async def http_exception_handler(_: Request, exc: HTTPException):
 async def validation_exception_handler(_: Request, exc: RequestValidationError):
     return JSONResponse(
         status_code=422,
-        content={"status": "error", "detail": exc.errors()}
+        content={"status": "error", "detail": _safe_validation_errors(exc)}
     )
 
 @app.exception_handler(Exception)

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -163,6 +163,12 @@ def _is_adapter_error(text: str) -> bool:
             detail,
         ):
             return True
+        if re.match(
+            r"^[a-z0-9][a-z0-9._:/ +()-]{0,79}\s+timed out"
+            r"(?:\s+after\s+\d+(?:\.\d+)?s?|$)",
+            detail,
+        ):
+            return True
     if lowered.startswith(
         (
             "[codex-cli] app-server inference failed:",

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -4313,6 +4313,76 @@ class TestAutomatedVerifier(unittest.TestCase):
         self.assertEqual(verify_resp.status_code, 400, f"Expected rejection: {verify_resp.text}")
 
 
+class TestValidationErrorResponses(unittest.TestCase):
+
+    def test_raw_bytes_are_removed_from_validation_error_response(self):
+
+        error = main.RequestValidationError(
+            [
+                {
+                    "type": "model_attributes_type",
+                    "loc": ("body",),
+                    "msg": "Input should be a valid dictionary",
+                    "input": b'{"signed":"private task body"}',
+                }
+            ],
+            body=b'{"signed":"private task body"}',
+        )
+
+        response = asyncio.run(main.validation_exception_handler(None, error))
+
+        payload = json.loads(response.body.decode("utf-8"))
+
+        self.assertEqual(response.status_code, 422)
+
+        self.assertEqual(payload["status"], "error")
+
+        self.assertEqual(
+            payload["detail"],
+            [
+                {
+                    "type": "model_attributes_type",
+                    "loc": ["body"],
+                    "msg": "Input should be a valid dictionary",
+                }
+            ],
+        )
+
+        self.assertNotIn("private task body", response.body.decode("utf-8"))
+
+    def test_signed_json_without_content_type_returns_422_not_500(self):
+
+        private_key, pub_pem, node_id = _make_identity()
+
+        _register(pub_pem)
+
+        body = json.dumps(
+            {
+                "task_id": "missing-task",
+                "provider_id": node_id,
+                "result_payload": "done",
+            }
+        )
+
+        headers = _auth_headers(private_key, node_id, body)
+
+        headers.pop("Content-Type")
+
+        response = client.post(
+            "/tasks/complete",
+            content=body.encode("utf-8"),
+            headers=headers,
+        )
+
+        self.assertEqual(response.status_code, 422, response.text)
+
+        payload = response.json()
+
+        self.assertEqual(payload["status"], "error")
+
+        self.assertNotIn("input", payload["detail"][0])
+
+
 class TestNodeConnectionLeases(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -4033,7 +4033,28 @@ class TestAdapterErrorDetection(unittest.TestCase):
         )
         self.assertTrue(mep_runtime._is_adapter_error("[codex-cli] inference failed: invalid UTF-8"))  # noqa: SLF001
         self.assertTrue(mep_runtime._is_adapter_error("[codex-cli] inference timed out after 60s"))  # noqa: SLF001
+        self.assertTrue(mep_runtime._is_adapter_error("[minimaxi] MiniMax-M3 timed out"))  # noqa: SLF001
         self.assertTrue(mep_runtime._is_adapter_error(""))  # noqa: SLF001
+
+    def test_provider_model_timeout_publishes_failed_action_terminal(self):
+        node = _runtime_node()
+        node._task_action_contexts["task-timeout"] = {  # noqa: SLF001
+            "spec_version": "mep.action.v1",
+            "context_id": "action-context-timeout",
+            "action_id": "review-timeout",
+        }
+
+        with (
+            patch(
+                "node.mep_runtime._safe_request",
+                return_value=(200, {"status": "completed"}, ""),
+            ),
+            patch.object(node, "_schedule_action_event") as event_mock,
+        ):
+            node.complete("task-timeout", "[minimaxi] MiniMax-M3 timed out")
+
+        self.assertEqual(event_mock.call_args.args[1], "action.failed")
+        self.assertEqual(event_mock.call_args.kwargs["phase"], "complete")
 
     def test_is_adapter_error_allows_real_reviews(self):
         self.assertFalse(  # noqa: SLF001


### PR DESCRIPTION
## Summary
- classify provider/model timeout sentinels as adapter failures so action timelines terminate with action.failed
- sanitize request-validation details and omit raw input bodies so malformed requests return stable 422 responses
- add exact regression coverage for the production timeout and missing-content-type cases

## Validation
- targeted regressions: 5 passed
- full suite: 626 passed, 1 skipped
- Ruff and git diff checks clean