### PR TITLE
feat: add autonomous MEP_NS purchase policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ MEP_REVIEW_MAX_CHARS=4000
 # synthesis turn is tool-free and provider-neutral.
 MEP_AGENTIC_MAX_TOOL_CALLS=6
 MEP_AGENTIC_CALL_TIMEOUT_SECONDS=45
+# Local autonomous purchasing policy. Integer MEP_NS only; zero hard caps
+# intentionally disable autonomous paid work until the owner opts in.
+MEP_PURCHASE_MAX_TOTAL_NS=0
+MEP_PURCHASE_MAX_PER_PROVIDER_NS=0
+MEP_PURCHASE_MIN_RESERVE_NS=0
+# Optional soft threshold inside the hard limits:
+# MEP_PURCHASE_HUMAN_APPROVAL_ABOVE_NS=2000000000
 # Run the PR's own linters/tests inside the isolated per-bridge workspace and feed
 # the results to the reviewer. Executes PR code, so keep it limited to isolated workspaces.
 MEP_REVIEW_RUN_CHECKS=false

--- a/README.md
+++ b/README.md
@@ -78,6 +78,42 @@ Humans should think and read balances in `SECONDS`. Protocol messages use intege
 - Raw `bounty_ns` values should only appear in protocol/debug views, clearly labeled as `MEP_NS`.
 - `bounty_ns` is non-negative. Direction is represented by `payment_direction`, not by a negative wire amount.
 
+### Autonomous Purchase Preflight
+
+AI agents may choose and negotiate provider offers, but the requesting runtime
+must enforce owner limits before it submits a paid compute task. The local
+policy gate uses only integer `MEP_NS`; it never sends the private owner policy
+to the Hub.
+
+```bash
+python -m node.mep_runtime \
+  --hub-url https://mep-hub.example.com \
+  --key-path .mep/my-node.pem \
+  budget \
+  --price-ns 1000000000 \
+  --provider-count 3 \
+  --max-total-price-ns 3000000000 \
+  --max-price-per-provider-ns 1000000000 \
+  --minimum-reserve-ns 1000000000
+```
+
+Omit `--price-ns` and pass `--capability code_review` to use the median from
+recent released compute settlements. The runtime requires at least five
+settled samples by default (`--minimum-samples` can raise that bar). If enough
+real settlement data does not exist, MEP requires an explicit owner-approved
+quote; it does not invent a universal price.
+
+The equivalent environment-policy boundaries are:
+
+- `MEP_PURCHASE_MAX_TOTAL_NS`
+- `MEP_PURCHASE_MAX_PER_PROVIDER_NS`
+- `MEP_PURCHASE_MIN_RESERVE_NS`
+- `MEP_PURCHASE_HUMAN_APPROVAL_ABOVE_NS`
+
+Autonomous paid work is fail-closed by default because the hard maximums
+default to zero. Human approval can cross the configured approval threshold,
+but it does not silently override hard price or reserve limits.
+
 ### Financial API Migration
 
 The canonical financial API now lives under `/v2/...` and uses `*_ns` string

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ The equivalent environment-policy boundaries are:
 Autonomous paid work is fail-closed by default because the hard maximums
 default to zero. Human approval can cross the configured approval threshold,
 but it does not silently override hard price or reserve limits.
+Paid submissions through one `MEPClient` instance serialize preflight and
+submission so concurrent calls cannot reuse the same reserve snapshot. The Hub
+still performs the final atomic balance and escrow check; cross-process
+periodic-budget enforcement remains a later owner-policy protocol slice.
 
 ### Financial API Migration
 

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -52,6 +52,7 @@ class MEPClient:
         self.session.trust_env = False
         self.task_channels: dict[str, str] = {}
         self._stop = asyncio.Event()
+        self._purchase_lock = asyncio.Lock()
         self._active_ws = None
         self.connection_id: Optional[str] = None
         self.connection_epoch: Optional[int] = None
@@ -500,6 +501,46 @@ class MEPClient:
         return {"status_code": 200, "json": decision.as_wire_dict()}
 
     async def submit_compute_task_ns(
+        self,
+        payload: str,
+        price_ns: str | int,
+        *,
+        policy: OwnerPurchasePolicy,
+        model_requirement: Optional[str] = None,
+        target_node: Optional[str] = None,
+        expected_output: Optional[dict[str, Any]] = None,
+        intent_type: str = "analysis.request",
+        intent_priority: Optional[str] = None,
+        task_title: Optional[str] = None,
+        task_inputs: Optional[dict[str, Any]] = None,
+        payload_uri: Optional[str] = None,
+        expires_in_seconds: Optional[int] = None,
+        bargaining_round: int = 0,
+        human_approved: bool = False,
+        idempotency_key: Optional[str] = None,
+    ) -> dict:
+        """Serialize policy preflight and submission for this client instance."""
+
+        async with self._purchase_lock:
+            return await self._submit_compute_task_ns_unlocked(
+                payload,
+                price_ns,
+                policy=policy,
+                model_requirement=model_requirement,
+                target_node=target_node,
+                expected_output=expected_output,
+                intent_type=intent_type,
+                intent_priority=intent_priority,
+                task_title=task_title,
+                task_inputs=task_inputs,
+                payload_uri=payload_uri,
+                expires_in_seconds=expires_in_seconds,
+                bargaining_round=bargaining_round,
+                human_approved=human_approved,
+                idempotency_key=idempotency_key,
+            )
+
+    async def _submit_compute_task_ns_unlocked(
         self,
         payload: str,
         price_ns: str | int,

--- a/clients/shared/mep_client.py
+++ b/clients/shared/mep_client.py
@@ -11,6 +11,13 @@ import requests
 from clients.shared.dm_crypto import decode_dm_envelope, decrypt_dm_payload, encode_dm_envelope, encrypt_dm_payload
 from clients.shared.identity import MEPIdentity
 from clients.shared.manifest import load_manifest
+from clients.shared.purchase_policy import (
+    CURRENCY_MEP_NS,
+    OwnerPurchasePolicy,
+    PurchasePolicyError,
+    evaluate_purchase,
+    parse_non_negative_ns,
+)
 from node.task_envelope import build_task_envelope
 from node.ws_connect import ws_connect
 
@@ -426,6 +433,183 @@ class MEPClient:
             timeout=20,
         )
         return {"status_code": response.status_code, "json": response.json()}
+
+    async def get_balance_ns(self) -> dict:
+        """Read the canonical v2 balance without a float boundary conversion."""
+
+        payload_str = ""
+        headers = self._auth_headers(payload_str)
+        response = await asyncio.to_thread(
+            self.session.get,
+            f"{self.hub_url}/v2/balance/{self.node_id}",
+            headers=headers,
+            timeout=20,
+        )
+        return {"status_code": response.status_code, "json": response.json()}
+
+    async def evaluate_purchase_plan(
+        self,
+        provider_prices_ns: list[str | int],
+        policy: OwnerPurchasePolicy,
+        *,
+        bargaining_round: int = 0,
+        human_approved: bool = False,
+    ) -> dict:
+        """Evaluate AI-selected quotes against the local owner policy.
+
+        This is a preflight gate. The Hub remains the final atomic balance and
+        escrow authority when the task is submitted.
+        """
+
+        balance_response = await self.get_balance_ns()
+        if balance_response["status_code"] != 200:
+            return {
+                "status_code": balance_response["status_code"],
+                "json": {
+                    "status": "rejected",
+                    "reason": "balance_lookup_failed",
+                    "detail": balance_response.get("json"),
+                },
+            }
+        balance_payload = balance_response.get("json") or {}
+        if balance_payload.get("currency") != CURRENCY_MEP_NS:
+            return {
+                "status_code": 502,
+                "json": {
+                    "status": "rejected",
+                    "reason": "unexpected_balance_currency",
+                },
+            }
+        try:
+            decision = evaluate_purchase(
+                balance_ns=balance_payload.get("balance_ns"),
+                provider_prices_ns=provider_prices_ns,
+                policy=policy,
+                bargaining_round=bargaining_round,
+                human_approved=human_approved,
+            )
+        except PurchasePolicyError as exc:
+            return {
+                "status_code": 400,
+                "json": {
+                    "status": "rejected",
+                    "reason": "invalid_purchase_plan",
+                    "detail": str(exc),
+                },
+            }
+        return {"status_code": 200, "json": decision.as_wire_dict()}
+
+    async def submit_compute_task_ns(
+        self,
+        payload: str,
+        price_ns: str | int,
+        *,
+        policy: OwnerPurchasePolicy,
+        model_requirement: Optional[str] = None,
+        target_node: Optional[str] = None,
+        expected_output: Optional[dict[str, Any]] = None,
+        intent_type: str = "analysis.request",
+        intent_priority: Optional[str] = None,
+        task_title: Optional[str] = None,
+        task_inputs: Optional[dict[str, Any]] = None,
+        payload_uri: Optional[str] = None,
+        expires_in_seconds: Optional[int] = None,
+        bargaining_round: int = 0,
+        human_approved: bool = False,
+        idempotency_key: Optional[str] = None,
+    ) -> dict:
+        """Submit paid compute only after deterministic local authorization."""
+
+        try:
+            canonical_price_ns = parse_non_negative_ns(price_ns, "price_ns")
+        except PurchasePolicyError as exc:
+            return {
+                "status_code": 400,
+                "json": {
+                    "status": "rejected",
+                    "reason": "invalid_price",
+                    "detail": str(exc),
+                },
+            }
+        if canonical_price_ns == 0:
+            return {
+                "status_code": 400,
+                "json": {
+                    "status": "rejected",
+                    "reason": "compute_price_must_be_positive",
+                },
+            }
+
+        authorization = await self.evaluate_purchase_plan(
+            [canonical_price_ns],
+            policy,
+            bargaining_round=bargaining_round,
+            human_approved=human_approved,
+        )
+        authorization_payload = authorization.get("json") or {}
+        if authorization["status_code"] != 200:
+            return authorization
+        if authorization_payload.get("status") != "approved":
+            return {
+                "status_code": (
+                    428
+                    if authorization_payload.get("status") == "approval_required"
+                    else 403
+                ),
+                "json": {
+                    **authorization_payload,
+                    "local_policy": True,
+                },
+            }
+
+        task_body: dict[str, Any] = {
+            "instructions": payload,
+            "expected_output": expected_output or {"result_type": "text"},
+        }
+        if task_title:
+            task_body["title"] = task_title
+        if task_inputs:
+            task_body["inputs"] = task_inputs
+        intent: dict[str, Any] = {"type": intent_type}
+        if intent_priority:
+            intent["priority"] = intent_priority
+        body: dict[str, Any] = {
+            "source": {"node_id": self.node_id},
+            "intent": intent,
+            "task": task_body,
+            "economics": {
+                "bounty_ns": str(canonical_price_ns),
+                "currency": CURRENCY_MEP_NS,
+                "market": "compute",
+                "payment_direction": "sender_to_receiver",
+            },
+        }
+        if target_node or model_requirement:
+            body["routing"] = {}
+            if target_node:
+                body["routing"]["target_node_id"] = target_node
+            if model_requirement:
+                body["routing"]["target_capability"] = model_requirement
+        if payload_uri is not None:
+            body["payload_uri"] = payload_uri
+        if expires_in_seconds is not None:
+            body["expires_in_seconds"] = expires_in_seconds
+
+        payload_str = json.dumps(body)
+        headers = self._auth_headers(payload_str)
+        if idempotency_key:
+            headers["X-MEP-Idempotency-Key"] = idempotency_key
+        response = await asyncio.to_thread(
+            self.session.post,
+            f"{self.hub_url}/v2/tasks/submit",
+            data=payload_str,
+            headers=headers,
+            timeout=20,
+        )
+        result = response.json()
+        if isinstance(result, dict):
+            result.setdefault("purchase_authorization", authorization_payload)
+        return {"status_code": response.status_code, "json": result}
 
     async def create_brainstorm_session(
         self,

--- a/clients/shared/purchase_policy.py
+++ b/clients/shared/purchase_policy.py
@@ -44,6 +44,12 @@ def parse_non_negative_ns(value: Any, field_name: str) -> int:
     return parsed
 
 
+def parse_non_negative_int(value: Any, field_name: str) -> int:
+    """Parse a canonical non-negative policy count without coercion."""
+
+    return parse_non_negative_ns(value, field_name)
+
+
 def format_mep_seconds(amount_ns: int) -> str:
     """Render an internal MEP_NS amount for humans without float arithmetic."""
 
@@ -114,12 +120,10 @@ class OwnerPurchasePolicy:
             else parse_non_negative_ns(approval_raw, "human_approval_above_ns")
         )
         bargaining_raw = raw.get("max_bargaining_rounds", 2)
-        if isinstance(bargaining_raw, bool):
-            raise PurchasePolicyError("max_bargaining_rounds must be an integer")
-        try:
-            bargaining_rounds = int(bargaining_raw)
-        except (TypeError, ValueError) as exc:
-            raise PurchasePolicyError("max_bargaining_rounds must be an integer") from exc
+        bargaining_rounds = parse_non_negative_int(
+            bargaining_raw,
+            "max_bargaining_rounds",
+        )
         return cls(
             max_total_price_ns=max_total,
             max_price_per_provider_ns=max_per_provider,
@@ -198,6 +202,8 @@ def evaluate_purchase(
         raise PurchasePolicyError("bargaining_round must be an integer")
     if bargaining_round < 0:
         raise PurchasePolicyError("bargaining_round must be non-negative")
+    if not isinstance(human_approved, bool):
+        raise PurchasePolicyError("human_approved must be a boolean")
 
     total_price = sum(prices)
     spendable = max(0, balance - policy.minimum_reserve_ns)

--- a/clients/shared/purchase_policy.py
+++ b/clients/shared/purchase_policy.py
@@ -1,0 +1,234 @@
+"""Deterministic owner-policy checks for autonomous MEP purchases.
+
+AI agents may rank providers and negotiate terms, but they must not move MEP
+credits outside an owner's explicit limits.  This module keeps that financial
+gate local to the requesting runtime and performs every calculation in integer
+``MEP_NS`` units.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from decimal import Decimal
+from typing import Any, Mapping, Sequence
+
+
+CURRENCY_MEP_NS = "MEP_NS"
+NS_PER_MEP_SECOND = 1_000_000_000
+_NS_RE = re.compile(r"^(0|[1-9][0-9]*)$")
+
+
+class PurchasePolicyError(ValueError):
+    """Raised when a purchase policy or MEP_NS amount is malformed."""
+
+
+def parse_non_negative_ns(value: Any, field_name: str) -> int:
+    """Return a canonical non-negative integer MEP_NS amount.
+
+    Protocol JSON uses decimal strings. Internal callers may use integers, but
+    floats and booleans are rejected so financial policy never depends on
+    floating-point rounding.
+    """
+
+    if isinstance(value, bool):
+        raise PurchasePolicyError(f"{field_name} must be an integer or canonical decimal string")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str) and _NS_RE.fullmatch(value):
+        parsed = int(value)
+    else:
+        raise PurchasePolicyError(f"{field_name} must be an integer or canonical decimal string")
+    if parsed < 0:
+        raise PurchasePolicyError(f"{field_name} must be non-negative")
+    return parsed
+
+
+def format_mep_seconds(amount_ns: int) -> str:
+    """Render an internal MEP_NS amount for humans without float arithmetic."""
+
+    value = Decimal(parse_non_negative_ns(amount_ns, "amount_ns")) / Decimal(NS_PER_MEP_SECOND)
+    return format(value, "f")
+
+
+@dataclass(frozen=True)
+class OwnerPurchasePolicy:
+    """Hard local limits for autonomous provider hiring.
+
+    ``max_total_price_ns`` and ``max_price_per_provider_ns`` are hard limits;
+    human approval does not silently override them. ``human_approval_above_ns``
+    is an optional softer boundary within those limits.
+    """
+
+    max_total_price_ns: int
+    max_price_per_provider_ns: int
+    minimum_reserve_ns: int = 0
+    human_approval_above_ns: int | None = None
+    max_bargaining_rounds: int = 2
+    currency: str = CURRENCY_MEP_NS
+
+    def __post_init__(self) -> None:
+        if self.currency != CURRENCY_MEP_NS:
+            raise PurchasePolicyError("currency must be MEP_NS")
+        for field_name in (
+            "max_total_price_ns",
+            "max_price_per_provider_ns",
+            "minimum_reserve_ns",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                parse_non_negative_ns(getattr(self, field_name), field_name),
+            )
+        if self.human_approval_above_ns is not None:
+            object.__setattr__(
+                self,
+                "human_approval_above_ns",
+                parse_non_negative_ns(
+                    self.human_approval_above_ns,
+                    "human_approval_above_ns",
+                ),
+            )
+        if isinstance(self.max_bargaining_rounds, bool) or not isinstance(
+            self.max_bargaining_rounds, int
+        ):
+            raise PurchasePolicyError("max_bargaining_rounds must be an integer")
+        if self.max_bargaining_rounds < 0:
+            raise PurchasePolicyError("max_bargaining_rounds must be non-negative")
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "OwnerPurchasePolicy":
+        currency = str(raw.get("currency") or CURRENCY_MEP_NS)
+        max_total = parse_non_negative_ns(
+            raw.get("max_total_price_ns", 0),
+            "max_total_price_ns",
+        )
+        max_per_provider = parse_non_negative_ns(
+            raw.get("max_price_per_provider_ns", max_total),
+            "max_price_per_provider_ns",
+        )
+        approval_raw = raw.get("human_approval_above_ns")
+        approval_threshold = (
+            None
+            if approval_raw is None
+            else parse_non_negative_ns(approval_raw, "human_approval_above_ns")
+        )
+        bargaining_raw = raw.get("max_bargaining_rounds", 2)
+        if isinstance(bargaining_raw, bool):
+            raise PurchasePolicyError("max_bargaining_rounds must be an integer")
+        try:
+            bargaining_rounds = int(bargaining_raw)
+        except (TypeError, ValueError) as exc:
+            raise PurchasePolicyError("max_bargaining_rounds must be an integer") from exc
+        return cls(
+            max_total_price_ns=max_total,
+            max_price_per_provider_ns=max_per_provider,
+            minimum_reserve_ns=parse_non_negative_ns(
+                raw.get("minimum_reserve_ns", 0),
+                "minimum_reserve_ns",
+            ),
+            human_approval_above_ns=approval_threshold,
+            max_bargaining_rounds=bargaining_rounds,
+            currency=currency,
+        )
+
+    def as_wire_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        for key in (
+            "max_total_price_ns",
+            "max_price_per_provider_ns",
+            "minimum_reserve_ns",
+        ):
+            payload[key] = str(payload[key])
+        if payload["human_approval_above_ns"] is not None:
+            payload["human_approval_above_ns"] = str(payload["human_approval_above_ns"])
+        return payload
+
+
+@dataclass(frozen=True)
+class PurchaseDecision:
+    status: str
+    reason: str
+    balance_ns: int
+    total_price_ns: int
+    minimum_reserve_ns: int
+    spendable_balance_ns: int
+    remaining_balance_ns: int
+    provider_count: int
+    full_rounds_affordable: int
+    currency: str = CURRENCY_MEP_NS
+
+    @property
+    def approved(self) -> bool:
+        return self.status == "approved"
+
+    def as_wire_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        for key in (
+            "balance_ns",
+            "total_price_ns",
+            "minimum_reserve_ns",
+            "spendable_balance_ns",
+            "remaining_balance_ns",
+        ):
+            payload[key] = str(payload[key])
+        return payload
+
+
+def evaluate_purchase(
+    *,
+    balance_ns: Any,
+    provider_prices_ns: Sequence[Any],
+    policy: OwnerPurchasePolicy,
+    bargaining_round: int = 0,
+    human_approved: bool = False,
+) -> PurchaseDecision:
+    """Evaluate an AI-selected set of provider quotes against owner policy."""
+
+    balance = parse_non_negative_ns(balance_ns, "balance_ns")
+    prices = tuple(
+        parse_non_negative_ns(value, f"provider_prices_ns[{index}]")
+        for index, value in enumerate(provider_prices_ns)
+    )
+    if not prices:
+        raise PurchasePolicyError("provider_prices_ns must contain at least one quote")
+    if any(price == 0 for price in prices):
+        raise PurchasePolicyError("paid provider quotes must be greater than zero")
+    if isinstance(bargaining_round, bool) or not isinstance(bargaining_round, int):
+        raise PurchasePolicyError("bargaining_round must be an integer")
+    if bargaining_round < 0:
+        raise PurchasePolicyError("bargaining_round must be non-negative")
+
+    total_price = sum(prices)
+    spendable = max(0, balance - policy.minimum_reserve_ns)
+    rounds = spendable // total_price
+    remaining = max(0, balance - total_price) if total_price <= balance else balance
+
+    def decision(status: str, reason: str) -> PurchaseDecision:
+        return PurchaseDecision(
+            status=status,
+            reason=reason,
+            balance_ns=balance,
+            total_price_ns=total_price,
+            minimum_reserve_ns=policy.minimum_reserve_ns,
+            spendable_balance_ns=spendable,
+            remaining_balance_ns=remaining,
+            provider_count=len(prices),
+            full_rounds_affordable=rounds,
+        )
+
+    if bargaining_round > policy.max_bargaining_rounds:
+        return decision("rejected", "bargaining_round_limit_exceeded")
+    if any(price > policy.max_price_per_provider_ns for price in prices):
+        return decision("rejected", "per_provider_price_limit_exceeded")
+    if total_price > policy.max_total_price_ns:
+        return decision("rejected", "total_price_limit_exceeded")
+    if total_price > spendable:
+        return decision("rejected", "insufficient_spendable_balance")
+    if (
+        policy.human_approval_above_ns is not None
+        and total_price > policy.human_approval_above_ns
+        and not human_approved
+    ):
+        return decision("approval_required", "human_approval_threshold_exceeded")
+    return decision("approved", "within_owner_policy")

--- a/hub/db.py
+++ b/hub/db.py
@@ -1884,6 +1884,64 @@ def get_last_completed_task_time() -> Optional[float]:
     _release_conn(conn)
     return float(row[0]) if row else None
 
+
+def get_settled_compute_price_samples(
+    *,
+    capability: Optional[str] = None,
+    since_ts: Optional[float] = None,
+    limit: int = 500,
+) -> list[int]:
+    """Return recent released compute prices in canonical integer MEP_NS.
+
+    A completed task is not sufficient by itself: the escrow must also be
+    released. Refunded, disputed, zero-bounty chat, and data-market records do
+    not become market price signals.
+    """
+
+    safe_limit = max(1, min(int(limit), 5000))
+    normalized_capability = (capability or "").strip().lower() or None
+    clauses = [
+        "t.status = 'completed'",
+        "t.bounty_ns IS NOT NULL",
+        "t.bounty_ns > 0",
+        "e.status = 'released'",
+    ]
+    params: list = []
+    placeholder = _sql_placeholder()
+    if normalized_capability:
+        clauses.append(f"LOWER(t.model_requirement) = {placeholder}")
+        params.append(normalized_capability)
+    if since_ts is not None:
+        clauses.append(f"t.updated_at >= {placeholder}")
+        params.append(float(since_ts))
+    params.append(safe_limit)
+    sql = f"""
+        SELECT t.bounty_ns
+        FROM tasks t
+        INNER JOIN escrows e ON e.task_id = t.task_id
+        WHERE {' AND '.join(clauses)}
+        ORDER BY t.updated_at DESC
+        LIMIT {placeholder}
+    """
+    conn = _get_conn()
+    cursor = conn.cursor()
+    cursor.execute(sql, tuple(params))
+    rows = cursor.fetchall()
+    _release_conn(conn)
+    samples: list[int] = []
+    for row in rows:
+        value = row[0]
+        if isinstance(value, bool):
+            continue
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            continue
+        if parsed > 0:
+            samples.append(parsed)
+    return samples
+
+
 def check_database_health() -> dict:
     conn = None
     try:

--- a/hub/main.py
+++ b/hub/main.py
@@ -1576,6 +1576,32 @@ def _normalize_mesh_timeout_seconds(value: Optional[int]) -> int:
     return max(1, min(int(value), MESH_MAX_TIMEOUT_SECONDS))
 
 
+def _summarize_market_price_samples(samples: list[int]) -> dict[str, Optional[str]]:
+    """Return integer nearest-rank reference prices without float arithmetic."""
+
+    ordered = sorted(int(value) for value in samples if int(value) > 0)
+    if not ordered:
+        return {
+            "minimum_price_ns": None,
+            "p25_price_ns": None,
+            "median_price_ns": None,
+            "p75_price_ns": None,
+            "maximum_price_ns": None,
+        }
+
+    def nearest_rank(percent: int) -> int:
+        rank = max(1, (percent * len(ordered) + 99) // 100)
+        return ordered[min(len(ordered) - 1, rank - 1)]
+
+    return {
+        "minimum_price_ns": str(ordered[0]),
+        "p25_price_ns": str(nearest_rank(25)),
+        "median_price_ns": str(nearest_rank(50)),
+        "p75_price_ns": str(nearest_rank(75)),
+        "maximum_price_ns": str(ordered[-1]),
+    }
+
+
 def _mesh_provider_rank(provider: Optional[str]) -> int:
     table = {
         "deepseek": 5,
@@ -2942,6 +2968,42 @@ async def get_reputation(node_id: str):
     if not entry:
         return {"node_id": node_id, "score": 0.0, "total_reviews": 0}
     return entry
+
+
+@app.get("/market/price-reference")
+async def get_market_price_reference(
+    capability: Optional[str] = None,
+    window_days: int = 30,
+    limit: int = 500,
+):
+    """Publish descriptive prices from real settled compute transactions."""
+
+    normalized_capability = (capability or "").strip().lower() or None
+    if normalized_capability and len(normalized_capability) > 120:
+        raise HTTPException(status_code=400, detail="capability must be at most 120 characters")
+    safe_window_days = max(1, min(int(window_days), 365))
+    safe_limit = max(1, min(int(limit), 5000))
+    since_ts = time.time() - safe_window_days * 86_400
+    samples = await asyncio.to_thread(
+        db.get_settled_compute_price_samples,
+        capability=normalized_capability,
+        since_ts=since_ts,
+        limit=safe_limit,
+    )
+    summary = _summarize_market_price_samples(samples)
+    return {
+        "status": "available" if samples else "no_data",
+        "basis": "released_compute_settlements",
+        "currency": "MEP_NS",
+        "capability": normalized_capability,
+        "window_days": safe_window_days,
+        "settled_count": len(samples),
+        "sample_limit": safe_limit,
+        "reference_only": True,
+        "universal_price": False,
+        **summary,
+    }
+
 
 @app.get("/balance/{node_id}")
 async def get_balance(node_id: str):

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -66,6 +66,23 @@ try:
 except ImportError:  # pragma: no cover - direct file execution from node/ may not see repo root
     _shared_has_partial_diff_caveat = None
 
+try:
+    from clients.shared.purchase_policy import (
+        CURRENCY_MEP_NS,
+        OwnerPurchasePolicy,
+        PurchasePolicyError,
+        evaluate_purchase,
+        format_mep_seconds,
+        parse_non_negative_ns,
+    )
+except ImportError:  # pragma: no cover - direct file execution from node/ may not see repo root
+    CURRENCY_MEP_NS = "MEP_NS"
+    OwnerPurchasePolicy = None  # type: ignore[assignment]
+    PurchasePolicyError = ValueError  # type: ignore[assignment,misc]
+    evaluate_purchase = None  # type: ignore[assignment]
+    format_mep_seconds = None  # type: ignore[assignment]
+    parse_non_negative_ns = None  # type: ignore[assignment]
+
 
 def _fallback_has_partial_diff_caveat(text: str) -> bool:
     lowered = str(text or "").strip().lower()
@@ -7815,6 +7832,138 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_budget(args: argparse.Namespace) -> int:
+    """Evaluate a proposed autonomous hire without moving any credits."""
+
+    if (
+        OwnerPurchasePolicy is None
+        or evaluate_purchase is None
+        or parse_non_negative_ns is None
+        or format_mep_seconds is None
+    ):
+        print("[mep budget] purchase policy support is unavailable")
+        return 2
+    if args.provider_count < 1:
+        print("[mep budget] provider_count must be at least 1")
+        return 2
+    if args.minimum_samples < 1:
+        print("[mep budget] minimum_samples must be at least 1")
+        return 2
+
+    identity = MEPIdentity(args.key_path)
+    balance_url = f"{args.hub_url.rstrip('/')}/v2/balance/{identity.node_id}"
+    code, balance_payload, raw = _safe_request("GET", balance_url)
+    if code != 200 or not balance_payload:
+        print(f"[mep budget] balance lookup failed status={code} detail={raw}")
+        return 2
+    if balance_payload.get("currency") != CURRENCY_MEP_NS:
+        print("[mep budget] balance lookup returned an unexpected currency")
+        return 2
+
+    price_source = "explicit"
+    price_raw = args.price_ns
+    if price_raw is None:
+        query = {
+            "window_days": args.window_days,
+            "limit": args.sample_limit,
+        }
+        if args.capability:
+            query["capability"] = args.capability
+        reference_url = (
+            f"{args.hub_url.rstrip('/')}/market/price-reference?"
+            f"{urllib.parse.urlencode(query)}"
+        )
+        reference_code, reference, reference_raw = _safe_request("GET", reference_url)
+        if reference_code != 200 or not reference:
+            print(
+                f"[mep budget] price reference failed status={reference_code} "
+                f"detail={reference_raw}"
+            )
+            return 2
+        settled_count = int(reference.get("settled_count") or 0)
+        if settled_count < args.minimum_samples:
+            capability = args.capability or "all compute"
+            print(
+                f"[mep budget] price reference has only {settled_count} settled sample(s) "
+                f"for {capability}; minimum={args.minimum_samples}"
+            )
+            print("[mep budget] pass --price-ns with an explicit owner-approved quote")
+            return 2
+        price_raw = reference.get("median_price_ns")
+        if price_raw is None:
+            capability = args.capability or "all compute"
+            print(f"[mep budget] no settled price reference is available for {capability}")
+            print("[mep budget] pass --price-ns with an explicit owner-approved quote")
+            return 2
+        price_source = "settled_market_median"
+
+    max_total_raw = (
+        args.max_total_price_ns
+        if args.max_total_price_ns is not None
+        else os.getenv("MEP_PURCHASE_MAX_TOTAL_NS", "0")
+    )
+    max_per_provider_raw = (
+        args.max_price_per_provider_ns
+        if args.max_price_per_provider_ns is not None
+        else os.getenv("MEP_PURCHASE_MAX_PER_PROVIDER_NS", str(max_total_raw))
+    )
+    reserve_raw = (
+        args.minimum_reserve_ns
+        if args.minimum_reserve_ns is not None
+        else os.getenv("MEP_PURCHASE_MIN_RESERVE_NS", "0")
+    )
+    approval_raw = (
+        args.human_approval_above_ns
+        if args.human_approval_above_ns is not None
+        else (os.getenv("MEP_PURCHASE_HUMAN_APPROVAL_ABOVE_NS") or None)
+    )
+
+    try:
+        price_ns = parse_non_negative_ns(price_raw, "price_ns")
+        if price_ns == 0:
+            raise PurchasePolicyError("price_ns must be greater than zero for compute work")
+        policy = OwnerPurchasePolicy.from_mapping(
+            {
+                "currency": CURRENCY_MEP_NS,
+                "max_total_price_ns": max_total_raw,
+                "max_price_per_provider_ns": max_per_provider_raw,
+                "minimum_reserve_ns": reserve_raw,
+                "human_approval_above_ns": approval_raw,
+                "max_bargaining_rounds": args.max_bargaining_rounds,
+            }
+        )
+        decision = evaluate_purchase(
+            balance_ns=balance_payload.get("balance_ns"),
+            provider_prices_ns=[price_ns] * args.provider_count,
+            policy=policy,
+            bargaining_round=args.bargaining_round,
+            human_approved=args.human_approved,
+        )
+    except PurchasePolicyError as exc:
+        print(f"[mep budget] invalid policy or amount: {exc}")
+        return 2
+
+    print(
+        f"[mep budget] balance={decision.balance_ns} MEP_NS "
+        f"({format_mep_seconds(decision.balance_ns)} SECONDS)"
+    )
+    print(
+        f"[mep budget] quote={price_ns} MEP_NS/provider "
+        f"providers={args.provider_count} total={decision.total_price_ns} MEP_NS "
+        f"source={price_source}"
+    )
+    print(
+        f"[mep budget] reserve={decision.minimum_reserve_ns} MEP_NS "
+        f"full_rounds_affordable={decision.full_rounds_affordable}"
+    )
+    print(f"[mep budget] decision={decision.status} reason={decision.reason}")
+    if decision.status == "approved":
+        return 0
+    if decision.status == "approval_required":
+        return 3
+    return 4
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     _ensure_key_parent(args.key_path)
     if args.adapter == "codex":
@@ -7964,6 +8113,33 @@ def build_parser() -> argparse.ArgumentParser:
     status_p = sub.add_parser("status", help="Show quick node readiness badges.")
     status_p.add_argument("--require-online", action="store_true", help="Return non-zero unless all badges pass.")
     status_p.set_defaults(func=cmd_status)
+
+    budget_p = sub.add_parser(
+        "budget",
+        help="Preflight an autonomous provider purchase in exact MEP_NS.",
+    )
+    budget_p.add_argument(
+        "--price-ns",
+        default=None,
+        help="Explicit per-provider quote in MEP_NS; otherwise use the settled market median.",
+    )
+    budget_p.add_argument(
+        "--capability",
+        default=None,
+        help="Capability used to query the settled market price reference.",
+    )
+    budget_p.add_argument("--provider-count", type=int, default=1)
+    budget_p.add_argument("--max-total-price-ns", default=None)
+    budget_p.add_argument("--max-price-per-provider-ns", default=None)
+    budget_p.add_argument("--minimum-reserve-ns", default=None)
+    budget_p.add_argument("--human-approval-above-ns", default=None)
+    budget_p.add_argument("--max-bargaining-rounds", type=int, default=2)
+    budget_p.add_argument("--bargaining-round", type=int, default=0)
+    budget_p.add_argument("--human-approved", action="store_true")
+    budget_p.add_argument("--window-days", type=int, default=30)
+    budget_p.add_argument("--sample-limit", type=int, default=500)
+    budget_p.add_argument("--minimum-samples", type=int, default=5)
+    budget_p.set_defaults(func=cmd_budget)
 
     doctor_p = sub.add_parser("doctor", help="Run onboarding diagnostics against Hub.")
     doctor_p.add_argument("--auth-status", default="ok", help="Override auth status signal.")

--- a/tests/test_hub_api.py
+++ b/tests/test_hub_api.py
@@ -393,6 +393,51 @@ class TestBalance(unittest.TestCase):
 
 
 
+class TestMarketPriceReference(unittest.TestCase):
+
+    def test_reference_uses_only_db_settled_samples_and_mep_ns(self):
+        with mock.patch.object(
+            main.db,
+            "get_settled_compute_price_samples",
+            return_value=[
+                500_000_000,
+                1_000_000_000,
+                2_000_000_000,
+                5_000_000_000,
+            ],
+        ) as samples_mock:
+            resp = client.get(
+                "/market/price-reference",
+                params={"capability": "Code_Review", "window_days": 30},
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "available")
+        self.assertEqual(data["currency"], "MEP_NS")
+        self.assertEqual(data["capability"], "code_review")
+        self.assertEqual(data["settled_count"], 4)
+        self.assertEqual(data["median_price_ns"], "1000000000")
+        self.assertEqual(data["p75_price_ns"], "2000000000")
+        self.assertTrue(data["reference_only"])
+        self.assertFalse(data["universal_price"])
+        self.assertEqual(samples_mock.call_args.kwargs["capability"], "code_review")
+
+    def test_reference_reports_no_data_instead_of_inventing_a_price(self):
+        with mock.patch.object(
+            main.db,
+            "get_settled_compute_price_samples",
+            return_value=[],
+        ):
+            resp = client.get("/market/price-reference")
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "no_data")
+        self.assertIsNone(data["median_price_ns"])
+        self.assertEqual(data["settled_count"], 0)
+
+
 class TestV2Endpoints(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -649,6 +649,152 @@ class TestRuntimeUx(unittest.TestCase):
         self.assertEqual(doctor_mock.call_count, 1)
         self.assertEqual(run_mock.call_count, 1)
 
+    def test_budget_reports_zero_three_bot_rounds_at_five_seconds_each(self):
+        args = argparse.Namespace(
+            hub_url="http://hub",
+            key_path="C:/tmp/test_key.pem",
+            provider_count=3,
+            price_ns="5000000000",
+            capability=None,
+            window_days=30,
+            sample_limit=500,
+            minimum_samples=5,
+            max_total_price_ns="20000000000",
+            max_price_per_provider_ns="5000000000",
+            minimum_reserve_ns="0",
+            human_approval_above_ns=None,
+            max_bargaining_rounds=2,
+            bargaining_round=0,
+            human_approved=False,
+        )
+        with (
+            patch("node.mep_runtime.MEPIdentity", return_value=_FakeIdentity()),
+            patch(
+                "node.mep_runtime._safe_request",
+                return_value=(
+                    200,
+                    {
+                        "node_id": "node_runtime",
+                        "balance_ns": "10000000000",
+                        "currency": "MEP_NS",
+                    },
+                    "",
+                ),
+            ),
+            patch("builtins.print") as print_mock,
+        ):
+            code = mep_runtime.cmd_budget(args)
+
+        self.assertEqual(code, 4)
+        printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list if call.args)
+        self.assertIn("total=15000000000 MEP_NS", printed)
+        self.assertIn("full_rounds_affordable=0", printed)
+        self.assertIn("reason=insufficient_spendable_balance", printed)
+
+    def test_budget_can_use_settled_market_median_inside_owner_policy(self):
+        args = argparse.Namespace(
+            hub_url="http://hub",
+            key_path="C:/tmp/test_key.pem",
+            provider_count=3,
+            price_ns=None,
+            capability="code_review",
+            window_days=30,
+            sample_limit=500,
+            minimum_samples=5,
+            max_total_price_ns="3000000000",
+            max_price_per_provider_ns="1000000000",
+            minimum_reserve_ns="1000000000",
+            human_approval_above_ns=None,
+            max_bargaining_rounds=2,
+            bargaining_round=0,
+            human_approved=False,
+        )
+        with (
+            patch("node.mep_runtime.MEPIdentity", return_value=_FakeIdentity()),
+            patch(
+                "node.mep_runtime._safe_request",
+                side_effect=[
+                    (
+                        200,
+                        {
+                            "node_id": "node_runtime",
+                            "balance_ns": "10000000000",
+                            "currency": "MEP_NS",
+                        },
+                        "",
+                    ),
+                    (
+                        200,
+                        {
+                            "status": "available",
+                            "currency": "MEP_NS",
+                            "settled_count": 12,
+                            "median_price_ns": "1000000000",
+                        },
+                        "",
+                    ),
+                ],
+            ),
+            patch("builtins.print") as print_mock,
+        ):
+            code = mep_runtime.cmd_budget(args)
+
+        self.assertEqual(code, 0)
+        printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list if call.args)
+        self.assertIn("source=settled_market_median", printed)
+        self.assertIn("decision=approved", printed)
+
+    def test_budget_refuses_under_sampled_market_price(self):
+        args = mep_runtime.build_parser().parse_args(
+            [
+                "--hub-url",
+                "http://hub",
+                "--key-path",
+                "C:/tmp/test_key.pem",
+                "budget",
+                "--capability",
+                "code_review",
+                "--max-total-price-ns",
+                "3000000000",
+                "--max-price-per-provider-ns",
+                "1000000000",
+            ]
+        )
+        with (
+            patch("node.mep_runtime.MEPIdentity", return_value=_FakeIdentity()),
+            patch(
+                "node.mep_runtime._safe_request",
+                side_effect=[
+                    (
+                        200,
+                        {
+                            "node_id": "node_runtime",
+                            "balance_ns": "10000000000",
+                            "currency": "MEP_NS",
+                        },
+                        "",
+                    ),
+                    (
+                        200,
+                        {
+                            "status": "available",
+                            "currency": "MEP_NS",
+                            "settled_count": 1,
+                            "median_price_ns": "1000000000",
+                        },
+                        "",
+                    ),
+                ],
+            ),
+            patch("builtins.print") as print_mock,
+        ):
+            code = mep_runtime.cmd_budget(args)
+
+        self.assertEqual(code, 2)
+        printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list if call.args)
+        self.assertIn("only 1 settled sample(s)", printed)
+        self.assertIn("explicit owner-approved quote", printed)
+
     def test_runtime_register_includes_alias_and_x25519_public_key(self):
         node = _runtime_node()
         with patch("node.mep_runtime._safe_request", return_value=(200, {"node_id": node.node_id, "balance": 10.0}, "")) as request_mock:
@@ -706,6 +852,21 @@ class TestRuntimeUx(unittest.TestCase):
         self.assertEqual(ollama_args.adapter, "ollama")
         self.assertEqual(openai_args.adapter, "openai")
         self.assertEqual(codex_args.adapter, "codex")
+
+        budget_args = parser.parse_args(
+            [
+                "budget",
+                "--price-ns",
+                "1000000000",
+                "--provider-count",
+                "3",
+                "--max-total-price-ns",
+                "3000000000",
+            ]
+        )
+        self.assertEqual(budget_args.price_ns, "1000000000")
+        self.assertEqual(budget_args.provider_count, 3)
+        self.assertIs(budget_args.func, mep_runtime.cmd_budget)
 
     def test_run_with_unavailable_codex_cli_fails_closed(self):
         args = argparse.Namespace(

--- a/tests/test_ns_storage.py
+++ b/tests/test_ns_storage.py
@@ -201,6 +201,60 @@ class TestDualWriteConsistency(unittest.TestCase):
         self.assertEqual(amount_ns, 3000000000)
         self.db._release_conn(conn)
 
+    def test_market_price_samples_include_only_released_compute_escrow(self):
+        self.db.create_task(
+            "released_review",
+            "consumer",
+            "review",
+            1.0,
+            "completed",
+            None,
+            "code_review",
+            100.0,
+        )
+        self.db.create_escrow("released_review", "consumer", 1.0, 100.0)
+        self.db.create_task(
+            "released_test",
+            "consumer",
+            "test",
+            2.0,
+            "completed",
+            None,
+            "testing",
+            101.0,
+        )
+        self.db.create_escrow("released_test", "consumer", 2.0, 101.0)
+        self.db.create_task(
+            "held_review",
+            "consumer",
+            "review",
+            3.0,
+            "completed",
+            None,
+            "code_review",
+            102.0,
+        )
+        self.db.create_escrow("held_review", "consumer", 3.0, 102.0)
+
+        conn = self.db._get_conn()
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE escrows SET status = 'released' WHERE task_id IN (?, ?)",
+            ("released_review", "released_test"),
+        )
+        conn.commit()
+        self.db._release_conn(conn)
+
+        all_samples = self.db.get_settled_compute_price_samples(since_ts=0, limit=10)
+        review_samples = self.db.get_settled_compute_price_samples(
+            capability="CODE_REVIEW",
+            since_ts=0,
+            limit=10,
+        )
+
+        self.assertCountEqual(all_samples, [1_000_000_000, 2_000_000_000])
+        self.assertEqual(review_samples, [1_000_000_000])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_purchase_policy.py
+++ b/tests/test_purchase_policy.py
@@ -1,0 +1,124 @@
+import pytest
+
+from clients.shared.purchase_policy import (
+    OwnerPurchasePolicy,
+    PurchasePolicyError,
+    evaluate_purchase,
+    format_mep_seconds,
+    parse_non_negative_ns,
+)
+
+
+def _policy(**overrides):
+    values = {
+        "max_total_price_ns": "20000000000",
+        "max_price_per_provider_ns": "5000000000",
+        "minimum_reserve_ns": "0",
+        "max_bargaining_rounds": 2,
+        "currency": "MEP_NS",
+    }
+    values.update(overrides)
+    return OwnerPurchasePolicy.from_mapping(values)
+
+
+def test_ns_policy_rejects_float_and_wrong_currency():
+    with pytest.raises(PurchasePolicyError, match="canonical decimal string"):
+        parse_non_negative_ns(1.5, "price_ns")
+    with pytest.raises(PurchasePolicyError, match="currency must be MEP_NS"):
+        _policy(currency="SECONDS")
+
+
+def test_ten_seconds_funds_two_default_single_provider_tasks():
+    decision = evaluate_purchase(
+        balance_ns="10000000000",
+        provider_prices_ns=["5000000000"],
+        policy=_policy(),
+    )
+
+    assert decision.approved
+    assert decision.full_rounds_affordable == 2
+    assert decision.remaining_balance_ns == 5_000_000_000
+    assert decision.currency == "MEP_NS"
+
+
+def test_ten_seconds_cannot_fund_three_default_provider_quotes():
+    decision = evaluate_purchase(
+        balance_ns="10000000000",
+        provider_prices_ns=["5000000000"] * 3,
+        policy=_policy(),
+    )
+
+    assert decision.status == "rejected"
+    assert decision.reason == "insufficient_spendable_balance"
+    assert decision.total_price_ns == 15_000_000_000
+    assert decision.full_rounds_affordable == 0
+
+
+def test_three_one_second_providers_are_autonomously_affordable_with_reserve():
+    decision = evaluate_purchase(
+        balance_ns="10000000000",
+        provider_prices_ns=["1000000000"] * 3,
+        policy=_policy(
+            max_total_price_ns="3000000000",
+            max_price_per_provider_ns="1000000000",
+            minimum_reserve_ns="1000000000",
+        ),
+    )
+
+    assert decision.status == "approved"
+    assert decision.full_rounds_affordable == 3
+    assert decision.remaining_balance_ns == 7_000_000_000
+
+
+def test_human_approval_is_soft_boundary_but_hard_caps_remain():
+    policy = _policy(
+        max_total_price_ns="5000000000",
+        human_approval_above_ns="2000000000",
+    )
+    pending = evaluate_purchase(
+        balance_ns="10000000000",
+        provider_prices_ns=["3000000000"],
+        policy=policy,
+    )
+    approved = evaluate_purchase(
+        balance_ns="10000000000",
+        provider_prices_ns=["3000000000"],
+        policy=policy,
+        human_approved=True,
+    )
+    over_cap = evaluate_purchase(
+        balance_ns="10000000000",
+        provider_prices_ns=["6000000000"],
+        policy=policy,
+        human_approved=True,
+    )
+
+    assert pending.status == "approval_required"
+    assert approved.status == "approved"
+    assert over_cap.status == "rejected"
+    assert over_cap.reason == "per_provider_price_limit_exceeded"
+
+
+def test_bargaining_round_limit_is_deterministic():
+    decision = evaluate_purchase(
+        balance_ns="10000000000",
+        provider_prices_ns=["1000000000"],
+        policy=_policy(max_bargaining_rounds=2),
+        bargaining_round=3,
+    )
+
+    assert decision.status == "rejected"
+    assert decision.reason == "bargaining_round_limit_exceeded"
+
+
+def test_wire_policy_and_decision_keep_ns_as_strings():
+    policy = _policy(human_approval_above_ns="2000000000")
+    decision = evaluate_purchase(
+        balance_ns="10000000000",
+        provider_prices_ns=["1000000000"],
+        policy=policy,
+    )
+
+    assert policy.as_wire_dict()["max_total_price_ns"] == "20000000000"
+    assert decision.as_wire_dict()["total_price_ns"] == "1000000000"
+    assert format_mep_seconds(10_000_000_000) == "10"

--- a/tests/test_purchase_policy.py
+++ b/tests/test_purchase_policy.py
@@ -111,6 +111,21 @@ def test_bargaining_round_limit_is_deterministic():
     assert decision.reason == "bargaining_round_limit_exceeded"
 
 
+def test_policy_rejects_fractional_bargaining_round_limit():
+    with pytest.raises(PurchasePolicyError, match="max_bargaining_rounds"):
+        _policy(max_bargaining_rounds=2.9)
+
+
+def test_human_approval_requires_real_boolean():
+    with pytest.raises(PurchasePolicyError, match="human_approved must be a boolean"):
+        evaluate_purchase(
+            balance_ns="10000000000",
+            provider_prices_ns=["3000000000"],
+            policy=_policy(human_approval_above_ns="2000000000"),
+            human_approved="false",
+        )
+
+
 def test_wire_policy_and_decision_keep_ns_as_strings():
     policy = _policy(human_approval_above_ns="2000000000")
     decision = evaluate_purchase(

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -6,6 +6,7 @@ import urllib.parse
 from unittest.mock import patch
 
 from clients.shared.mep_client import MEPClient
+from clients.shared.purchase_policy import OwnerPurchasePolicy
 
 
 class _FakeIdentity:
@@ -187,6 +188,120 @@ class TestSharedMEPClient(unittest.TestCase):
             },
         )
         self.assertEqual(body["routing"], {"target_node_id": "node_provider", "target_capability": "text"})
+
+    def test_get_balance_ns_uses_canonical_v2_endpoint(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.get.return_value = _FakeResponse(
+                json_data={
+                    "node_id": "node_consumer",
+                    "balance_ns": "10000000000",
+                    "currency": "MEP_NS",
+                }
+            )
+            client = MEPClient("unused.pem")
+
+            result = asyncio.run(client.get_balance_ns())
+
+        self.assertEqual(result["json"]["balance_ns"], "10000000000")
+        self.assertTrue(session.get.call_args.args[0].endswith("/v2/balance/node_consumer"))
+
+    def test_submit_compute_task_ns_enforces_policy_and_uses_v2_wire_amount(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.get.return_value = _FakeResponse(
+                json_data={
+                    "node_id": "node_consumer",
+                    "balance_ns": "10000000000",
+                    "currency": "MEP_NS",
+                }
+            )
+            session.post.return_value = _FakeResponse()
+            client = MEPClient("unused.pem")
+            policy = OwnerPurchasePolicy.from_mapping(
+                {
+                    "max_total_price_ns": "3000000000",
+                    "max_price_per_provider_ns": "3000000000",
+                    "minimum_reserve_ns": "2000000000",
+                    "currency": "MEP_NS",
+                }
+            )
+
+            result = asyncio.run(
+                client.submit_compute_task_ns(
+                    "Review exact PR head",
+                    "3000000000",
+                    policy=policy,
+                    model_requirement="code_review",
+                    target_node="node_provider",
+                    idempotency_key="purchase-001",
+                )
+            )
+
+        self.assertEqual(result["status_code"], 200)
+        self.assertEqual(result["json"]["purchase_authorization"]["status"], "approved")
+        self.assertTrue(session.post.call_args.args[0].endswith("/v2/tasks/submit"))
+        self.assertEqual(
+            session.post.call_args.kwargs["headers"]["X-MEP-Idempotency-Key"],
+            "purchase-001",
+        )
+        body = json.loads(session.post.call_args.kwargs["data"])
+        self.assertEqual(
+            body["economics"],
+            {
+                "bounty_ns": "3000000000",
+                "currency": "MEP_NS",
+                "market": "compute",
+                "payment_direction": "sender_to_receiver",
+            },
+        )
+        self.assertEqual(
+            body["routing"],
+            {
+                "target_node_id": "node_provider",
+                "target_capability": "code_review",
+            },
+        )
+
+    def test_submit_compute_task_ns_fails_closed_before_posting(self):
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session") as session_cls,
+        ):
+            session = session_cls.return_value
+            session.get.return_value = _FakeResponse(
+                json_data={
+                    "node_id": "node_consumer",
+                    "balance_ns": "10000000000",
+                    "currency": "MEP_NS",
+                }
+            )
+            client = MEPClient("unused.pem")
+            policy = OwnerPurchasePolicy.from_mapping(
+                {
+                    "max_total_price_ns": "2000000000",
+                    "max_price_per_provider_ns": "2000000000",
+                    "currency": "MEP_NS",
+                }
+            )
+
+            result = asyncio.run(
+                client.submit_compute_task_ns(
+                    "Too expensive",
+                    "3000000000",
+                    policy=policy,
+                )
+            )
+
+        self.assertEqual(result["status_code"], 403)
+        self.assertEqual(result["json"]["reason"], "per_provider_price_limit_exceeded")
+        session.post.assert_not_called()
 
     def test_action_context_helpers_use_signed_persistent_endpoints(self):
         with (

--- a/tests/test_shared_mep_client.py
+++ b/tests/test_shared_mep_client.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 import os
+import threading
+import time
 import unittest
 import urllib.parse
 from unittest.mock import patch
@@ -302,6 +304,66 @@ class TestSharedMEPClient(unittest.TestCase):
         self.assertEqual(result["status_code"], 403)
         self.assertEqual(result["json"]["reason"], "per_provider_price_limit_exceeded")
         session.post.assert_not_called()
+
+    def test_concurrent_compute_submissions_serialize_reserve_preflight(self):
+        class _BalanceAwareSession:
+            def __init__(self):
+                self.trust_env = False
+                self.post_count = 0
+                self.lock = threading.Lock()
+
+            def get(self, *_args, **_kwargs):
+                with self.lock:
+                    balance_ns = 10_000_000_000 - self.post_count * 3_000_000_000
+                return _FakeResponse(
+                    json_data={
+                        "node_id": "node_consumer",
+                        "balance_ns": str(balance_ns),
+                        "currency": "MEP_NS",
+                    }
+                )
+
+            def post(self, *_args, **_kwargs):
+                time.sleep(0.05)
+                with self.lock:
+                    self.post_count += 1
+                return _FakeResponse()
+
+        session = _BalanceAwareSession()
+        with (
+            patch("clients.shared.mep_client.MEPIdentity", return_value=_FakeIdentity()),
+            patch("clients.shared.mep_client.requests.Session", return_value=session),
+        ):
+            client = MEPClient("unused.pem")
+            policy = OwnerPurchasePolicy.from_mapping(
+                {
+                    "max_total_price_ns": "3000000000",
+                    "max_price_per_provider_ns": "3000000000",
+                    "minimum_reserve_ns": "5000000000",
+                    "currency": "MEP_NS",
+                }
+            )
+
+            async def run_both():
+                return await asyncio.gather(
+                    client.submit_compute_task_ns(
+                        "first",
+                        "3000000000",
+                        policy=policy,
+                    ),
+                    client.submit_compute_task_ns(
+                        "second",
+                        "3000000000",
+                        policy=policy,
+                    ),
+                )
+
+            first, second = asyncio.run(run_both())
+
+        self.assertEqual(first["status_code"], 200)
+        self.assertEqual(second["status_code"], 403)
+        self.assertEqual(second["json"]["reason"], "insufficient_spendable_balance")
+        self.assertEqual(session.post_count, 1)
 
     def test_action_context_helpers_use_signed_persistent_endpoints(self):
         with (


### PR DESCRIPTION
## Summary

- add an exact-integer `MEP_NS` owner policy gate for autonomous provider hiring
- add canonical v2 balance lookup and policy-guarded paid compute submission to `MEPClient`
- publish capability-filtered reference prices from released compute settlements only
- add `mep budget` preflight for multi-provider affordability, reserves, approval thresholds, and bounded bargaining
- fail closed when market history is absent or below the default five-sample safety floor

## Why

The current 10-SECONDS starter balance and 5-SECONDS quickstart bounty fund two single-provider tasks but zero three-provider collaboration rounds. Precise `MEP_NS` accounting alone does not give an AI a safe purchasing decision. This slice lets AI select offers while deterministic local owner policy controls whether credits may be spent.

It does not introduce a universal fixed price. Market medians are descriptive, reference-only, and derived only from released compute escrow.

## Validation

- `python -m pytest tests/ -q` -> 642 passed, 1 skipped
- `python -m ruff check hub/ node/ core/ tests/ clients/shared/purchase_policy.py clients/shared/mep_client.py` -> clean
- production read-only preflight at 10 SECONDS:
  - 3 providers x 5 SECONDS -> rejected, 0 full rounds affordable
  - 3 providers x 1 SECOND with 1-SECOND reserve -> approved, 3 full rounds affordable
