### PR TITLE
fix: support grounded docs approvals

### DIFF
--- a/bridge/github_to_mep.py
+++ b/bridge/github_to_mep.py
@@ -1708,8 +1708,8 @@ class GitHubToMEPBridgeService:
             compact["changed_files"] = compact_files
         return compact
 
-    @staticmethod
-    def _build_hunk_contexts(changed_file_entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    @classmethod
+    def _build_hunk_contexts(cls, changed_file_entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
         contexts: list[dict[str, Any]] = []
         for entry in changed_file_entries:
             if not isinstance(entry, dict):
@@ -1720,7 +1720,8 @@ class GitHubToMEPBridgeService:
                 continue
             hunk_header = ""
             changed_lines: list[str] = []
-            for line in patch_text.splitlines():
+            patch_lines = patch_text.splitlines()
+            for line in patch_lines:
                 if line.startswith("@@") and not hunk_header:
                     hunk_header = line.strip()
                     continue
@@ -1731,6 +1732,25 @@ class GitHubToMEPBridgeService:
                     changed_lines.append(clipped)
                 if len(changed_lines) >= 3:
                     break
+            changed_identifiers = cls._extract_changed_identifiers(
+                patch_text,
+                include_inline_code=cls._is_docs_only_path(filename),
+            )
+            for identifier in changed_identifiers:
+                if len(changed_lines) >= 6:
+                    break
+                evidence_line = next(
+                    (
+                        line[:160].rstrip()
+                        for line in patch_lines
+                        if line.startswith(("+", "-"))
+                        and not line.startswith(("+++", "---"))
+                        and identifier in line
+                    ),
+                    "",
+                )
+                if evidence_line and evidence_line not in changed_lines:
+                    changed_lines.append(evidence_line)
             if not hunk_header and not changed_lines:
                 continue
             contexts.append(
@@ -1795,7 +1815,11 @@ class GitHubToMEPBridgeService:
         )
 
     @staticmethod
-    def _extract_changed_identifiers(patch_text: str) -> list[str]:
+    def _extract_changed_identifiers(
+        patch_text: str,
+        *,
+        include_inline_code: bool = False,
+    ) -> list[str]:
         if not patch_text:
             return []
         identifiers: list[str] = []
@@ -1817,6 +1841,13 @@ class GitHubToMEPBridgeService:
                     identifiers.append(identifier)
                     seen.add(identifier)
                 break
+            if include_inline_code:
+                for identifier in re.findall(r"`([A-Za-z_][A-Za-z0-9_]*)`", line):
+                    if identifier not in seen:
+                        identifiers.append(identifier)
+                        seen.add(identifier)
+                    if len(identifiers) >= 12:
+                        break
             if len(identifiers) >= 12:
                 break
         return identifiers
@@ -1863,7 +1894,10 @@ class GitHubToMEPBridgeService:
             status = str(entry.get("status") or "").strip().lower()
             include_identifiers = not (status == "removed" and cls._is_test_path(filename))
             if include_identifiers:
-                for identifier in cls._extract_changed_identifiers(patch_text):
+                for identifier in cls._extract_changed_identifiers(
+                    patch_text,
+                    include_inline_code=cls._is_docs_only_path(filename),
+                ):
                     if identifier not in seen_identifiers:
                         changed_identifiers.append(identifier)
                         seen_identifiers.add(identifier)
@@ -2535,33 +2569,44 @@ class GitHubToMEPBridgeService:
     def _extract_review_section_text(detail: str, label: str) -> str:
         if not detail:
             return ""
-        match = re.search(rf"{re.escape(label)}:\s*(.+)", detail, re.IGNORECASE)
-        if not match:
+        match = re.search(rf"(?im)^\s*{re.escape(label)}:\s*(.+)$", detail)
+        if match:
+            return str(match.group(1) or "").strip()
+        heading = re.search(rf"(?im)^\s*#{{1,6}}\s*{re.escape(label)}\s*$", detail)
+        if not heading:
             return ""
-        return str(match.group(1) or "").strip()
+        trailing = detail[heading.end() :]
+        next_heading = re.search(r"(?m)^\s*#{1,6}\s+", trailing)
+        if next_heading:
+            trailing = trailing[: next_heading.start()]
+        return trailing.strip()
 
     @classmethod
     def _split_review_section_items(cls, text: str) -> list[str]:
         if not text:
             return []
         parts: list[str] = []
-        current: list[str] = []
-        in_backticks = False
-        for char in str(text):
-            if char == "`":
-                in_backticks = not in_backticks
+        for raw_line in str(text).splitlines() or [str(text)]:
+            line = re.sub(r"^\s*(?:[-*]\s+|\d+\.\s+)", "", raw_line).strip()
+            if not line:
+                continue
+            current: list[str] = []
+            in_backticks = False
+            for char in line:
+                if char == "`":
+                    in_backticks = not in_backticks
+                    current.append(char)
+                    continue
+                if char == "," and not in_backticks:
+                    part = "".join(current).strip()
+                    if part:
+                        parts.append(part)
+                    current = []
+                    continue
                 current.append(char)
-                continue
-            if char == "," and not in_backticks:
-                part = "".join(current).strip()
-                if part:
-                    parts.append(part)
-                current = []
-                continue
-            current.append(char)
-        trailing = "".join(current).strip()
-        if trailing:
-            parts.append(trailing)
+            trailing = "".join(current).strip()
+            if trailing:
+                parts.append(trailing)
         return parts
 
     @staticmethod
@@ -2904,7 +2949,43 @@ class GitHubToMEPBridgeService:
             r"recommend(?:ation|ed)?|invariant|finding|issue|concern|gap|"
             r"should be|must be|broken|incorrect|unsafe|missing)",
         )
-        has_findings_proxy = bool(_HAS_FINDINGS_PROXY_RE.search(detail or ""))
+        evidence_sections = {
+            "risk areas checked",
+            "risk areas covered",
+            "lenses inspected",
+            "lenses audited",
+            "areas checked",
+            "areas audited",
+            "audited lenses",
+            "checks performed",
+            "checks run",
+            "checks executed",
+            "checks completed",
+            "verifications",
+            "verification steps",
+            "changed identifiers verified",
+            "why no finding",
+        }
+        current_section = ""
+        has_findings_proxy = False
+        for line in str(detail or "").splitlines():
+            heading = re.match(r"^\s*#{1,6}\s*(.+?)\s*$", line)
+            if heading:
+                current_section = str(heading.group(1) or "").strip().rstrip(":").lower()
+            else:
+                section_label = re.match(
+                    r"^\s*(Risk areas checked|Risk areas covered|Lenses inspected|Lenses audited|"
+                    r"Areas checked|Areas audited|Audited lenses|Checks performed|Checks run|"
+                    r"Checks executed|Checks completed|Verifications|Verification steps|"
+                    r"Changed identifiers verified|Why no finding)\s*:",
+                    line,
+                    re.IGNORECASE,
+                )
+                if section_label:
+                    current_section = str(section_label.group(1) or "").strip().lower()
+            if current_section not in evidence_sections and _HAS_FINDINGS_PROXY_RE.search(line):
+                has_findings_proxy = True
+                break
         has_findings = (
             "## review findings" in lowered
             or bool(self._extract_review_finding_entries(detail or ""))
@@ -2959,6 +3040,8 @@ class GitHubToMEPBridgeService:
         unsupported_verified_identifiers: list[str] = []
         for item in verified_identifiers:
             identifier_tokens = self._extract_identifier_tokens(item)
+            if not identifier_tokens and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", item):
+                identifier_tokens = {item.lower()}
             if not item or not identifier_tokens:
                 continue
             if all(token in changed_text for token in identifier_tokens):

--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -1778,6 +1778,15 @@ def _review_text_has_anchor(text: str, *, touched_paths: list[str], identifiers:
     return False
 
 
+def _review_detail_has_section(text: str, label: str) -> bool:
+    return bool(
+        re.search(
+            rf"(?im)^\s*(?:#{{1,6}}\s*)?{re.escape(label)}(?:\s*:|\s*$)",
+            str(text or ""),
+        )
+    )
+
+
 def _approval_detail_supports_publishable_approval(
     detail: Optional[str],
     *,
@@ -1788,9 +1797,12 @@ def _approval_detail_supports_publishable_approval(
         return False
     if "## Review Findings" in text:
         return False
-    if "## Review Summary" not in text or "Touched paths reviewed:" not in text:
+    if "## Review Summary" not in text or not _review_detail_has_section(text, "Touched paths reviewed"):
         return False
-    if "Checks performed:" not in text or "Risk areas checked:" not in text:
+    if not _review_detail_has_section(text, "Checks performed") or not _review_detail_has_section(
+        text,
+        "Risk areas checked",
+    ):
         return False
     github_inputs = _review_github_inputs(task_data or {})
     touched_tests = _clean_review_list(github_inputs.get("touched_tests"), max_items=3, max_chars=120)
@@ -1805,10 +1817,10 @@ def _approval_detail_supports_publishable_approval(
         task_data=task_data,
     )
     touched_paths = _clean_review_list(github_inputs.get("touched_paths"), max_items=4, max_chars=120)
-    if touched_tests and "Tests reviewed:" not in text:
+    if touched_tests and not _review_detail_has_section(text, "Tests reviewed"):
         return False
     if changed_identifiers:
-        if "Changed identifiers verified:" not in text:
+        if not _review_detail_has_section(text, "Changed identifiers verified"):
             return False
         if not _review_text_has_anchor(
             text,

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -2475,6 +2475,111 @@ class TestGitHubToMEPBridge(unittest.TestCase):
         self.assertFalse(review_package["reviewability"]["publish_no_finding"])
         self.assertIn("Reviewability assessment:", review_package["instructions_context"])
 
+    def test_docs_review_package_extracts_inline_identifiers_and_preserves_evidence(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "docs/verified-review-market/INTERVIEW_DECISIONS.md",
+                    "status": "modified",
+                    "additions": 12,
+                    "deletions": 0,
+                    "changes": 12,
+                    "patch": (
+                        "@@ -1,2 +1,12 @@\n"
+                        "+## Governed bot network\n"
+                        "+Introductory context.\n"
+                        "+More context.\n"
+                        "+A `Network` bot remains controlled by its owner.\n"
+                        "+It becomes a `Collaborator` only for a scoped grant.\n"
+                    ),
+                }
+            ],
+            pr_body="Documents the governed bot network boundary.",
+        )
+
+        review_package = self.service._fetch_pr_review_package("WUAIBING/MEP", 355)
+
+        self.assertEqual(
+            review_package["risk_pack"]["changed_identifiers"],
+            ["Network", "Collaborator"],
+        )
+        hunk_lines = review_package["hunk_contexts"][0]["changed_lines"]
+        self.assertTrue(any("`Network`" in line for line in hunk_lines))
+        self.assertTrue(any("`Collaborator`" in line for line in hunk_lines))
+
+    def test_status_callback_publishes_grounded_docs_approval_with_inline_identifiers(self):
+        self._set_pr_review_package(
+            [
+                {
+                    "filename": "docs/verified-review-market/INTERVIEW_DECISIONS.md",
+                    "status": "modified",
+                    "additions": 12,
+                    "deletions": 0,
+                    "changes": 12,
+                    "patch": (
+                        "@@ -1,2 +1,12 @@\n"
+                        "+## Governed bot network\n"
+                        "+A `Network` bot remains controlled by its owner.\n"
+                        "+It becomes a `Collaborator` only for a scoped grant.\n"
+                    ),
+                }
+            ],
+            pr_body="Documents the governed bot network boundary.",
+            checks_payload={
+                "total_count": 1,
+                "check_runs": [
+                    {
+                        "name": "test (ubuntu-latest, 3.10)",
+                        "status": "completed",
+                        "conclusion": "success",
+                    }
+                ],
+            },
+        )
+        response = self._post_webhook(
+            _issue_comment_payload("@Hub-Sentinel approve this PR", delivery_number=355),
+            delivery_id="delivery-docs-approval",
+        )
+        self.assertEqual(response.status_code, 200)
+        bridge_id = response.json()["bridge_id"]
+        self._flush_context(response.json()["context_id"])
+
+        token = self.service._generate_status_token(bridge_id, "node_target")
+        status_response = self.client.post(
+            "/bridge/status",
+            json={
+                "bridge_id": bridge_id,
+                "status": "completed",
+                "target_node_id": "node_target",
+                "task_id": "task-docs-approval",
+                "action": "approved",
+                "detail": (
+                    "## Review Summary\n\n"
+                    "The `Network` and `Collaborator` definitions are low-risk and internally consistent.\n\n"
+                    "Observation: `Network` and `Collaborator` preserve the ownership boundary.\n\n"
+                    "## Touched paths reviewed\n\n"
+                    "`docs/verified-review-market/INTERVIEW_DECISIONS.md`\n\n"
+                    "## Changed identifiers verified\n\n"
+                    "- `Network`\n"
+                    "- `Collaborator`\n\n"
+                    "## Risk areas checked\n\n"
+                    "- ownership boundary\n"
+                    "- collaboration authority\n\n"
+                    "## Checks performed\n\n"
+                    "- reviewed the changed wording\n"
+                    "- confirmed green tests"
+                ),
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        self.assertEqual(status_response.status_code, 200, status_response.text)
+        self.assertEqual(len(self.github_session.posts), 1)
+        self.assertEqual(self.github_session.posts[0]["json"]["event"], "APPROVE")
+        trial = self.store.get_execution(bridge_id)["review_result"]
+        self.assertEqual(trial["changed_token_sample"], ["collaborator", "network"])
+        self.assertEqual(trial["resolved_action"], "approved")
+
     def test_status_callback_suppresses_low_signal_no_finding_without_retry(self):
         self._set_pr_review_package(
             [

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -1706,6 +1706,44 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
 
         self.assertEqual(action, "approved")
 
+    def test_approval_bridge_action_accepts_markdown_heading_sections(self):
+        task_data = self._bridge_review_task_data(
+            intent_type="code.review.approve",
+            changed_identifiers=["Network", "Collaborator"],
+            touched_paths=["docs/verified-review-market/INTERVIEW_DECISIONS.md"],
+            touched_tests=[],
+            changed_files=[
+                {
+                    "filename": "docs/verified-review-market/INTERVIEW_DECISIONS.md",
+                    "patch_excerpt": (
+                        "+A `Network` bot remains controlled by its owner.\n"
+                        "+It becomes a `Collaborator` only for a scoped grant.\n"
+                    ),
+                }
+            ],
+            ci_checks={"has_checks": True, "state": "green", "all_green": True},
+        )
+        detail = (
+            "## Review Summary\n\n"
+            "The `Network` and `Collaborator` definitions are low-risk.\n\n"
+            "## Touched paths reviewed\n\n"
+            "docs/verified-review-market/INTERVIEW_DECISIONS.md\n\n"
+            "## Risk areas checked\n\n"
+            "Ownership boundary and collaboration authority.\n\n"
+            "## Checks performed\n\n"
+            "Read the exact changed wording and confirmed green tests.\n\n"
+            "## Changed identifiers verified\n\n"
+            "Network and Collaborator."
+        )
+
+        action = mep_runtime.RuntimeNode._bridge_status_action(  # noqa: SLF001
+            mep_runtime._interbot_message_from_task_data(task_data),  # noqa: SLF001
+            detail=detail,
+            task_data=task_data,
+        )
+
+        self.assertEqual(action, "approved")
+
     def test_approval_bridge_action_downgrades_when_runtime_tool_evidence_is_weak(self):
         task_data = self._bridge_review_task_data(
             intent_type="code.review.approve",


### PR DESCRIPTION
## Summary

- extract inline-code identifiers from documentation changes for grounded review evidence
- preserve identifier-bearing changed lines in compact review tasks
- accept colon and Markdown-heading review sections consistently across the runtime and bridge
- prevent evidence-section bullets from being misclassified as findings
- verify simple documentation identifiers against the authoritative full patch

## Why

PR #355 exposed a fail-closed compatibility gap: Hub Sentinel performed a repository-grounded review, but the docs-only approval could not pass the code-declaration-only identifier contract. The bridge correctly refused to approve, leaving the release loop incomplete.

This patch keeps the approval bar intact while allowing documentation changes to supply real changed-line evidence.

## Validation

- changed-file ruff: clean
- git diff --check: clean
- pytest: 653 passed, 1 skipped

## Follow-up

After this PR is merged and deployed, rerun Hub Sentinel against exact head ed799e81668ce40ccf995174d04e931ddf4265c9 of PR #355.
