### PR TITLE
fix: render CI state as review context

### DIFF
--- a/node/mep_runtime.py
+++ b/node/mep_runtime.py
@@ -2974,7 +2974,11 @@ def _default_review_checks(
     if isinstance(ci_checks, dict) and ci_checks.get("has_checks"):
         state = _clean_review_label(ci_checks.get("state"), max_chars=40)
         if state:
-            checks.append(f"noted GitHub checks were `{state}` at review time")
+            # CI states are review-context evidence, not identifiers from the
+            # changed patch. Keep them as prose so the bridge's identifier
+            # grounding guard does not mistake values such as `green` for
+            # changed code symbols.
+            checks.append(f"noted GitHub checks were {state} at review time")
     deduped: list[str] = []
     seen: set[str] = set()
     for item in checks:

--- a/tests/test_node_runtime.py
+++ b/tests/test_node_runtime.py
@@ -1872,6 +1872,29 @@ class TestRuntimeReviewPrompts(unittest.TestCase):
         self.assertIn("reviewed the changed diff for `bridge/github_to_mep.py`", rendered)
         self.assertIn("verified changed identifiers `_build_review_trial_result`, `list_review_trials` against the supplied review context", rendered)
 
+    def test_structured_review_renders_ci_state_as_context_evidence_not_code_identifier(self):
+        rendered = mep_runtime._render_structured_review_with_task_data(  # noqa: SLF001
+            (
+                '{"summary":"Checked the documentation-only network vocabulary update.",'
+                '"observation":"`Network` and `Collaborator` remain scoped to the changed decision record.",'
+                '"touched_paths":["docs/verified-review-market/INTERVIEW_DECISIONS.md"],'
+                '"risk_areas_checked":["terminology consistency"],'
+                '"verified_identifiers":["Network","Collaborator"],'
+                '"findings":[],"approval_recommendation":"approve"}'
+            ),
+            max_chars=1000,
+            task_data=self._bridge_review_task_data(
+                intent_type="code.review.approve",
+                changed_identifiers=["Network", "Collaborator"],
+                touched_paths=["docs/verified-review-market/INTERVIEW_DECISIONS.md"],
+                touched_tests=[],
+                ci_checks={"has_checks": True, "state": "green", "all_green": True},
+            ),
+        )
+
+        self.assertIn("noted GitHub checks were green at review time", rendered)
+        self.assertNotIn("GitHub checks were `green`", rendered)
+
     def test_clean_review_label_drops_partial_trailing_word_when_clipped(self):
         cleaned = mep_runtime._clean_review_label(  # noqa: SLF001
             "Confirmed that _filter_review_list_to_allowed uses exact matching and avoids trailing filteri",


### PR DESCRIPTION
## Summary

- render GitHub CI state as review-context prose instead of a backticked code identifier
- prevent grounded documentation approvals from being falsely suppressed as `checks_in_context_only`
- add a regression test matching the live PR #355 review shape

## Verification

- `python -m pytest tests/test_node_runtime.py -q` — 218 passed
- `python -m pytest -q` — 654 passed, 1 skipped
- `python -m ruff check node/mep_runtime.py tests/test_node_runtime.py`
- `git diff --check`

## Production evidence

Hub Sentinel's exact-head PR #355 canary correctly anchored the path, three changed identifiers, and green CI at quality 7/10. Its generated check text said GitHub checks were backticked `green`; the bridge correctly treats backticked words as candidate code identifiers, so it suppressed the approval because `green` is not in the documentation patch. CI state is trusted review context and should be rendered as prose.
